### PR TITLE
Fix plain-text email body: no more raw CSS, links now survive

### DIFF
--- a/django/subscriptions/management/commands/send_admin_summary.py
+++ b/django/subscriptions/management/commands/send_admin_summary.py
@@ -2,7 +2,6 @@ import logging
 import requests
 from django.core.management.base import BaseCommand
 from django.template.loader import get_template
-from django.utils.html import strip_tags
 from gregory.models import MLPredictions
 from gregory.relevance import compute_ml_drift
 from subscriptions.management.commands.utils.get_credentials import (
@@ -175,6 +174,8 @@ class Command(BaseCommand):
 				)
 				new_trials = list(new_trials.order_by("-discovery_date")[:trial_limit])
 
+				_context_holder = {}
+
 				def _render(
 					articles,
 					trials,
@@ -213,6 +214,7 @@ class Command(BaseCommand):
 					used_trials = list(summary_context.get("trials", [])) + list(
 						summary_context.get("additional_trials", [])
 					)
+					_context_holder["context"] = summary_context
 					return html, used_articles, used_trials
 
 				try:
@@ -254,7 +256,9 @@ class Command(BaseCommand):
 					)
 					continue
 
-				text_content = strip_tags(html_content)
+				text_content = get_template("emails/admin_summary.txt").render(
+					_context_holder["context"]
+				)
 
 				# Step 5: Send email
 				try:

--- a/django/subscriptions/management/commands/send_trials_notification.py
+++ b/django/subscriptions/management/commands/send_trials_notification.py
@@ -4,7 +4,6 @@ import requests
 from django.utils.timezone import now
 from django.core.management.base import BaseCommand
 from django.template.loader import get_template
-from django.utils.html import strip_tags
 from subscriptions.management.commands.utils.send_email import send_email
 from subscriptions.management.commands.utils.subscription import get_trials_for_list
 from subscriptions.models import (
@@ -148,6 +147,8 @@ class Command(BaseCommand):
 				_, trial_limit = resolve_limits(lst)
 				new_trials = list(new_trials.order_by("-discovery_date")[:trial_limit])
 
+				_context_holder = {}
+
 				def _render(articles, trials, _lst=lst, _subscriber=subscriber):
 					summary_context = get_optimized_email_context(
 						email_type="trial_notification",
@@ -176,6 +177,7 @@ class Command(BaseCommand):
 					used_trials = list(summary_context.get("trials", [])) + list(
 						summary_context.get("additional_trials", [])
 					)
+					_context_holder["context"] = summary_context
 					return html, used_articles, used_trials
 
 				html_content, _articles_to_be_sent, trials_to_be_sent = (
@@ -204,7 +206,9 @@ class Command(BaseCommand):
 					emails_skipped += 1
 					continue
 
-				text_content = strip_tags(html_content)
+				text_content = get_template("emails/trial_notification.txt").render(
+					_context_holder["context"]
+				)
 
 				try:
 					result = send_email(

--- a/django/subscriptions/management/commands/send_weekly_summary.py
+++ b/django/subscriptions/management/commands/send_weekly_summary.py
@@ -4,7 +4,6 @@ from datetime import timedelta
 from django.utils.timezone import now
 from django.core.management.base import BaseCommand
 from django.template.loader import get_template
-from django.utils.html import strip_tags
 from subscriptions.management.commands.utils.send_email import send_email
 from subscriptions.management.commands.utils.get_credentials import (
 	build_unsubscribe_base_url,
@@ -632,8 +631,13 @@ class Command(BaseCommand):
 							)
 
 				# html_content was already rendered (possibly shrunk) by
-				# render_within_limit above.
-				text_content = strip_tags(html_content)
+				# render_within_limit above. Render a dedicated text template
+				# from the same context rather than strip_tags(html_content),
+				# which drags <style> block contents into the body and drops
+				# every href.
+				text_content = get_template("emails/weekly_summary.txt").render(
+					summary_context
+				)
 
 				# VERIFICATION: Check that the rendered HTML actually contains the articles
 				if debug:

--- a/django/subscriptions/tests/test_announcement_render.py
+++ b/django/subscriptions/tests/test_announcement_render.py
@@ -289,6 +289,14 @@ class RenderAnnouncementTextTests(TestCase):
 
 		self.assertIsNone(re.search(r"\n{3,}", text))
 
+	def test_inline_link_keeps_href(self):
+		# A plain (non-btn-cta) link inside body text used to lose its href
+		# entirely when converted to text — only the link text survived.
+		html = '<p>Read the <a href="https://example.com/paper">full paper</a> here.</p>'
+		sanitized = sanitize_announcement_html(html)
+		text = render_announcement_text(sanitized)
+		self.assertIn("full paper (https://example.com/paper)", text)
+
 
 # ---------------------------------------------------------------------------
 # AnnouncementAdminForm — alt-text validation

--- a/django/subscriptions/tests/test_email_plaintext_body.py
+++ b/django/subscriptions/tests/test_email_plaintext_body.py
@@ -1,0 +1,256 @@
+"""
+Regression tests for the plain-text alternative body of the three
+structured-content senders (weekly digest, admin summary, trial
+notification).
+
+These used to build the text part with strip_tags(html_content), which
+(a) prepends base_email.html's two <style> blocks verbatim as raw CSS
+because strip_tags keeps element content, and (b) drops every href, so
+the text part carried no links at all. Each sender now renders a
+dedicated emails/*.txt template from the same context instead.
+"""
+
+import os
+from io import StringIO
+from unittest.mock import MagicMock, patch
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "gregory.tests.test_settings")
+
+import django
+
+django.setup()
+
+from django.contrib.sites.models import Site
+from django.core.management import call_command
+from django.test import TestCase
+from django.utils.timezone import now
+
+from gregory.models import Articles, Subject, Team, Trials
+from organizations.models import Organization
+from sitesettings.models import CustomSetting
+from subscriptions.models import Lists, ListSubscription, Subscribers
+
+
+def _mock_ok_result():
+	result = MagicMock(status_code=200)
+	result.json.return_value = {"ErrorCode": 0, "Message": "OK"}
+	return result
+
+
+def _assert_clean_text_body(testcase, text):
+	testcase.assertNotIn("{", text)
+	testcase.assertNotIn("color:", text)
+	testcase.assertIn("https://", text)
+
+
+class WeeklySummaryPlainTextTests(TestCase):
+	def setUp(self):
+		self.org = Organization.objects.create(
+			name="Plaintext Weekly Org", slug="plaintext-weekly-org"
+		)
+		self.team = Team.objects.create(
+			name="Plaintext Weekly Team",
+			organization=self.org,
+			slug="plaintext-weekly-team",
+		)
+		self.subject = Subject.objects.create(
+			subject_name="Plaintext Subject",
+			team=self.team,
+			subject_slug="plaintext-subject",
+		)
+		self.site = Site.objects.get_or_create(
+			id=51, defaults={"domain": "plaintext.example.com", "name": "Plaintext"}
+		)[0]
+		self.custom_settings = CustomSetting.objects.get_or_create(
+			site=self.site,
+			defaults={
+				"title": "Plaintext Site",
+				"postmark_api_token": "test-token",
+				"postmark_api_url": "https://api.postmarkapp.com/email",
+			},
+		)[0]
+		self.digest_list = Lists.objects.create(
+			list_name="Plaintext Weekly List",
+			weekly_digest=True,
+			team=self.team,
+			site=self.site,
+			ml_threshold=0.0,
+		)
+		self.digest_list.subjects.add(self.subject)
+		self.subscriber = Subscribers.objects.create(
+			first_name="Text",
+			last_name="Reader",
+			email="text-reader@example.com",
+			active=True,
+		)
+		ListSubscription.objects.create(
+			subscriber=self.subscriber, list=self.digest_list, is_active=True
+		)
+		self.article = Articles.objects.create(
+			title="A Plaintext Body Article",
+			link="https://publisher.example.com/plaintext-article",
+			doi="10.1234/plaintext-article",
+		)
+		self.article.subjects.add(self.subject)
+
+	def _run_and_capture_text(self):
+		with patch(
+			"subscriptions.management.commands.send_weekly_summary.send_email",
+			return_value=_mock_ok_result(),
+		) as mock_send_email:
+			out = StringIO()
+			call_command("send_weekly_summary", stdout=out, all_articles=True)
+
+		self.assertTrue(mock_send_email.called)
+		_, kwargs = mock_send_email.call_args
+		return kwargs["text"]
+
+	def test_text_body_has_no_css_and_a_link(self):
+		text = self._run_and_capture_text()
+		_assert_clean_text_body(self, text)
+
+	def test_text_body_contains_article_title(self):
+		text = self._run_and_capture_text()
+		self.assertIn("A Plaintext Body Article", text)
+
+
+class AdminSummaryPlainTextTests(TestCase):
+	def setUp(self):
+		self.org = Organization.objects.create(
+			name="Plaintext Admin Org", slug="plaintext-admin-org"
+		)
+		self.team = Team.objects.create(
+			name="Plaintext Admin Team",
+			organization=self.org,
+			slug="plaintext-admin-team",
+		)
+		self.subject = Subject.objects.create(
+			subject_name="Plaintext Admin Subject",
+			team=self.team,
+			subject_slug="plaintext-admin-subject",
+			auto_predict=True,
+			ml_consensus_type="any",
+		)
+		self.site = Site.objects.get_or_create(
+			id=52,
+			defaults={"domain": "plaintext-admin.example.com", "name": "PlaintextAdmin"},
+		)[0]
+		self.custom_settings = CustomSetting.objects.get_or_create(
+			site=self.site,
+			defaults={
+				"title": "Plaintext Admin Site",
+				"postmark_api_token": "test-token",
+				"postmark_api_url": "https://api.postmarkapp.com/email",
+			},
+		)[0]
+		self.subscriber = Subscribers.objects.create(
+			first_name="Admin",
+			last_name="Reader",
+			email="admin-reader@example.com",
+			active=True,
+		)
+		self.admin_list = Lists.objects.create(
+			list_name="Plaintext Admin List",
+			admin_summary=True,
+			team=self.team,
+			site=self.site,
+		)
+		self.admin_list.subjects.add(self.subject)
+		self.subscriber.subscriptions.add(self.admin_list)
+		self.article = Articles.objects.create(
+			title="An Admin Plaintext Article",
+			link="https://publisher.example.com/admin-plaintext-article",
+			doi="10.1234/admin-plaintext-article",
+		)
+		self.article.subjects.add(self.subject)
+
+	def _run_and_capture_text(self):
+		with patch(
+			"subscriptions.management.commands.send_admin_summary.send_email",
+			return_value=_mock_ok_result(),
+		) as mock_send_email:
+			out = StringIO()
+			call_command("send_admin_summary", stdout=out)
+
+		self.assertTrue(mock_send_email.called)
+		_, kwargs = mock_send_email.call_args
+		return kwargs["text"]
+
+	def test_text_body_has_no_css_and_a_link(self):
+		text = self._run_and_capture_text()
+		_assert_clean_text_body(self, text)
+
+	def test_text_body_contains_article_title(self):
+		text = self._run_and_capture_text()
+		self.assertIn("An Admin Plaintext Article", text)
+
+
+class TrialNotificationPlainTextTests(TestCase):
+	def setUp(self):
+		self.org = Organization.objects.create(
+			name="Plaintext Trial Org", slug="plaintext-trial-org"
+		)
+		self.team = Team.objects.create(
+			name="Plaintext Trial Team",
+			organization=self.org,
+			slug="plaintext-trial-team",
+		)
+		self.subject = Subject.objects.create(
+			subject_name="Plaintext Trial Subject",
+			team=self.team,
+			subject_slug="plaintext-trial-subject",
+		)
+		self.site = Site.objects.get_or_create(
+			id=53,
+			defaults={"domain": "plaintext-trial.example.com", "name": "PlaintextTrial"},
+		)[0]
+		self.custom_settings = CustomSetting.objects.get_or_create(
+			site=self.site,
+			defaults={
+				"title": "Plaintext Trial Site",
+				"postmark_api_token": "test-token",
+				"postmark_api_url": "https://api.postmarkapp.com/email",
+			},
+		)[0]
+		self.lst = Lists.objects.create(
+			list_name="Plaintext Trial List",
+			team=self.team,
+			site=self.site,
+			clinical_trials_notifications=True,
+		)
+		self.lst.subjects.add(self.subject)
+		self.subscriber = Subscribers.objects.create(
+			first_name="Trial",
+			last_name="Reader",
+			email="trial-reader@example.com",
+			active=True,
+		)
+		ListSubscription.objects.create(
+			subscriber=self.subscriber, list=self.lst, is_active=True
+		)
+		self.trial = Trials.objects.create(
+			title="A Plaintext Body Trial",
+			link="https://registry.example.com/plaintext-trial",
+			discovery_date=now(),
+		)
+		self.trial.subjects.add(self.subject)
+
+	def _run_and_capture_text(self):
+		with patch(
+			"subscriptions.management.commands.send_trials_notification.send_email",
+			return_value=_mock_ok_result(),
+		) as mock_send_email:
+			out = StringIO()
+			call_command("send_trials_notification", stdout=out)
+
+		self.assertTrue(mock_send_email.called)
+		_, kwargs = mock_send_email.call_args
+		return kwargs["text"]
+
+	def test_text_body_has_no_css_and_a_link(self):
+		text = self._run_and_capture_text()
+		_assert_clean_text_body(self, text)
+
+	def test_text_body_contains_trial_title(self):
+		text = self._run_and_capture_text()
+		self.assertIn("A Plaintext Body Trial", text)

--- a/django/subscriptions/utils/render_email_body.py
+++ b/django/subscriptions/utils/render_email_body.py
@@ -226,8 +226,9 @@ def render_announcement_text(html: str) -> str:
 	"""
 	Generate a plain-text fallback from sanitized announcement HTML.
 
-	- CTA buttons → ``Label: https://…``
-	- Images       → ``[Image: alt text]``
+	- CTA buttons     → ``Label: https://…``
+	- Inline <a> links → ``Label (https://…)``
+	- Images          → ``[Image: alt text]``
 	- Runs of 3+ blank lines are collapsed to 2.
 
 	*html* must be the output of ``sanitize_announcement_html``.
@@ -239,6 +240,14 @@ def render_announcement_text(html: str) -> str:
 		href = a_tag.get("href", "")
 		label = a_tag.get_text()
 		a_tag.replace_with(NavigableString(f"\n\n{label}: {href}\n\n"))
+
+	# Replace remaining (inline) links with "Label (URL)" so the href
+	# survives into the text part instead of being silently dropped.
+	for a_tag in list(soup.find_all("a")):
+		href = a_tag.get("href", "")
+		label = a_tag.get_text()
+		text_value = f"{label} ({href})" if href else label
+		a_tag.replace_with(NavigableString(text_value))
 
 	# Replace images with [Image: alt]
 	for img in list(soup.find_all("img")):

--- a/django/templates/emails/admin_summary.txt
+++ b/django/templates/emails/admin_summary.txt
@@ -1,0 +1,40 @@
+{% load gregory_tags %}{{ header_title|default:title|default:"Gregory AI" }} — Admin Review Required
+
+Hello {{ admin|split:"@"|first }},
+
+Here are the articles and clinical trials discovered in the last 48 hours that require your review.
+{% if articles or additional_articles %}
+
+NEW ARTICLES FOR REVIEW ({{ content_stats.total_articles }})
+========================================
+{% if articles %}
+High-Confidence ({{ content_stats.high_confidence_articles }})
+{% for article in articles %}
+{% include 'emails/components/article_text.html' with article=article %}
+{% endfor %}{% endif %}{% if additional_articles %}
+Needs Review ({{ additional_articles|length }})
+{% for article in additional_articles %}
+{% include 'emails/components/article_text.html' with article=article %}
+{% endfor %}{% endif %}{% endif %}{% if trials or additional_trials %}
+
+NEW CLINICAL TRIALS ({{ content_stats.total_trials }})
+========================================
+{% for trial in trials %}
+{% include 'emails/components/trial_text.html' with trial=trial %}
+{% endfor %}{% for trial in additional_trials %}
+{% include 'emails/components/trial_text.html' with trial=trial %}
+{% endfor %}{% endif %}{% if not articles and not additional_articles and not trials and not additional_trials %}
+
+No New Content for Review
+No new articles or clinical trials were discovered in the last 48 hours.
+{% endif %}
+
+Admin Actions: Review the articles above and mark them as relevant in the admin dashboard. This helps improve our machine learning accuracy for future recommendations.
+{% if ml_drift %}{% with ml_drift_total=ml_drift.stale_ml_score|add:ml_drift.missing_relevant|add:ml_drift.unexpected_relevant %}
+ML field health: {{ ml_drift_total }} drifted ({{ ml_drift.stale_ml_score }} stale ml_score, {{ ml_drift.missing_relevant }} missing relevant, {{ ml_drift.unexpected_relevant }} unexpected relevant).
+{% endwith %}{% endif %}
+
+For the complete admin dashboard, visit https://api.{{ site.domain|default:"brain-regeneration.com" }}/
+
+----------------------------------------
+{% include 'emails/components/footer_text.html' %}

--- a/django/templates/emails/components/article_text.html
+++ b/django/templates/emails/components/article_text.html
@@ -1,0 +1,6 @@
+{% load gregory_tags %}{{ article.title|clean_html_tags }}
+{% if utm_params %}{{ article.article_id|build_article_url:site_domain|add_utm_params:utm_params }}{% else %}{{ article.article_id|build_article_url:site_domain }}{% endif %}
+{% if article.doi %}DOI: https://doi.org/{{ article.doi }}
+{% endif %}{% if article.authors.exists %}Authors: {% for author in article.authors.all %}{{ author.full_name }}{% if not forloop.last %}, {% endif %}{% endfor %}
+{% endif %}{% if article.summary %}{{ article.summary|clean_html_tags|truncatechars:300 }}
+{% endif %}

--- a/django/templates/emails/components/footer_text.html
+++ b/django/templates/emails/components/footer_text.html
@@ -1,0 +1,17 @@
+{% if website_url %}More information: {{ website_url }}
+{% endif %}{% if support_url %}Support: {{ support_url }}
+{% endif %}{% if about_url %}About: {{ about_url }}
+{% endif %}{% if contact_url %}Contact: {{ contact_url }}
+{% endif %}
+This email was sent to {{ subscriber.email|default:"you" }}
+{% if subscriber.unsubscribe_token and unsubscribe_lists %}{% for ul_id, ul_name in unsubscribe_lists %}Unsubscribe from {{ ul_name }}: {{ unsubscribe_base_url }}/subscriptions/unsubscribe/{{ subscriber.unsubscribe_token }}/list/{{ ul_id }}/
+{% endfor %}{% if site %}Unsubscribe from all lists on {{ site.domain }}: {{ unsubscribe_base_url }}/subscriptions/unsubscribe/{{ subscriber.unsubscribe_token }}/site/{{ site.id }}/
+{% endif %}Unsubscribe from everything: {{ unsubscribe_base_url }}/subscriptions/unsubscribe/{{ subscriber.unsubscribe_token }}/all/
+{% elif subscriber.unsubscribe_token and list_id %}Unsubscribe from this list: {{ unsubscribe_base_url }}/subscriptions/unsubscribe/{{ subscriber.unsubscribe_token }}/list/{{ list_id }}/
+{% if site %}Unsubscribe from all lists on {{ site.domain }}: {{ unsubscribe_base_url }}/subscriptions/unsubscribe/{{ subscriber.unsubscribe_token }}/site/{{ site.id }}/
+{% endif %}Unsubscribe from everything: {{ unsubscribe_base_url }}/subscriptions/unsubscribe/{{ subscriber.unsubscribe_token }}/all/
+{% endif %}
+{% if privacy_policy_url %}Privacy Policy: {{ privacy_policy_url }}
+{% endif %}{% if terms_url %}Terms of Service: {{ terms_url }}
+{% endif %}
+{{ title|default:"Gregory AI" }} — Powered by Gregory AI (https://gregory-ai.com/)

--- a/django/templates/emails/components/trial_text.html
+++ b/django/templates/emails/components/trial_text.html
@@ -1,0 +1,7 @@
+{% load gregory_tags %}{{ trial.title }}
+{% if trial.link %}{% if utm_params %}{{ trial.link|add_utm_params:utm_params }}{% else %}{{ trial.link }}{% endif %}
+{% endif %}{% if trial.phase_normalized and trial.phase_normalized != "other" %}Phase: {{ trial.get_phase_normalized_display }}
+{% elif trial.phase %}Phase: {{ trial.phase }}
+{% endif %}{% if trial.recruitment_status_normalized or trial.recruitment_status %}Status: {% if trial.recruitment_status_normalized and trial.recruitment_status_normalized != "other" %}{{ trial.get_recruitment_status_normalized_display }}{% else %}{{ trial.recruitment_status }}{% endif %}
+{% endif %}{% if trial.brief_summary %}{{ trial.brief_summary|clean_html_tags|truncatechars:350 }}
+{% endif %}

--- a/django/templates/emails/trial_notification.txt
+++ b/django/templates/emails/trial_notification.txt
@@ -1,0 +1,21 @@
+{% load gregory_tags %}{{ header_title|default:title|default:"Gregory AI" }} — New Clinical Trials Notification
+
+We've found {{ content_stats.total_trials|default:0 }} new clinical trial{{ content_stats.total_trials|default:0|pluralize }} that match your research interests.
+{% if trials or additional_trials %}
+
+NEW CLINICAL TRIALS ({{ content_stats.total_trials|default:0 }})
+========================================
+{% for trial in trials %}
+{% include 'emails/components/trial_text.html' with trial=trial %}
+{% endfor %}{% for trial in additional_trials %}
+{% include 'emails/components/trial_text.html' with trial=trial %}
+{% endfor %}{% else %}
+
+No New Clinical Trials
+No new clinical trials matching your interests were found at this time. We'll continue monitoring and notify you when new trials are available.
+{% endif %}
+
+Browse all available clinical trials at https://{{ site.domain|default:'gregory-ai.com' }}/
+
+----------------------------------------
+{% include 'emails/components/footer_text.html' %}

--- a/django/templates/emails/weekly_summary.txt
+++ b/django/templates/emails/weekly_summary.txt
@@ -1,0 +1,41 @@
+{% load gregory_tags %}{{ header_title|default:title|default:"Gregory AI" }} — Your Weekly Research Summary
+
+Good {{ greeting_time|default:"morning" }}, {% if user.first_name %}{{ user.first_name }}{% else %}{{ subscriber.email|split:"@"|first }}{% endif %}!
+
+Here are the most relevant articles and clinical trials we discovered this week.
+{% if articles or additional_articles %}
+
+NEW ARTICLES ({{ content_stats.total_articles }})
+========================================
+{% for article in articles %}
+{% include 'emails/components/article_text.html' with article=article %}
+{% endfor %}{% for article in additional_articles %}
+{% include 'emails/components/article_text.html' with article=article %}
+{% endfor %}{% endif %}{% if trials or additional_trials %}
+
+NEW CLINICAL TRIALS ({{ content_stats.total_trials }})
+========================================
+{% for trial in trials %}
+{% include 'emails/components/trial_text.html' with trial=trial %}
+{% endfor %}{% for trial in additional_trials %}
+{% include 'emails/components/trial_text.html' with trial=trial %}
+{% endfor %}{% endif %}{% if latest_research.has_latest_research %}
+
+LATEST RESEARCH BY CATEGORY
+========================================
+{% for category in latest_research.categories %}
+-- {{ category.category_name }} --
+{% for article in category.articles %}
+{{ article.title|clean_html_tags }}
+{% if utm_params %}{{ article.article_id|build_article_url:site_domain|add_utm_params:utm_params }}{% else %}{{ article.article_id|build_article_url:site_domain }}{% endif %}
+{% endfor %}
+{% endfor %}{% endif %}{% if not articles and not additional_articles and not trials and not additional_trials %}
+
+No New Content This Week
+We didn't find any new relevant articles or clinical trials matching your interests this week. Check back next week for updates.
+{% endif %}
+
+For the complete archive, visit https://{{ site.domain|default:'gregory-ai.com' }}/
+
+----------------------------------------
+{% include 'emails/components/footer_text.html' %}


### PR DESCRIPTION
## Summary
- `weekly_summary`, `admin_summary`, and `trial_notification` built their plain-text alternative with `strip_tags(html_content)`. This kept element *content* for stripped tags — including `base_email.html`'s two `<style>` blocks, which landed as raw CSS at the top of the text body — and dropped every `href`, so a text-only recipient got article titles with no way to reach them.
- Each of the three senders now renders a dedicated `emails/*.txt` template from the same context object the HTML render already builds, with every link emitted as `Title\n<url>`.
- `announcement`'s existing custom text renderer (`render_announcement_text`) didn't have the CSS problem (it only ever renders the sanitized CKEditor body, not the full page), but it silently dropped the `href` of any plain `<a>` link that wasn't a `btn-cta` button. Fixed to emit `Label (url)` instead.

## Test plan
- [x] `docker exec gregory python manage.py test subscriptions.tests.test_email_plaintext_body subscriptions.tests.test_announcement_render` — new/updated tests pass
- [x] Full suite: `docker exec gregory python manage.py test` — 2571 tests, OK
- [x] New tests assert the text body contains no `{`/`color:`, at least one `https://` URL, and the title of every article/trial in the send

🤖 Generated with [Claude Code](https://claude.com/claude-code)