### PR TITLE
Fix add_utm_params: host-restrict tagging, stop corrupting query strings

### DIFF
--- a/django/gregory/templatetags/gregory_tags.py
+++ b/django/gregory/templatetags/gregory_tags.py
@@ -132,24 +132,26 @@ def add_utm_params(url, utm_params, site_domain=""):
 	Args:
 	    url: The URL to modify
 	    utm_params: Dictionary of UTM parameters
-	    site_domain: The sending site's domain. When given, the URL is
-	        returned unmodified unless its host matches this domain.
+	    site_domain: The sending site's domain. Required to tag anything —
+	        a missing/blank site_domain fails closed to a no-op rather
+	        than falling back to tagging every host, so a caller can
+	        never accidentally leak UTM params onto a third-party link by
+	        forgetting to pass this.
 
 	Returns:
 	    URL with UTM parameters appended, or the original URL unchanged.
 	"""
-	if not url or not utm_params:
+	if not url or not utm_params or not site_domain:
 		return url
 
 	from urllib.parse import urlparse, parse_qs, urlencode, urlunparse
 
 	parsed_url = urlparse(url)
 
-	if site_domain:
-		host = parsed_url.netloc.split(":")[0].lower()
-		expected = site_domain.split(":")[0].lower()
-		if host != expected:
-			return url
+	host = parsed_url.netloc.split(":")[0].lower()
+	expected = site_domain.split(":")[0].lower()
+	if host != expected:
+		return url
 
 	existing = parse_qs(parsed_url.query, keep_blank_values=True)
 	additions = [(k, v) for k, v in utm_params.items() if k not in existing]

--- a/django/gregory/templatetags/gregory_tags.py
+++ b/django/gregory/templatetags/gregory_tags.py
@@ -113,35 +113,52 @@ def has_attribute(obj, attribute):
 	return hasattr(obj, attribute)
 
 
-@register.filter
-def add_utm_params(url, utm_params):
+@register.simple_tag
+def add_utm_params(url, utm_params, site_domain=""):
 	"""
-	Add UTM parameters to a URL for tracking.
-	Usage: {{ article.link|add_utm_params:utm_params }}
+	Add UTM parameters to a URL for tracking, but only when the URL points
+	at the sending site itself. Third-party destinations (DOI resolvers,
+	trial registries, the original publisher) never get tagged, since
+	Umami cannot see those clicks and the parameters would only leak into
+	someone else's analytics.
+
+	Usage: {% add_utm_params article.link utm_params site_domain %}
+
+	The original query string is preserved byte-for-byte; only UTM keys
+	that are not already present are appended. This avoids the
+	decode/re-encode round trip of parse_qs()+urlencode(), which can
+	silently rewrite '+', literal '%', or repeated keys in the input URL.
 
 	Args:
 	    url: The URL to modify
 	    utm_params: Dictionary of UTM parameters
+	    site_domain: The sending site's domain. When given, the URL is
+	        returned unmodified unless its host matches this domain.
 
 	Returns:
-	    URL with UTM parameters appended
+	    URL with UTM parameters appended, or the original URL unchanged.
 	"""
 	if not url or not utm_params:
 		return url
 
 	from urllib.parse import urlparse, parse_qs, urlencode, urlunparse
 
-	# Parse the URL
 	parsed_url = urlparse(url)
-	query_params = parse_qs(parsed_url.query)
 
-	# Add UTM parameters (don't override existing ones)
-	for key, value in utm_params.items():
-		if key not in query_params:
-			query_params[key] = [value]
+	if site_domain:
+		host = parsed_url.netloc.split(":")[0].lower()
+		expected = site_domain.split(":")[0].lower()
+		if host != expected:
+			return url
 
-	# Rebuild the URL
-	new_query = urlencode(query_params, doseq=True)
+	existing = parse_qs(parsed_url.query, keep_blank_values=True)
+	additions = [(k, v) for k, v in utm_params.items() if k not in existing]
+	if additions:
+		sep = "&" if parsed_url.query else ""
+		new_query = f"{parsed_url.query}{sep}{urlencode(additions)}"
+	else:
+		new_query = parsed_url.query
+
 	new_url = urlunparse(
 		(
 			parsed_url.scheme,

--- a/django/gregory/tests/test_gregory_tags.py
+++ b/django/gregory/tests/test_gregory_tags.py
@@ -56,15 +56,30 @@ class AddUtmParamsTest(SimpleTestCase):
 
 	def test_no_op_without_utm_params(self):
 		self.assertEqual(
-			add_utm_params("https://example.com/x", {}),
+			add_utm_params("https://example.com/x", {}, "example.com"),
 			"https://example.com/x",
 		)
-		self.assertEqual(add_utm_params("", {"utm_source": "a"}), "")
+		self.assertEqual(add_utm_params("", {"utm_source": "a"}, "example.com"), "")
+
+	def test_no_op_without_site_domain(self):
+		# site_domain is required to tag anything — a caller that forgets
+		# to pass it must fail closed (no tagging) rather than fall back
+		# to tagging every host, which would reintroduce the leakage this
+		# host restriction exists to prevent.
+		result = add_utm_params(
+			"https://example.com/articles/1/", {"utm_source": "weekly_summary"}
+		)
+		self.assertEqual(result, "https://example.com/articles/1/")
+		result = add_utm_params(
+			"https://example.com/articles/1/", {"utm_source": "weekly_summary"}, ""
+		)
+		self.assertEqual(result, "https://example.com/articles/1/")
 
 	def test_appends_params_to_bare_url(self):
 		result = add_utm_params(
 			"https://example.com/articles/1/",
 			{"utm_source": "weekly_summary", "utm_medium": "email"},
+			"example.com",
 		)
 		self.assertIn("utm_source=weekly_summary", result)
 		self.assertIn("utm_medium=email", result)
@@ -75,7 +90,7 @@ class AddUtmParamsTest(SimpleTestCase):
 		# differently, and repeated keys must survive — all things
 		# parse_qs()+urlencode() can silently rewrite.
 		url = "https://example.com/x?q=a+b&note=100%25&tag=a&tag=b"
-		result = add_utm_params(url, {"utm_source": "weekly_summary"})
+		result = add_utm_params(url, {"utm_source": "weekly_summary"}, "example.com")
 		self.assertTrue(
 			result.startswith(
 				"https://example.com/x?q=a+b&note=100%25&tag=a&tag=b&"
@@ -87,7 +102,9 @@ class AddUtmParamsTest(SimpleTestCase):
 		# overridden; utm_medium is missing and must be appended.
 		url = "https://example.com/x?utm_source=manual"
 		result = add_utm_params(
-			url, {"utm_source": "weekly_summary", "utm_medium": "email"}
+			url,
+			{"utm_source": "weekly_summary", "utm_medium": "email"},
+			"example.com",
 		)
 		self.assertEqual(result.count("utm_source="), 1)
 		self.assertIn("utm_source=manual", result)

--- a/django/gregory/tests/test_gregory_tags.py
+++ b/django/gregory/tests/test_gregory_tags.py
@@ -14,7 +14,7 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "gregory.tests.test_settings")
 django.setup()
 
 from django.test import SimpleTestCase
-from gregory.templatetags.gregory_tags import author_profile_url
+from gregory.templatetags.gregory_tags import author_profile_url, add_utm_params
 
 
 class AuthorProfileUrlTest(SimpleTestCase):
@@ -43,3 +43,79 @@ class AuthorProfileUrlTest(SimpleTestCase):
 			author_profile_url("0000-0002-7922-9785", "https://example.com/authors/"),
 			"https://example.com/authors/0000-0002-7922-9785/",
 		)
+
+
+class AddUtmParamsTest(SimpleTestCase):
+	"""
+	add_utm_params used to (a) tag every URL regardless of host, leaking
+	tracking params onto DOI resolvers and trial registries that Umami
+	never sees, and (b) rebuild the whole query string via
+	parse_qs()+urlencode(), which can silently rewrite '+', literal '%',
+	or repeated keys that were never meant to be touched.
+	"""
+
+	def test_no_op_without_utm_params(self):
+		self.assertEqual(
+			add_utm_params("https://example.com/x", {}),
+			"https://example.com/x",
+		)
+		self.assertEqual(add_utm_params("", {"utm_source": "a"}), "")
+
+	def test_appends_params_to_bare_url(self):
+		result = add_utm_params(
+			"https://example.com/articles/1/",
+			{"utm_source": "weekly_summary", "utm_medium": "email"},
+		)
+		self.assertIn("utm_source=weekly_summary", result)
+		self.assertIn("utm_medium=email", result)
+		self.assertTrue(result.startswith("https://example.com/articles/1/?"))
+
+	def test_existing_query_string_preserved_byte_identical(self):
+		# '+' must not become a space, '%20' must not be re-decoded/re-encoded
+		# differently, and repeated keys must survive — all things
+		# parse_qs()+urlencode() can silently rewrite.
+		url = "https://example.com/x?q=a+b&note=100%25&tag=a&tag=b"
+		result = add_utm_params(url, {"utm_source": "weekly_summary"})
+		self.assertTrue(
+			result.startswith(
+				"https://example.com/x?q=a+b&note=100%25&tag=a&tag=b&"
+			)
+		)
+
+	def test_only_appends_missing_keys(self):
+		# utm_source is already present and must not be duplicated or
+		# overridden; utm_medium is missing and must be appended.
+		url = "https://example.com/x?utm_source=manual"
+		result = add_utm_params(
+			url, {"utm_source": "weekly_summary", "utm_medium": "email"}
+		)
+		self.assertEqual(result.count("utm_source="), 1)
+		self.assertIn("utm_source=manual", result)
+		self.assertIn("utm_medium=email", result)
+
+	def test_no_op_for_host_that_is_not_the_sending_site(self):
+		# Trial registries, DOI resolvers, and the original publisher must
+		# never be tagged — Umami can't see those hits, and the params
+		# would only pollute a third party's analytics.
+		result = add_utm_params(
+			"https://clinicaltrials.gov/study/NCT123",
+			{"utm_source": "weekly_summary"},
+			"example.com",
+		)
+		self.assertEqual(result, "https://clinicaltrials.gov/study/NCT123")
+
+	def test_tags_url_matching_site_domain(self):
+		result = add_utm_params(
+			"https://example.com/articles/1/",
+			{"utm_source": "weekly_summary"},
+			"example.com",
+		)
+		self.assertIn("utm_source=weekly_summary", result)
+
+	def test_host_check_ignores_port(self):
+		result = add_utm_params(
+			"https://example.com:8443/articles/1/",
+			{"utm_source": "weekly_summary"},
+			"example.com",
+		)
+		self.assertIn("utm_source=weekly_summary", result)

--- a/django/subscriptions/tests/test_utm_host_restriction.py
+++ b/django/subscriptions/tests/test_utm_host_restriction.py
@@ -1,0 +1,133 @@
+"""
+End-to-end check that add_utm_params only tags links pointing at the
+sending site, when rendered inside the real email templates.
+
+article_card.html's site article link and author link (when
+has_author_pages is on) must be tagged; trial_card.html's registry link
+(always a third-party host) must never be tagged, since Umami can't see
+those clicks.
+
+Run:
+  docker exec gregory python manage.py test subscriptions.tests.test_utm_host_restriction
+"""
+
+import os
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "gregory.tests.test_settings")
+
+import django
+
+django.setup()
+
+from django.contrib.sites.models import Site
+from django.template.loader import get_template
+from django.test import TestCase
+
+from gregory.models import Articles, Authors, Subject, Team, Trials
+from organizations.models import Organization
+from sitesettings.models import CustomSetting
+from templates.emails.components.content_organizer import get_optimized_email_context
+
+
+class UtmHostRestrictionTest(TestCase):
+	def setUp(self):
+		self.organization = Organization.objects.create(
+			name="Utm Host Org", slug="utm-host-org"
+		)
+		self.team = Team.objects.create(
+			name="Utm Host Team", organization=self.organization, slug="utm-host-team"
+		)
+		self.subject = Subject.objects.create(
+			subject_name="Utm Host Subject",
+			team=self.team,
+			subject_slug="utm-host-subject",
+		)
+		self.site = Site.objects.create(domain="utm-host.example.com", name="UtmHost")
+		self.author = Authors.objects.create(
+			given_name="Jane", family_name="Doe", ORCID="0000-0002-7922-9785"
+		)
+		self.article = Articles.objects.create(
+			title="Utm Host Article",
+			doi="10.9999/utm-host-1",
+			link="https://publisher.example.com/utm-host-1",
+		)
+		self.article.subjects.add(self.subject)
+		self.article.authors.add(self.author)
+		self.trial = Trials.objects.create(
+			title="Utm Host Trial",
+			link="https://clinicaltrials.gov/study/NCT-utm-host",
+		)
+		self.trial.subjects.add(self.subject)
+
+	def _render(self, template_name, email_type, has_author_pages):
+		custom_settings = CustomSetting.objects.create(
+			site=self.site,
+			title="Utm Host Site",
+			has_author_pages=has_author_pages,
+		)
+		utm_params = {"utm_source": email_type, "utm_medium": "email"}
+		context = get_optimized_email_context(
+			email_type=email_type,
+			articles=Articles.objects.filter(pk=self.article.pk),
+			trials=Trials.objects.filter(pk=self.trial.pk),
+			subscriber={"email": "admin@example.com"},
+			site=self.site,
+			custom_settings=custom_settings,
+			utm_params=utm_params,
+		)
+		return get_template(template_name).render(context)
+
+	def test_site_article_link_is_tagged(self):
+		html = self._render(
+			"emails/weekly_summary.html", "weekly_summary", has_author_pages=False
+		)
+		self.assertIn(
+			f'href="https://utm-host.example.com/articles/{self.article.article_id}/?utm_source=weekly_summary&amp;utm_medium=email"',
+			html,
+		)
+
+	def test_author_link_to_site_is_tagged_when_flag_on(self):
+		html = self._render(
+			"emails/weekly_summary.html", "weekly_summary", has_author_pages=True
+		)
+		self.assertIn(
+			'href="https://utm-host.example.com/authors/0000-0002-7922-9785/?utm_source=weekly_summary&amp;utm_medium=email"',
+			html,
+		)
+
+	def test_author_link_to_orcid_is_not_tagged(self):
+		html = self._render(
+			"emails/weekly_summary.html", "weekly_summary", has_author_pages=False
+		)
+		self.assertIn('href="https://orcid.org/0000-0002-7922-9785"', html)
+		self.assertNotIn("orcid.org/0000-0002-7922-9785?", html)
+
+	def test_trial_registry_link_is_never_tagged(self):
+		html = self._render(
+			"emails/weekly_summary.html", "weekly_summary", has_author_pages=False
+		)
+		self.assertIn(
+			'href="https://clinicaltrials.gov/study/NCT-utm-host"', html
+		)
+		self.assertNotIn("clinicaltrials.gov/study/NCT-utm-host?", html)
+
+	def test_admin_summary_original_article_link_is_never_tagged(self):
+		# admin_summary always renders article_card.html with
+		# show_admin_links=True, which links to the original publisher
+		# (article.link) rather than the site's own article page.
+		html = self._render(
+			"emails/admin_summary.html", "admin_summary", has_author_pages=False
+		)
+		self.assertIn(
+			'href="https://publisher.example.com/utm-host-1"', html
+		)
+		self.assertNotIn("publisher.example.com/utm-host-1?", html)
+
+	def test_admin_summary_trial_registry_link_is_never_tagged(self):
+		html = self._render(
+			"emails/admin_summary.html", "admin_summary", has_author_pages=False
+		)
+		self.assertIn(
+			'href="https://clinicaltrials.gov/study/NCT-utm-host"', html
+		)
+		self.assertNotIn("clinicaltrials.gov/study/NCT-utm-host?", html)

--- a/django/templates/emails/components/article_card.html
+++ b/django/templates/emails/components/article_card.html
@@ -32,7 +32,9 @@ Usage:
             <strong>Authors:</strong>
             {% for author in article.authors.all %}
                 {% if author.ORCID %}
-                    <a href="{{ author.ORCID|author_profile_url:author_page_base }}" class="article-card-link" style="color: #3b82f6; text-decoration: underline;">{{ author.full_name }}</a>
+                    {% with author_url=author.ORCID|author_profile_url:author_page_base %}
+                    <a href="{% add_utm_params author_url utm_params site_domain %}" class="article-card-link" style="color: #3b82f6; text-decoration: underline;">{{ author.full_name }}</a>
+                    {% endwith %}
                 {% else %}
                     {{ author.full_name }}
                 {% endif %}
@@ -61,9 +63,11 @@ Usage:
         {% else %}
         <!-- Regular user links -->
         {% with domain=site.domain|default:"brain-regeneration.com" %}
-        <a href="https://{{ domain }}/articles/{{ article.article_id }}/" class="article-card-link" style="color: #3b82f6; text-decoration: underline; font-weight: 500;">
+        {% with article_url=article.article_id|build_article_url:domain %}
+        <a href="{% add_utm_params article_url utm_params domain %}" class="article-card-link" style="color: #3b82f6; text-decoration: underline; font-weight: 500;">
             View Full Article →
         </a>
+        {% endwith %}
         {% endwith %}
         {% endif %}
     </div>

--- a/django/templates/emails/components/article_card_simple.html
+++ b/django/templates/emails/components/article_card_simple.html
@@ -9,30 +9,32 @@ This is a simplified version for contexts where we just need basic article displ
 <div class="article-card" style="background-color: #ffffff; border: 1px solid #e5e7eb; border-radius: 8px; padding: 20px; margin-bottom: 20px; box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);">
     
     <!-- Article Title -->
+    {% with article_url=article.article_id|build_article_url:site_domain %}
     <h3 class="article-card-title" style="color: #1e3a8a; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 18px; font-weight: 600; line-height: 1.3; margin: 0 0 15px 0;">
-        <a href="{% if utm_params %}{{ article.article_id|build_article_url:site_domain|add_utm_params:utm_params }}{% else %}{{ article.article_id|build_article_url:site_domain }}{% endif %}">{{ article.title|safe }}</a>
+        <a href="{% add_utm_params article_url utm_params site_domain %}">{{ article.title|safe }}</a>
     </h3>
-    
+
     <!-- Article Metadata -->
     <div style="margin-bottom: 15px;">
         <p class="article-card-meta" style="color: #6b7280; font-size: 14px; margin: 0 0 5px 0;">
             <strong>Discovery Date:</strong> {{ article.discovery_date|date:"M d, Y" }}
         </p>
-        
+
         {% if article.authors.exists %}
         <p class="article-card-meta" style="color: #6b7280; font-size: 14px; margin: 0 0 5px 0;">
             <strong>Authors:</strong>
-            {% for author in article.authors.all %}{% if author.ORCID %}<a href="{{ author.ORCID|author_profile_url:author_page_base }}" class="article-card-link" style="color: #3b82f6; text-decoration: underline;">{{ author.full_name }}</a>{% else %}{{ author.full_name }}{% endif %}{% if not forloop.last %}, {% endif %}{% endfor %}
+            {% for author in article.authors.all %}{% if author.ORCID %}{% with author_url=author.ORCID|author_profile_url:author_page_base %}<a href="{% add_utm_params author_url utm_params site_domain %}" class="article-card-link" style="color: #3b82f6; text-decoration: underline;">{{ author.full_name }}</a>{% endwith %}{% else %}{{ author.full_name }}{% endif %}{% if not forloop.last %}, {% endif %}{% endfor %}
         </p>
         {% endif %}
     </div>
-    
+
     <!-- Article Link -->
     <div style="margin-bottom: 15px;">
-        <a href="{% if utm_params %}{{ article.article_id|build_article_url:site_domain|add_utm_params:utm_params }}{% else %}{{ article.article_id|build_article_url:site_domain }}{% endif %}" class="article-card-link" style="color: #3b82f6; text-decoration: underline; font-weight: 500;">
+        <a href="{% add_utm_params article_url utm_params site_domain %}" class="article-card-link" style="color: #3b82f6; text-decoration: underline; font-weight: 500;">
             View Full Article →
         </a>
     </div>
+    {% endwith %}
     
     <!-- Key Takeaways (per-organisation) -->
     {% with org_content=org_content_map|get_item:article.article_id %}

--- a/django/templates/emails/components/article_link_simple.html
+++ b/django/templates/emails/components/article_link_simple.html
@@ -1,9 +1,11 @@
 <!-- Simple Article Link Component for Latest Research Section -->
 {% load gregory_tags %}
 <div class="article-link-row" style="margin-bottom: 15px; padding: 5px 0; border-bottom: 1px solid #e5e7eb;">
-    <a href="{% if utm_params %}{{ article.article_id|build_article_url:site_domain|add_utm_params:utm_params }}{% else %}{{ article.article_id|build_article_url:site_domain }}{% endif %}" class="article-link-title" style="text-decoration: none; color: #2563eb; font-weight: 500; display: block; font-size: 15px;">
+    {% with article_url=article.article_id|build_article_url:site_domain %}
+    <a href="{% add_utm_params article_url utm_params site_domain %}" class="article-link-title" style="text-decoration: none; color: #2563eb; font-weight: 500; display: block; font-size: 15px;">
         {{ article.title|clean_html_tags|default:"Article title" }}
     </a>
+    {% endwith %}
     {% if article.doi %}
     <p class="article-link-doi" style="margin: 5px 0 0 0; font-size: 13px; color: #6b7280;">
         DOI: <a href="https://doi.org/{{ article.doi }}" style="color: #6b7280;">{{ article.doi }}</a>

--- a/django/templates/emails/components/footer.html
+++ b/django/templates/emails/components/footer.html
@@ -1,4 +1,5 @@
 <!-- Reusable Email Footer Component -->
+{% load gregory_tags %}
 <table role="presentation" border="0" cellpadding="0" cellspacing="0" class="email-footer-container" style="width: 100%; background-color: #f9fafb; border-radius: 0 0 8px 8px; border-top: 1px solid #e5e7eb;">
     <tr>
         <td style="padding: 30px 40px; text-align: center;">
@@ -25,8 +26,8 @@
                             <tr>
                                 <td style="text-align: center;">
                                     <p class="footer-text" style="color: #6b7280; font-size: 14px; margin: 0 0 10px 0; line-height: 1.5;">
-                                        For more information visit 
-                                        <a href="{{ website_url }}" style="color: #3b82f6; text-decoration: underline; font-weight: 500;">
+                                        For more information visit
+                                        <a href="{% add_utm_params website_url utm_params site_domain %}" style="color: #3b82f6; text-decoration: underline; font-weight: 500;">
                                             {{ website_url }}
                                         </a>
                                     </p>
@@ -41,7 +42,7 @@
                             <tr>
                                 <td style="text-align: center;">
                                     <p class="footer-text" style="color: #6b7280; font-size: 13px; margin: 0; line-height: 1.4;">
-                                        {% if support_url %}<a href="{{ support_url }}" class="footer-link" style="color: #3b82f6; text-decoration: underline; margin: 0 8px;">Support</a>{% endif %}{% if support_url and about_url %} | {% endif %}{% if about_url %}<a href="{{ about_url }}" class="footer-link" style="color: #3b82f6; text-decoration: underline; margin: 0 8px;">About</a>{% endif %}{% if contact_url and about_url or contact_url and support_url %} | {% endif %}{% if contact_url %}<a href="{{ contact_url }}" class="footer-link" style="color: #3b82f6; text-decoration: underline; margin: 0 8px;">Contact</a>{% endif %}
+                                        {% if support_url %}<a href="{% add_utm_params support_url utm_params site_domain %}" class="footer-link" style="color: #3b82f6; text-decoration: underline; margin: 0 8px;">Support</a>{% endif %}{% if support_url and about_url %} | {% endif %}{% if about_url %}<a href="{% add_utm_params about_url utm_params site_domain %}" class="footer-link" style="color: #3b82f6; text-decoration: underline; margin: 0 8px;">About</a>{% endif %}{% if contact_url and about_url or contact_url and support_url %} | {% endif %}{% if contact_url %}<a href="{% add_utm_params contact_url utm_params site_domain %}" class="footer-link" style="color: #3b82f6; text-decoration: underline; margin: 0 8px;">Contact</a>{% endif %}
                                     </p>
                                 </td>
                             </tr>

--- a/django/templates/emails/components/trial_card.html
+++ b/django/templates/emails/components/trial_card.html
@@ -86,7 +86,7 @@ Usage:
         {% if show_admin_links %}
         <!-- Admin-specific links -->
         {% if trial.link %}
-        <a href="{% if utm_params %}{{ trial.link|add_utm_params:utm_params }}{% else %}{{ trial.link }}{% endif %}" class="trial-card-link" style="color: #3b82f6; text-decoration: underline; font-weight: 500; margin-right: 15px;">
+        <a href="{% add_utm_params trial.link utm_params site_domain %}" class="trial-card-link" style="color: #3b82f6; text-decoration: underline; font-weight: 500; margin-right: 15px;">
             View Original Trial →
         </a>
         {% endif %}
@@ -96,7 +96,7 @@ Usage:
         {% else %}
         <!-- Regular user links -->
         {% if trial.link %}
-        <a href="{% if utm_params %}{{ trial.link|add_utm_params:utm_params }}{% else %}{{ trial.link }}{% endif %}" class="trial-card-link" style="color: #3b82f6; text-decoration: underline; font-weight: 500;">
+        <a href="{% add_utm_params trial.link utm_params site_domain %}" class="trial-card-link" style="color: #3b82f6; text-decoration: underline; font-weight: 500;">
             View Trial Details →
         </a>
         {% endif %}

--- a/django/templates/emails/components/trial_card_simple.html
+++ b/django/templates/emails/components/trial_card_simple.html
@@ -64,7 +64,7 @@ This is a simplified version for contexts where we just need basic trial display
     <!-- Trial Link -->
     {% if trial.link %}
     <div style="margin-bottom: 15px;">
-        <a href="{% if utm_params %}{{ trial.link|add_utm_params:utm_params }}{% else %}{{ trial.link }}{% endif %}" class="trial-card-link" style="color: #3b82f6; text-decoration: underline; font-weight: 500;">
+        <a href="{% add_utm_params trial.link utm_params site_domain %}" class="trial-card-link" style="color: #3b82f6; text-decoration: underline; font-weight: 500;">
             View Trial Details →
         </a>
     </div>


### PR DESCRIPTION
## Summary
- `add_utm_params` tagged every link regardless of host, so DOI resolvers, clinical trial registries, and the original publisher URL all got UTM parameters appended — Umami never sees those hits, so the parameters only leaked into a third party's analytics and bloated the URL.
- It also rebuilt the entire query string via `parse_qs()` + `urlencode()`, which can silently rewrite a `+`, a literal `%`, or a repeated key that the filter was never asked to touch.
- `add_utm_params` is now a `simple_tag` taking `(url, utm_params, site_domain)`: it only tags a link whose host matches the sending site, and preserves the original query string verbatim, appending only the UTM keys that are missing.
- Also wires tagging into internal links that were previously untagged: `article_card.html`'s site article link and author links (both card variants), and `footer.html`'s site/brand links — unsubscribe links stay untouched.

## Test plan
- [x] `docker exec gregory python manage.py test gregory.tests.test_gregory_tags subscriptions.tests.test_utm_host_restriction` — new tests pass
- [x] Full suite: `docker exec gregory python manage.py test` — 2577 tests, OK
- [x] New tests: query string preserved byte-identical, no-op for a non-matching host, external registry/DOI links never tagged, internal site/author links tagged correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)