### PR TITLE
Add Categories sheet to export_trials_xlsx

### DIFF
--- a/django/gregory/management/commands/export_trials_xlsx.py
+++ b/django/gregory/management/commands/export_trials_xlsx.py
@@ -3,12 +3,13 @@ import re
 from datetime import datetime, date, timezone as dt_timezone
 
 from django.core.management.base import BaseCommand, CommandError
-from django.db.models import GeneratedField
+from django.db.models import Count, GeneratedField
+from django.db.models.functions import Lower
 from openpyxl import Workbook
 from openpyxl.styles import Font, PatternFill, Alignment
 from openpyxl.utils import get_column_letter
 
-from gregory.models import Trials, Subject
+from gregory.models import Trials, Subject, TeamCategory
 
 
 EXCLUDED_SCALARS = frozenset({"utitle", "usummary"})
@@ -148,7 +149,8 @@ EXTRA_GLOSSARY = {
 	),
 	"team_categories": (
 		"Categories",
-		"Team categories assigned to this trial (semicolon-separated).",
+		"Team categories assigned to this trial (semicolon-separated). See the "
+		"Categories sheet for each category's description and search terms.",
 		"",
 	),
 	"articles": (
@@ -301,6 +303,33 @@ MERGE_PROSE = (
 
 REGISTRY_NAMES = ["WHO ICTRP", "ClinicalTrials.gov", "EU CTIS"]
 
+CATEGORY_COLUMNS = [
+	"Subject",
+	"Team",
+	"Category",
+	"Slug",
+	"Description",
+	"Search terms",
+	"Terms (count)",
+	"Category type",
+	"Modality",
+	"Match scope",
+	"Min score (trials)",
+	"Field weights (trials)",
+	"Trials (this subject)",
+	"Last synced",
+]
+
+CATEGORY_MATCH_PROSE = (
+	"Each row is one category assigned to one subject. Automatic categories are populated "
+	"by the rebuild_categories command: each search term is matched case-insensitively as a "
+	"whole word against the fields listed in \"Field weights (trials)\" (only those fields "
+	"are searched, per the category's match scope); every matching field adds its weight, "
+	"plus a flat 2 points per unique matched term, and a trial is assigned once the total "
+	"reaches the \"Min score (trials)\" threshold. Manual categories are curated by hand and "
+	"ignore the term list."
+)
+
 # Column widths for data sheets
 _WIDE_COLS = {
 	"title",
@@ -385,17 +414,38 @@ def _format_trial_countries(trial):
 	return "; ".join(parts)
 
 
-def _apply_header(ws, columns):
+def _apply_header(ws, columns, row=1):
 	"""Write a bold, coloured header row and return the cell count."""
 	hdr_font = Font(bold=True, color="FFFFFF")
 	hdr_fill = PatternFill(fill_type="solid", fgColor="2F4F8F")
 	hdr_align = Alignment(vertical="center")
 	for col_idx, name in enumerate(columns, 1):
-		cell = ws.cell(row=1, column=col_idx, value=name)
+		cell = ws.cell(row=row, column=col_idx, value=name)
 		cell.font = hdr_font
 		cell.fill = hdr_fill
 		cell.alignment = hdr_align
 	return len(columns)
+
+
+def _excel_text(value, limit=32767):
+	"""Truncate a string to Excel's per-cell character limit."""
+	if not value:
+		return value
+	text = str(value)
+	if len(text) > limit:
+		text = text[: limit - 1] + "…"
+	return text
+
+
+def _write_safe_text_cell(ws, row, col, value, wrap=False):
+	"""Write a long/user-authored text value, truncated and defused against formula injection."""
+	text = _excel_text(value)
+	cell = ws.cell(row=row, column=col, value=text)
+	if isinstance(text, str) and text.startswith("="):
+		cell.data_type = "s"
+	if wrap:
+		cell.alignment = Alignment(wrap_text=True)
+	return cell
 
 
 def _set_column_widths(ws, columns):
@@ -575,6 +625,95 @@ def _build_registries_sheet(wb, all_data_cols):
 		ws.column_dimensions[letter].width = width
 
 
+def _category_rows(subjects):
+	"""Return one row per (subject, category) pair, ordered by subject then category name.
+
+	Categories with no subject never appear here: filtering by `subjects=subject`
+	only matches categories reachable from an exported subject.
+	"""
+	rows = []
+	for subject in subjects:
+		cats = list(
+			TeamCategory.objects.filter(subjects=subject)
+			.select_related("team")
+			.order_by(Lower("category_name"))
+		)
+		if not cats:
+			continue
+		counts = {
+			r["team_categories"]: r["n"]
+			for r in (
+				Trials.objects.filter(
+					subjects=subject, team_categories__in=[c.pk for c in cats]
+				)
+				.values("team_categories")
+				.annotate(n=Count("pk", distinct=True))
+			)
+		}
+		for cat in cats:
+			weights = cat.get_scored_fields("trial")
+			weights_str = "; ".join(f"{f}:{w}" for f, w in weights.items() if w)
+			rows.append(
+				(
+					subject.subject_name,
+					cat.team.name,
+					cat.category_name,
+					cat.category_slug or "",
+					cat.category_description or "",
+					"; ".join(cat.category_terms or []),
+					len(cat.category_terms or []),
+					cat.get_category_type_display(),
+					cat.get_modality_display() if cat.modality else "",
+					cat.get_match_scope_display(),
+					cat.match_min_score_trials,
+					weights_str,
+					counts.get(cat.pk, 0),
+					_cell_value(cat.last_synced_at),
+				)
+			)
+	return rows
+
+
+def _build_categories_sheet(wb, subjects):
+	"""Add a Categories sheet — one row per (subject, category) pair."""
+	ws = wb.create_sheet(title="Categories")
+	section_font = Font(bold=True, size=13)
+
+	ws.cell(
+		row=1, column=1, value="Categories and their search terms"
+	).font = section_font
+	prose_cell = ws.cell(row=2, column=1, value=CATEGORY_MATCH_PROSE)
+	prose_cell.alignment = Alignment(wrap_text=True)
+	last_col_letter = get_column_letter(len(CATEGORY_COLUMNS))
+	ws.merge_cells(f"A2:{last_col_letter}2")
+	ws.row_dimensions[2].height = 90
+
+	_apply_header(ws, CATEGORY_COLUMNS, row=4)
+	ws.freeze_panes = "A5"
+	ws.auto_filter.ref = f"A4:{last_col_letter}4"
+
+	rows = _category_rows(subjects)
+	desc_col = CATEGORY_COLUMNS.index("Description") + 1
+	terms_col = CATEGORY_COLUMNS.index("Search terms") + 1
+
+	if not rows:
+		ws.cell(row=5, column=1, value="No categories found.")
+	else:
+		for row_idx, row_data in enumerate(rows, 5):
+			for col_idx, value in enumerate(row_data, 1):
+				if col_idx in (desc_col, terms_col):
+					_write_safe_text_cell(ws, row_idx, col_idx, value, wrap=True)
+				else:
+					ws.cell(row=row_idx, column=col_idx, value=value)
+
+	wide_widths = {"Description": 65, "Search terms": 65, "Field weights (trials)": 40}
+	for col_idx, name in enumerate(CATEGORY_COLUMNS, 1):
+		letter = get_column_letter(col_idx)
+		ws.column_dimensions[letter].width = wide_widths.get(
+			name, max(12, min(32, len(name) + 4))
+		)
+
+
 class Command(BaseCommand):
 	help = "Export clinical-trial data to an XLSX workbook, one sheet per subject."
 
@@ -674,7 +813,7 @@ class Command(BaseCommand):
 		# --- Build workbook ---
 		wb = Workbook()
 		wb.remove(wb.active)  # remove the default blank sheet
-		used_sheet_names: set = set()
+		used_sheet_names: set = {"Categories", "Glossary", "Registries"}
 
 		for subject in subjects:
 			sheet_name = _sanitise_sheet_name(subject.subject_name, used_sheet_names)
@@ -775,6 +914,7 @@ class Command(BaseCommand):
 
 			_set_column_widths(ws, all_data_cols)
 
+		_build_categories_sheet(wb, subjects)
 		_build_glossary_sheet(wb, all_data_cols)
 		_build_registries_sheet(wb, all_data_cols)
 

--- a/django/gregory/management/commands/export_trials_xlsx.py
+++ b/django/gregory/management/commands/export_trials_xlsx.py
@@ -437,12 +437,25 @@ def _excel_text(value, limit=32767):
 	return text
 
 
+_FORMULA_TRIGGER_CHARS = ("=", "+", "-", "@")
+
+
 def _write_safe_text_cell(ws, row, col, value, wrap=False):
-	"""Write a long/user-authored text value, truncated and defused against formula injection."""
+	"""Write a long/user-authored text value, truncated and defused against formula injection.
+
+	A leading apostrophe is the standard mitigation (OWASP CSV injection guidance):
+	it forces the cell to render as literal text in Excel/LibreOffice/Sheets even
+	when the value starts with =, +, -, or @. Relying on openpyxl's data_type alone
+	is not enough — several of those trigger characters (+, -, @) are never
+	auto-detected as formulas by openpyxl in the first place, so its cell.data_type
+	would stay "s" regardless, while spreadsheet applications still treat a leading
+	=, +, -, or @ as a formula cue on their own.
+	"""
 	text = _excel_text(value)
+	if isinstance(text, str) and text.startswith(_FORMULA_TRIGGER_CHARS):
+		text = "'" + text
 	cell = ws.cell(row=row, column=col, value=text)
-	if isinstance(text, str) and text.startswith("="):
-		cell.data_type = "s"
+	cell.data_type = "s"
 	if wrap:
 		cell.alignment = Alignment(wrap_text=True)
 	return cell

--- a/django/gregory/tests/test_export_trials_xlsx.py
+++ b/django/gregory/tests/test_export_trials_xlsx.py
@@ -752,6 +752,34 @@ class ExportTrialsXlsxTests(TestCase):
 		finally:
 			os.unlink(path)
 
+	def test_category_description_formula_injection_defused(self):
+		"""A description starting with =, +, -, or @ must not become a live formula cell."""
+		cat_formula = TeamCategory.objects.create(
+			team=self.team,
+			category_name="Formula-like description",
+			category_description="=SUM(A1:A10)",
+			category_terms=["+1(555)", "-benchmark", "@mention"],
+		)
+		cat_formula.subjects.add(self.subject_ms)
+		path, wb = self._export(subjects=str(self.subject_ms.pk))
+		try:
+			ws = wb["Categories"]
+			headers = [
+				ws.cell(row=4, column=c).value for c in range(1, ws.max_column + 1)
+			]
+			cat_col = headers.index("Category") + 1
+			desc_col = headers.index("Description") + 1
+			for r in range(5, ws.max_row + 1):
+				if ws.cell(row=r, column=cat_col).value == "Formula-like description":
+					cell = ws.cell(row=r, column=desc_col)
+					self.assertNotEqual(cell.data_type, "f")
+					self.assertEqual(cell.value, "'=SUM(A1:A10)")
+					break
+			else:
+				self.fail("Row for Formula-like description not found")
+		finally:
+			os.unlink(path)
+
 	def test_subjectless_category_never_exported(self):
 		path, wb = self._export(
 			subjects=f"{self.subject_ms.pk},{self.subject_cancer.pk}"

--- a/django/gregory/tests/test_export_trials_xlsx.py
+++ b/django/gregory/tests/test_export_trials_xlsx.py
@@ -17,13 +17,18 @@ import openpyxl
 from gregory.models import (
 	Articles,
 	ArticleTrialReference,
+	CategoryModality,
+	CategoryType,
 	Sources,
 	Subject,
 	Team,
+	TeamCategory,
 	Trials,
+	TrialCategoryAssignment,
 	TrialCountry,
 )
 from gregory.management.commands.export_trials_xlsx import (
+	CATEGORY_COLUMNS,
 	IDENTITY_COLS,
 	RELATION_COLS,
 	REGISTRY_NAMES,
@@ -93,6 +98,41 @@ class ExportTrialsXlsxTests(TestCase):
 			trial=self.trial_ms,
 			identifier_type="nct",
 			identifier_value="NCT00111111",
+		)
+
+		# Categories exercising the Categories sheet
+		self.cat_natalizumab = TeamCategory.objects.create(
+			team=self.team,
+			category_name="Natalizumab",
+			category_description="Trials studying natalizumab (Tysabri) in MS.",
+			category_terms=["natalizumab", "tysabri"],
+			category_type=CategoryType.AUTOMATIC,
+			modality=CategoryModality.BIOLOGIC_ANTIBODY,
+		)
+		self.cat_natalizumab.subjects.add(self.subject_ms)
+		TrialCategoryAssignment.objects.create(
+			trials=self.trial_ms, teamcategory=self.cat_natalizumab
+		)
+
+		self.cat_manual = TeamCategory.objects.create(
+			team=self.team,
+			category_name="Manual watchlist",
+			category_type=CategoryType.MANUAL,
+			category_terms=[],
+		)
+		self.cat_manual.subjects.add(self.subject_ms)
+
+		self.cat_shared = TeamCategory.objects.create(
+			team=self.team,
+			category_name="Shared category",
+			category_terms=["shared-term"],
+		)
+		self.cat_shared.subjects.add(self.subject_ms, self.subject_cancer)
+
+		self.cat_orphan = TeamCategory.objects.create(
+			team=self.team,
+			category_name="Orphan category",
+			category_terms=["orphan-term"],
 		)
 
 	def _export(self, **kwargs):
@@ -620,6 +660,154 @@ class ExportTrialsXlsxTests(TestCase):
 				self.assertIn(
 					reg, all_values, f'Registry column "{reg}" not in field matrix'
 				)
+		finally:
+			os.unlink(path)
+
+	# ------------------------------------------------------------------
+	# Categories sheet
+	# ------------------------------------------------------------------
+
+	def _category_row(self, ws, subject_name, category_name):
+		"""Return {header: value} for the Categories sheet row matching (subject, category)."""
+		headers = [ws.cell(row=4, column=c).value for c in range(1, ws.max_column + 1)]
+		subj_col = headers.index("Subject") + 1
+		cat_col = headers.index("Category") + 1
+		for r in range(5, ws.max_row + 1):
+			if (
+				ws.cell(row=r, column=subj_col).value == subject_name
+				and ws.cell(row=r, column=cat_col).value == category_name
+			):
+				return {h: ws.cell(row=r, column=c + 1).value for c, h in enumerate(headers)}
+		self.fail(f"Row for subject={subject_name!r} category={category_name!r} not found")
+
+	def test_categories_sheet_present(self):
+		path, wb = self._export(subjects=str(self.subject_ms.pk))
+		try:
+			self.assertIn("Categories", wb.sheetnames)
+		finally:
+			os.unlink(path)
+
+	def test_categories_sheet_headers(self):
+		path, wb = self._export(subjects=str(self.subject_ms.pk))
+		try:
+			ws = wb["Categories"]
+			headers = [
+				ws.cell(row=4, column=c).value for c in range(1, ws.max_column + 1)
+			]
+			self.assertEqual(headers, CATEGORY_COLUMNS)
+		finally:
+			os.unlink(path)
+
+	def test_category_description_and_terms_rendered(self):
+		path, wb = self._export(subjects=str(self.subject_ms.pk))
+		try:
+			ws = wb["Categories"]
+			row = self._category_row(ws, "Multiple Sclerosis", "Natalizumab")
+			self.assertEqual(
+				row["Description"], "Trials studying natalizumab (Tysabri) in MS."
+			)
+			self.assertEqual(row["Search terms"], "natalizumab; tysabri")
+		finally:
+			os.unlink(path)
+
+	def test_category_row_per_subject_pair(self):
+		path, wb = self._export(
+			subjects=f"{self.subject_ms.pk},{self.subject_cancer.pk}"
+		)
+		try:
+			ws = wb["Categories"]
+			# Present under both subjects it is assigned to
+			self._category_row(ws, "Multiple Sclerosis", "Shared category")
+			self._category_row(ws, "Cancer", "Shared category")
+		finally:
+			os.unlink(path)
+
+	def test_category_trial_count_scoped_to_subject(self):
+		path, wb = self._export(subjects=str(self.subject_ms.pk))
+		try:
+			ws = wb["Categories"]
+			row = self._category_row(ws, "Multiple Sclerosis", "Natalizumab")
+			self.assertEqual(row["Trials (this subject)"], 1)
+		finally:
+			os.unlink(path)
+
+	def test_manual_category_shows_type_and_empty_terms(self):
+		path, wb = self._export(subjects=str(self.subject_ms.pk))
+		try:
+			ws = wb["Categories"]
+			row = self._category_row(ws, "Multiple Sclerosis", "Manual watchlist")
+			self.assertEqual(row["Category type"], "Manual")
+			self.assertFalse(row["Search terms"])
+		finally:
+			os.unlink(path)
+
+	def test_match_config_columns_populated(self):
+		path, wb = self._export(subjects=str(self.subject_ms.pk))
+		try:
+			ws = wb["Categories"]
+			row = self._category_row(ws, "Multiple Sclerosis", "Natalizumab")
+			self.assertTrue(row["Match scope"])
+			self.assertTrue(row["Min score (trials)"])
+			self.assertTrue(row["Field weights (trials)"])
+		finally:
+			os.unlink(path)
+
+	def test_subjectless_category_never_exported(self):
+		path, wb = self._export(
+			subjects=f"{self.subject_ms.pk},{self.subject_cancer.pk}"
+		)
+		try:
+			ws = wb["Categories"]
+			names = [ws.cell(row=r, column=3).value for r in range(5, ws.max_row + 1)]
+			self.assertNotIn("Orphan category", names)
+		finally:
+			os.unlink(path)
+
+		path, wb = self._export(all_subjects=True)
+		try:
+			ws = wb["Categories"]
+			names = [ws.cell(row=r, column=3).value for r in range(5, ws.max_row + 1)]
+			self.assertNotIn("Orphan category", names)
+		finally:
+			os.unlink(path)
+
+	def test_categories_sheet_explains_matching(self):
+		path, wb = self._export(subjects=str(self.subject_ms.pk))
+		try:
+			ws = wb["Categories"]
+			self.assertTrue(ws.cell(row=1, column=1).value)
+			prose = ws.cell(row=2, column=1).value
+			self.assertTrue(prose)
+			self.assertIn("score", prose.lower())
+		finally:
+			os.unlink(path)
+
+	def test_no_categories_writes_placeholder(self):
+		no_cat_subject = Subject.objects.create(
+			subject_name="No Categories Subject",
+			subject_slug="no-categories-subject",
+			team=self.team,
+		)
+		path, wb = self._export(subjects=str(no_cat_subject.pk))
+		try:
+			ws = wb["Categories"]
+			self.assertEqual(ws.cell(row=5, column=1).value, "No categories found.")
+		finally:
+			os.unlink(path)
+
+	def test_reserved_sheet_names(self):
+		clash = Subject.objects.create(
+			subject_name="Categories", subject_slug="categories-clash", team=self.team
+		)
+		path, wb = self._export(subjects=str(clash.pk))
+		try:
+			self.assertIn("Categories", wb.sheetnames)
+			self.assertIn("Categories_2", wb.sheetnames)
+			ws = wb["Categories"]
+			headers = [
+				ws.cell(row=4, column=c).value for c in range(1, ws.max_column + 1)
+			]
+			self.assertEqual(headers, CATEGORY_COLUMNS)
 		finally:
 			os.unlink(path)
 

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -252,3 +252,33 @@ docker exec gregory python manage.py send_weekly_summary --dry-run --debug --day
 ```
 
 The `--days` flag controls the lookback window; articles older than N days are excluded regardless of sort order.
+
+---
+
+## How do I export trials to Excel?
+
+```bash
+# Export one or more subjects by ID
+docker exec gregory python manage.py export_trials_xlsx --subjects 1,2 --output /tmp/trials.xlsx
+
+# Export every subject
+docker exec gregory python manage.py export_trials_xlsx --all-subjects --output /tmp/trials.xlsx
+
+# Restrict to subjects belonging to a team
+docker exec gregory python manage.py export_trials_xlsx --all-subjects --team 1 --output /tmp/trials.xlsx
+```
+
+Flags:
+
+| Flag | Purpose |
+|---|---|
+| `--subjects <ids>` | Comma-separated subject IDs to export (mutually exclusive with `--all-subjects`). |
+| `--all-subjects` | Export every subject, one sheet each. |
+| `--team <id>` | Optional; narrows which subjects are exported to one team. |
+| `--output <path>` | Output file path (default: `trials_export_YYYYMMDD.xlsx` in the current directory). |
+
+The workbook has one sheet per exported subject, plus three reference sheets at the end:
+
+- **Categories** — one row per (subject, category) pair, with each category's description, search terms, matching configuration (scope, score threshold, field weights), and trial count scoped to that subject. Categories with no subject assigned are never exported.
+- **Glossary** — one row per exported trial column, with its label, description, and source registries.
+- **Registries** — prose on how trial data from multiple registries (WHO ICTRP, ClinicalTrials.gov, EU CTIS) is merged, plus a field-by-registry coverage matrix.


### PR DESCRIPTION
## Summary
- Adds a `Categories` sheet to the trials Excel export (issue #820), listing every category of every exported subject: description, search terms, matching configuration (scope, score threshold, per-field weights), and a trial count scoped to that subject.
- Sheet order becomes: one sheet per subject, then `Categories`, `Glossary`, `Registries`.
- Categories with no subject assigned are never exported (a data-quality issue, out of scope here).
- Adds `_excel_text`/`_write_safe_text_cell` guards against Excel's 32,767-char cell limit and formula-injection from admin-entered text starting with `=`.
- Reserves `Categories`/`Glossary`/`Registries` as sheet names so a subject with one of those names can't collide with the fixed sheets.
- Appends a pointer sentence to the existing `Glossary` row for `team_categories` pointing at the new sheet (no change to `Glossary`'s one-row-per-column contract).
- Documents the command in `docs/cookbook.md` (new "How do I export trials to Excel?" recipe).

## Test plan
- [x] `docker exec gregory python manage.py test gregory.tests.test_export_trials_xlsx` — 43/43 pass (11 new tests covering the Categories sheet: headers, description/terms rendering, one row per subject×category pair, subject-scoped trial counts, manual categories, match-config columns, subjectless-category exclusion, empty-sheet placeholder, reserved sheet names).
- [x] Full suite: `docker exec gregory python manage.py test` — 2636 tests, 2 pre-existing failures in `api/tests/test_author_coauthors.py` (query-count budget drift, unrelated to this change; reproduced on `main` before this branch's changes).
- [x] Manual export against the dev DB (`export_trials_xlsx --all-subjects`): sheet order, ~94 category rows (89 MS + 1 Neuroinflammation), no empty-subject cells, no orphan categories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)