### PR TITLE
Re-validate outreach candidacy at send time

### DIFF
--- a/django/subscriptions/management/commands/send_author_outreach.py
+++ b/django/subscriptions/management/commands/send_author_outreach.py
@@ -49,7 +49,10 @@ from subscriptions.management.commands.utils.send_email import (
 	send_email,
 )
 from subscriptions.models import AuthorOutreach, AuthorOutreachCampaign, EmailMessage
-from subscriptions.utils.author_outreach import is_contact_blocked
+from subscriptions.utils.author_outreach import (
+	currently_qualifying_article_ids,
+	is_contact_blocked,
+)
 from subscriptions.utils.author_outreach_send import (
 	evaluate_circuit_breakers,
 	render_author_outreach_email,
@@ -314,6 +317,9 @@ class Command(BaseCommand):
 	):
 		slug = campaign.utm_campaign_slug
 		sent_count = 0
+		# Lazily computed on the first upcoming-mode row, then reused for the
+		# rest of the run — see the re-validation block below.
+		still_qualifying = None
 
 		for index, row in enumerate(rows):
 			today_start = timezone.now().replace(
@@ -330,6 +336,56 @@ class Command(BaseCommand):
 					)
 				)
 				break
+
+			# Re-validate that this row's papers are still headed for the
+			# next digest. Only `upcoming` mode makes a forward-looking
+			# claim; a `retrospective` email says the paper *was* featured,
+			# which no later change can falsify.
+			#
+			# Computed once per run rather than per row: the set cannot
+			# meaningfully move during a run that sends a handful of
+			# messages, and recomputing it per row would re-run
+			# select_digest_articles for every recipient.
+			#
+			# ALL of the row's papers must still qualify, not merely one.
+			# The email names each of them as forthcoming, so a row that
+			# has lost any of its papers would send a partly false promise.
+			if campaign.mode == AuthorOutreachCampaign.MODE_UPCOMING:
+				if still_qualifying is None:
+					still_qualifying = currently_qualifying_article_ids(campaign)
+				row_article_ids = set(row.articles.values_list("pk", flat=True))
+				dropped = row_article_ids - still_qualifying
+				if dropped:
+					# Back to pending, not skipped or failed: the slot is
+					# not burned, because nothing was sent and this author
+					# may well qualify again next cycle. It needs a human
+					# to look, so approval is cleared rather than kept.
+					row.status = AuthorOutreach.STATUS_PENDING
+					row.approved_at = None
+					row.approved_by = None
+					row.error_message = (
+						f"Not sent: {len(dropped)} of {len(row_article_ids)} "
+						"queued paper(s) are no longer in the next digest's "
+						"selection, so the email's 'will be featured' claim "
+						"would be false. Returned to pending for review — "
+						"re-approve if they qualify again, or cancel."
+					)
+					row.save(
+						update_fields=[
+							"status",
+							"approved_at",
+							"approved_by",
+							"error_message",
+						]
+					)
+					self.stdout.write(
+						self.style.WARNING(
+							f"Returned {row.email} to pending: "
+							f"{len(dropped)} queued paper(s) dropped out of "
+							"the next digest since the queue was built."
+						)
+					)
+					continue
 
 			# Re-check the opt-out tables immediately before this send —
 			# an address can have been opted out, suppressed, or

--- a/django/subscriptions/management/commands/send_author_outreach.py
+++ b/django/subscriptions/management/commands/send_author_outreach.py
@@ -183,7 +183,11 @@ class Command(BaseCommand):
 		approved_rows = list(
 			AuthorOutreach.objects.filter(
 				campaign=campaign, status=AuthorOutreach.STATUS_APPROVED
-			).order_by("queued_at")
+			)
+			# Both the send-time candidacy re-check and the renderer walk
+			# row.articles; without this each row costs two extra queries.
+			.prefetch_related("articles")
+			.order_by("queued_at")
 		)
 		if limit is not None:
 			approved_rows = approved_rows[:limit]
@@ -350,10 +354,43 @@ class Command(BaseCommand):
 			# ALL of the row's papers must still qualify, not merely one.
 			# The email names each of them as forthcoming, so a row that
 			# has lost any of its papers would send a partly false promise.
+			# Prefetched above, so this costs no query.
+			row_article_ids = {article.pk for article in row.articles.all()}
+
+			# A row with no papers left would render the template's
+			# multi-paper branch with an empty list — "your recent papers"
+			# followed by nothing. Guard both modes, not just upcoming: a
+			# retrospective row emptied by an article deletion or a manual
+			# edit is just as broken, and the drift check below cannot catch
+			# it (an empty set drops nothing, so it would read as "still
+			# qualifying" and send).
+			if not row_article_ids:
+				row.status = AuthorOutreach.STATUS_PENDING
+				row.approved_at = None
+				row.approved_by = None
+				row.error_message = (
+					"Not sent: the row has no papers attached, so the email "
+					"would name none. Returned to pending — re-build or "
+					"cancel it."
+				)
+				row.save(
+					update_fields=[
+						"status",
+						"approved_at",
+						"approved_by",
+						"error_message",
+					]
+				)
+				self.stdout.write(
+					self.style.WARNING(
+						f"Returned {row.email} to pending: no papers attached."
+					)
+				)
+				continue
+
 			if campaign.mode == AuthorOutreachCampaign.MODE_UPCOMING:
 				if still_qualifying is None:
 					still_qualifying = currently_qualifying_article_ids(campaign)
-				row_article_ids = set(row.articles.values_list("pk", flat=True))
 				dropped = row_article_ids - still_qualifying
 				if dropped:
 					# Back to pending, not skipped or failed: the slot is

--- a/django/subscriptions/tests/test_send_author_outreach_command.py
+++ b/django/subscriptions/tests/test_send_author_outreach_command.py
@@ -470,6 +470,49 @@ class SendAuthorOutreachCommandTestCase(TestCase):
 		row.refresh_from_db()
 		self.assertEqual(row.status, AuthorOutreach.STATUS_PENDING)
 
+	def test_row_with_no_papers_is_never_sent_upcoming(self):
+		"""
+		An empty article set drops nothing, so the drift check alone would
+		read it as "still qualifying" and send an email naming no papers at
+		all. Guarded separately, before the drift check.
+		"""
+		w = self._new_world("empty1")
+		row = self._new_row(w, "empty1")
+		row.articles.clear()
+
+		with mock.patch(SEND_EMAIL_POST_TARGET) as mock_post:
+			self._run(w.campaign.utm_campaign_slug, still_qualifying=set())
+
+		mock_post.assert_not_called()
+		row.refresh_from_db()
+		self.assertEqual(row.status, AuthorOutreach.STATUS_PENDING)
+		self.assertIsNone(row.approved_at)
+		self.assertIn("no papers attached", row.error_message)
+
+	def test_row_with_no_papers_is_never_sent_retrospective(self):
+		"""
+		Same guard must apply in retrospective mode, which is exempt from the
+		drift check — a row emptied by an article deletion is just as broken
+		there.
+		"""
+		w = self._new_world(
+			"empty2",
+			campaign_kwargs={
+				"mode": AuthorOutreachCampaign.MODE_RETROSPECTIVE,
+				"featured_within_days": 30,
+				"body_template": "<p>Your paper was featured. {{ opt_out_url }}</p>",
+			},
+		)
+		row = self._new_row(w, "empty2")
+		row.articles.clear()
+
+		with mock.patch(SEND_EMAIL_POST_TARGET) as mock_post:
+			self._run(w.campaign.utm_campaign_slug)
+
+		mock_post.assert_not_called()
+		row.refresh_from_db()
+		self.assertEqual(row.status, AuthorOutreach.STATUS_PENDING)
+
 	def test_retrospective_campaign_skips_revalidation(self):
 		"""
 		A retrospective email says the paper *was* featured — a claim no

--- a/django/subscriptions/tests/test_send_author_outreach_command.py
+++ b/django/subscriptions/tests/test_send_author_outreach_command.py
@@ -51,6 +51,12 @@ def _mock_response(status_code=200, error_code=0, message_id="msg-1", message="O
 	return response
 
 
+# Sentinel for _run's default: "stub re-validation to accept whatever this
+# campaign's rows already reference". A sentinel rather than None, because
+# None is a meaningful value to pass (nothing qualifies any more).
+_ALL_STILL_QUALIFY = object()
+
+
 class SendAuthorOutreachCommandTestCase(TestCase):
 	def _new_world(self, tag, campaign_kwargs=None):
 		org = Organization.objects.create(name=f"Org {tag}", slug=f"org-{tag}")
@@ -103,9 +109,39 @@ class SendAuthorOutreachCommandTestCase(TestCase):
 		row.articles.set([article])
 		return row
 
-	def _run(self, campaign_slug, **extra):
+	def _run(self, campaign_slug, still_qualifying=_ALL_STILL_QUALIFY, **extra):
+		"""
+		Run the command with send-time candidacy re-validation stubbed out by
+		default.
+
+		These tests exercise the send loop — approval gating, breakers,
+		throttling, status transitions — not the eligibility engine, which has
+		its own integration tests in test_author_outreach_eligibility.py. The
+		fixtures here build bare Articles with no digest list, subject, or ML
+		predictions, so real re-validation would correctly reject every one of
+		them and every test below would be testing the drift path by accident.
+
+		Pass `still_qualifying` explicitly (a set of article ids, possibly
+		empty) to exercise that path deliberately — see the re-validation
+		tests at the end of this class.
+		"""
 		out = StringIO()
-		call_command("send_author_outreach", campaign=campaign_slug, stdout=out, **extra)
+		if still_qualifying is _ALL_STILL_QUALIFY:
+			resolved = set(
+				AuthorOutreach.objects.filter(
+					campaign__utm_campaign_slug=campaign_slug
+				).values_list("articles__pk", flat=True)
+			)
+		else:
+			resolved = still_qualifying
+		with mock.patch(
+			"subscriptions.management.commands.send_author_outreach."
+			"currently_qualifying_article_ids",
+			return_value=resolved,
+		):
+			call_command(
+				"send_author_outreach", campaign=campaign_slug, stdout=out, **extra
+			)
 		return out.getvalue()
 
 	# ------------------------------------------------------------------
@@ -367,6 +403,99 @@ class SendAuthorOutreachCommandTestCase(TestCase):
 	# ------------------------------------------------------------------
 	# Send-time opt-out recheck
 	# ------------------------------------------------------------------
+
+	# ------------------------------------------------------------------
+	# Send-time candidacy re-validation (upcoming mode only)
+	# ------------------------------------------------------------------
+
+	def test_row_whose_paper_dropped_out_returns_to_pending_unsent(self):
+		"""
+		The recommended schedule builds Thursday and sends Monday, so a
+		queued paper can fall out of the next digest's selection in between.
+		The email claims it "will be featured", so the row must not go out —
+		and must not burn the slot either, since nothing was sent and the
+		author may qualify again next cycle. Approval is cleared so a human
+		has to look before it is sent.
+		"""
+		w = self._new_world("drift1")
+		row = self._new_row(w, "drift1")
+
+		with mock.patch(SEND_EMAIL_POST_TARGET) as mock_post:
+			self._run(w.campaign.utm_campaign_slug, still_qualifying=set())
+
+		mock_post.assert_not_called()
+		row.refresh_from_db()
+		self.assertEqual(row.status, AuthorOutreach.STATUS_PENDING)
+		self.assertIsNone(row.approved_at)
+		self.assertIsNone(row.approved_by)
+		self.assertIn("no longer in the next digest", row.error_message)
+
+	def test_row_still_qualifying_is_sent_normally(self):
+		"""Counterpart to the test above — proves the guard is not simply
+		rejecting everything."""
+		w = self._new_world("drift2")
+		row = self._new_row(w, "drift2")
+		article_ids = set(row.articles.values_list("pk", flat=True))
+
+		with mock.patch(
+			SEND_EMAIL_POST_TARGET, return_value=_mock_response()
+		) as mock_post:
+			self._run(w.campaign.utm_campaign_slug, still_qualifying=article_ids)
+
+		mock_post.assert_called_once()
+		row.refresh_from_db()
+		self.assertEqual(row.status, AuthorOutreach.STATUS_SENT)
+
+	def test_partial_drop_still_returns_row_to_pending(self):
+		"""
+		The email names every queued paper as forthcoming, so losing one of
+		two makes the message partly false. All must still qualify.
+		"""
+		w = self._new_world("drift3")
+		row = self._new_row(w, "drift3")
+		extra = Articles.objects.create(
+			title="Second paper",
+			link="https://example.com/drift3-second",
+			doi="10.9999/drift3-second",
+			published_date=timezone.now() - timedelta(days=2),
+		)
+		extra.authors.add(row.author)
+		row.articles.add(extra)
+		kept = {row.articles.first().pk}
+
+		with mock.patch(SEND_EMAIL_POST_TARGET) as mock_post:
+			self._run(w.campaign.utm_campaign_slug, still_qualifying=kept)
+
+		mock_post.assert_not_called()
+		row.refresh_from_db()
+		self.assertEqual(row.status, AuthorOutreach.STATUS_PENDING)
+
+	def test_retrospective_campaign_skips_revalidation(self):
+		"""
+		A retrospective email says the paper *was* featured — a claim no
+		later change can falsify — so the forward-looking guard must not
+		apply, and must not block a legitimate back-catalogue send.
+		"""
+		w = self._new_world(
+			"retro1",
+			campaign_kwargs={
+				"mode": AuthorOutreachCampaign.MODE_RETROSPECTIVE,
+				"featured_within_days": 30,
+				"body_template": "<p>Your paper was featured. {{ opt_out_url }}</p>",
+			},
+		)
+		row = self._new_row(w, "retro1")
+
+		with mock.patch(
+			SEND_EMAIL_POST_TARGET, return_value=_mock_response()
+		) as mock_post:
+			# Nothing qualifies under the upcoming rules; a retrospective
+			# campaign must send anyway.
+			self._run(w.campaign.utm_campaign_slug, still_qualifying=set())
+
+		mock_post.assert_called_once()
+		row.refresh_from_db()
+		self.assertEqual(row.status, AuthorOutreach.STATUS_SENT)
 
 	def test_send_time_opt_out_recheck_skips_without_calling_postmark(self):
 		w = self._new_world("recheck1")

--- a/django/subscriptions/utils/author_outreach.py
+++ b/django/subscriptions/utils/author_outreach.py
@@ -160,6 +160,48 @@ def eligible_authors(campaign, since=None):
 	return results
 
 
+def currently_qualifying_article_ids(campaign):
+	"""
+	The article ids that satisfy `campaign`'s article-level eligibility
+	rules right now, ignoring every author-level rule (email, ORCID flags,
+	opt-outs, existing rows). Read-only.
+
+	Exists for send_author_outreach's re-validation step. A queue is built
+	days before it is sent — the recommended schedule builds Thursday and
+	sends Monday, ahead of Tuesday's digest — and in `upcoming` mode
+	eligibility is a snapshot of what the *next* digest would feature. New
+	articles arriving in between can push a queued paper past the list's
+	article_limit, at which point the email's "will be featured in the next
+	digest" promise is no longer true. Re-running the same gates at send
+	time is what catches that.
+
+	Deliberately shares `eligible_authors`'s list loop and both candidate
+	helpers rather than reimplementing them: a re-validation that could
+	disagree with the build would be worse than none, because it would
+	reject rows the build would still accept.
+	"""
+	lists = Lists.objects.filter(site=campaign.site, weekly_digest=True)
+	campaign_subject_ids = set(campaign.subjects.values_list("id", flat=True))
+	if campaign_subject_ids:
+		lists = lists.filter(subjects__id__in=campaign_subject_ids).distinct()
+
+	qualifying = set()
+	for digest_list in lists.prefetch_related("subjects"):
+		if campaign.mode == AuthorOutreachCampaign.MODE_UPCOMING:
+			candidate_ids = _upcoming_candidate_ids(digest_list)
+		else:
+			candidate_ids = _retrospective_candidate_ids(
+				digest_list, campaign.featured_within_days
+			)
+		if not candidate_ids:
+			continue
+		list_subjects = list(digest_list.subjects.all())
+		qualifying |= _relevance_gate(
+			candidate_ids, list_subjects, digest_list.ml_threshold
+		)
+	return qualifying
+
+
 def _upcoming_candidate_ids(digest_list):
 	"""
 	Spec "Who qualifies", mode `upcoming`, rules 1-2: call the digest's own

--- a/docs/author-outreach-spec.md
+++ b/docs/author-outreach-spec.md
@@ -116,14 +116,21 @@ author regardless of how many qualifying papers they have.
 
 ### Timing
 
-In `upcoming` mode the outreach run must complete **immediately before** `send_weekly_summary`
-for that list, in the same cron slot. The two commands read the same candidate set, so a long
-gap lets new articles arrive and change the ranking between the promise and the send.
+**Superseded during implementation — see [author-outreach.md](author-outreach.md#scheduling)
+for the schedule actually in use.** This section originally required the outreach run to
+complete immediately before `send_weekly_summary`, in the same cron slot, because both read
+the same candidate set and any gap lets new articles change the ranking between the promise
+and the send.
+
+That turned out to be unimplementable as stated: the queue needs a human to approve rows
+between the build and the send, so the two cannot share a cron slot. The schedule builds
+Thursday and sends Monday instead, and the drift the same-slot rule was protecting against is
+handled at send time — `send_author_outreach` re-runs the article-level gates immediately
+before dispatch and returns any row that has lost a paper to `pending` rather than sending a
+promise that is no longer true.
 
 If the digest then fails to run, the promise is delayed rather than broken: the article stays
-in the candidate set and goes out the following week. If an article rolls over because of
-`article_limit`, the author sees it one edition later than the email implied — the never-sent
-plus top-N restriction in rule 2 is what keeps that rare.
+in the candidate set and goes out the following week.
 
 ### Addressing and sending
 
@@ -263,9 +270,10 @@ claims both hold.
 
 **"It will be featured in the next research digest newsletter."** True by construction:
 eligibility rule 2 admits only articles that have never been sent for that list and that rank
-within `article_limit` of the digest's own priority order, and the outreach run happens in the
-same cron slot immediately before the digest. A rollover can still push an article one edition
-later — see Timing — which is why the rule is never-sent *and* top-N rather than either alone.
+within `article_limit` of the digest's own priority order, and `send_author_outreach` re-runs
+those same gates immediately before dispatch, returning any row that has lost a paper to
+`pending` instead of sending. A rollover can still push an article one edition later, which is
+why the rule is never-sent *and* top-N rather than either alone.
 
 **"A high score in these three models and the human review."** Every candidate article has
 passed through a curator review surface: the admin summary emails ML-scored articles at the list's

--- a/docs/author-outreach.md
+++ b/docs/author-outreach.md
@@ -427,44 +427,68 @@ campaign be enabled and put on the cron schedule below.
 
 ---
 
-## Cron ordering
+## Scheduling
 
-Cron ordering is load-bearing, not a convenience. In `upcoming` mode, the
-build and the send have to run in the same slot, immediately **before**
-`send_weekly_summary` — both `build_author_outreach` and
-`send_weekly_summary` read the same candidate set
-(`select_digest_articles`), and any gap between them lets a new article
-arrive and change the ranking, breaking the "will be featured in the next
-digest" promise the email already made. `send_weekly_summary` takes no
-`--list` argument — one invocation covers every weekly digest list on
-every site — so one campaign per site, with an empty `subjects` set
-(covering every weekly digest list on that site), needs exactly one
-build-and-send line ahead of the single shared `send_weekly_summary` line.
-A site running more than one `upcoming` campaign (scoped to different
-`subjects`) needs one build-and-send line per campaign, all still ahead of
-that same shared line.
+`build_author_outreach` writes rows as `pending`; `send_author_outreach`
+only ever sends rows a human has moved to `approved`. **The two cannot be
+chained in one cron slot** — a `build && send` line would queue a batch and
+then send nothing, silently, every week. The approval step is deliberate and
+there is no flag to bypass it.
+
+So the schedule is two slots with a person in between:
 
 ```cron
-# Author outreach (upcoming) for gregory-ms.com — must finish before
-# send_weekly_summary below, since both read select_digest_articles's
-# candidate set and a gap between them changes the ranking. One line per
-# site running an enabled upcoming campaign; repeat with that site's own
-# --campaign slug for additional sites.
-50 7 * * 2 flock -n /tmp/author_outreach_ms-weekly-outreach docker exec gregory sh -c "python manage.py build_author_outreach --campaign ms-weekly-outreach && python manage.py send_author_outreach --campaign ms-weekly-outreach"
+# Author outreach: build Thursday, leaving two working days to review the
+# queue in the admin before it is sent.
+0 9 * * 4 /usr/bin/docker exec gregory python manage.py build_author_outreach --campaign ms-weekly-outreach
+
+# Send Monday morning — only sends what was approved. The digest follows on
+# Tuesday, so a problem noticed on Monday is still fixable before the
+# promise in the email comes due.
+0 9 * * 1 /usr/bin/flock -n /tmp/author_outreach_ms-weekly-outreach /usr/bin/docker exec gregory python manage.py send_author_outreach --campaign ms-weekly-outreach
 
 # Weekly summary every Tuesday — unchanged
-5 8 * * 2 docker exec gregory python manage.py send_weekly_summary
+5 8 * * 2 /usr/bin/docker exec gregory python manage.py send_weekly_summary
 ```
 
-The `flock` guard (matching the pipeline entry in `CLAUDE.md`) stops a slow
-run from overlapping with itself on the next cron tick; it says nothing
-about the fifteen-minute gap before `send_weekly_summary`, which exists
-only to leave the send command comfortable headroom under
-`send_rate_per_minute`/`daily_send_limit` at this feature's measured
-volume. If the digest fails to run after outreach has sent, the promise is
-delayed rather than broken — the article stays a candidate and goes out
-the following week. `retrospective` campaigns are one-off and are never
-part of this recurring schedule; run them by hand, per the
+Wrap the send in `runitor` (or your monitoring of choice) as the other jobs
+are. A silent failure here means authors were promised a digest appearance
+and never told, which you would otherwise only notice by spotting that the
+queue never drained.
+
+One campaign needs one build line and one send line. `send_weekly_summary`
+takes no `--list` argument — one invocation covers every weekly digest list
+on every site — so a site running several `upcoming` campaigns scoped to
+different `subjects` needs one pair of lines per campaign, all ahead of that
+single shared Tuesday line.
+
+### Why the gap between build and send is safe
+
+Eligibility in `upcoming` mode is a snapshot of what the *next* digest would
+feature, and the schedule above computes it on Thursday for a send on
+Monday. Articles arriving over those five days can push a queued paper past
+the list's `article_limit`, at which point the email's "will be featured in
+the next digest" claim is no longer true.
+
+`send_author_outreach` therefore re-runs the article-level gates
+(`currently_qualifying_article_ids`, sharing the build's own list loop and
+candidate helpers) immediately before dispatch. A row that has lost **any**
+of its queued papers goes back to `pending` with the reason recorded, and is
+not sent — the email names every queued paper as forthcoming, so losing one
+of two makes the message partly false.
+
+Returning to `pending` rather than `failed` or `skipped` is deliberate: the
+slot is not burned, because nothing was sent and the author may well qualify
+again next cycle. Approval is cleared, so the row cannot go out until a
+person looks at it again.
+
+Opt-outs and the circuit breakers are re-checked per row on the same pass,
+so an author who unsubscribes or complains over the weekend is protected
+regardless of when the queue was built.
+
+`retrospective` campaigns are exempt from the candidacy re-check — their
+copy says the paper *was* featured, a claim no later change can falsify —
+and are one-off in any case. Run them by hand, per the
 [first-run runbook](#first-run-runbook) above.
 
 ---


### PR DESCRIPTION
Closes the gap that opens as soon as author outreach is put on a schedule.

## The problem

The recommended schedule builds the queue Thursday and sends Monday, ahead of Tuesday's digest. In `upcoming` mode eligibility is a snapshot of what the *next* digest would feature, so articles arriving over those five days can push a queued paper past the list's `article_limit` — and the email has already claimed it "will be featured in the next digest".

`send_author_outreach` re-checked opt-outs and the circuit breakers per row, but nothing checked whether the papers were still headed for the digest. Tolerable while sends were run by hand and someone could eyeball the queue; not once cron does it.

## The change

`currently_qualifying_article_ids(campaign)` re-runs the article-level gates, **sharing `eligible_authors`'s own list loop and both candidate helpers** rather than reimplementing them. A re-validation that could disagree with the build would be worse than none — it would reject rows the build would still accept.

Before each dispatch in `upcoming` mode, a row that has lost **any** of its queued papers returns to `pending` with the reason recorded, approval cleared, and is not sent.

- **All** papers must still qualify, not merely one: the email names each as forthcoming, so losing one of two makes it partly false.
- **`pending`, not `failed`/`skipped`**: nothing was sent, so the slot must not burn — the author may qualify again next cycle. Approval is cleared so a human has to look before it goes out.
- Computed once per run, not per row — the set can't meaningfully move while a handful of messages go out, and per-row would re-run `select_digest_articles` for every recipient.
- `retrospective` campaigns are exempt: their copy says the paper *was* featured, which no later change can falsify.

## Also: the runbook's cron was broken

The scheduling section documented a `build && send` one-liner. `build` writes `pending`, `send` reads `approved`, and there's no flag to bypass the human in between — so that line would have queued a batch and sent **nothing, silently, every week**. Rewritten as the two-slot Thursday-build / Monday-send schedule with the approval step in between.

## Note on the tests

Ten existing send tests broke on the new guard, because their fixtures build bare `Articles` with no digest list, subject, or ML predictions — real re-validation correctly rejects every one. Those tests exercise the send loop, not the eligibility engine (which has its own integration tests), so `_run` now stubs re-validation by default with a comment explaining why, and four new tests drive the drift path deliberately.

Verified the guard isn't vacuous by removing its `continue` and confirming the new tests fail.

## Testing

**3262 passed, 0 failed, 0 errors.** No migration, `schema.yml` unchanged, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)