### PR TITLE
deps: bump nltk to 3.10.3

### DIFF
--- a/django/requirements.txt
+++ b/django/requirements.txt
@@ -63,7 +63,7 @@ mpmath==1.3.0
 munkres==1.1.4
 namex==0.0.9
 networkx==3.4.2
-nltk==3.9.1
+nltk==3.10.3
 numexpr==2.8.7
 numpy==1.26.3
 oauthlib==3.2.2


### PR DESCRIPTION
Updates `nltk` to address the advisories below.

Evidence:
- `django/requirements.txt` pinned `nltk==3.9.1`
- `osv-scanner` reported 39 advisories for `nltk@3.9.1`, including GHSA-469j-vmhf-r6v7, GHSA-68j8-pq59-fqgm, GHSA-6hm5-jgcp-p838, GHSA-7p94-766c-hgjp, GHSA-848c-c2cx-j7qx, GHSA-fg7f-2386-8897, GHSA-qvv7-cg9c-w4x3, GHSA-xh95-f55m-82fw, GHSA-m42h-3232-vpv3, GHSA-p4gq-832x-fm9v, and their PYSEC counterparts
- updated version: `3.10.3`

Validation:
- `osv-scanner` reports no advisories for `nltk@3.10.3`
- `pytest` per `django/pytest.ini` testpaths (api gregory subscriptions indexers rss sitesettings): 3264 passed, 0 failed with the bump applied

Scope: dependency pin update only, `django/requirements.txt` line 66.
