### PR TITLE
ci: update test workflow actions to current majors

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -34,10 +34,10 @@ jobs:
       POSTGRES_USER: postgres
       DB_HOST: postgres
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Cache pip
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.cache/pip
           key: pip-${{ hashFiles('django/requirements.txt') }}
@@ -98,9 +98,9 @@ jobs:
   mcp-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
           cache: pip
@@ -122,8 +122,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v10
       - name: Ruff — empty-catch gate (E722/S110/S112)
         # Version pinned so CI and local `uvx ruff` never drift. Config: ruff.toml.
         run: uvx ruff@0.16.00 check django/

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -123,7 +123,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: astral-sh/setup-uv@v10
+      - uses: astral-sh/setup-uv@v10.0.1
       - name: Ruff — empty-catch gate (E722/S110/S112)
         # Version pinned so CI and local `uvx ruff` never drift. Config: ruff.toml.
         run: uvx ruff@0.16.00 check django/


### PR DESCRIPTION
Updates the test workflow to current stable majors of the actions it uses.

Changes:
- `actions/checkout` v6 -> v7
- `actions/cache` v4 -> v6
- `actions/setup-python` v5 -> v7
- `astral-sh/setup-uv` v5 -> v10

Validation:
- workflow parses with a YAML parser after the change
- checked release notes for breaking changes; the removed setup-python `pip-install` input is not used here

Scope: `.github/workflows/tests.yaml` only.
