### PR TITLE
Build the author-outreach queue from the Django admin

### DIFF
--- a/django/subscriptions/admin.py
+++ b/django/subscriptions/admin.py
@@ -2,8 +2,11 @@ from django.contrib import admin
 from django.utils.html import format_html
 from django.urls import path, reverse
 from django.shortcuts import render, redirect, get_object_or_404
-from django.http import JsonResponse, HttpResponse
+from django.http import JsonResponse, HttpResponse, HttpResponseForbidden
 import csv
+from io import StringIO
+from django.core.management import call_command
+from django.core.management.base import CommandError
 from django.db.models import Count, Q
 from django.db.models.functions import TruncDate, TruncWeek, TruncMonth
 from django.utils import timezone
@@ -30,6 +33,7 @@ from .forms import ListsAdminForm, AnnouncementAdminForm
 from gregory.models import Team
 from subscriptions.utils.render_email_body import strip_scheme
 from subscriptions.utils.suppression import deactivate_subscribers
+from subscriptions.utils.author_outreach import eligible_authors
 from subscriptions.utils.announcement_send import (
 	render_announcement_email,
 	render_announcement_text,
@@ -1510,6 +1514,108 @@ class AuthorOutreachCampaignAdmin(admin.ModelAdmin):
 		),
 		("Timestamps", {"fields": ["created_at", "updated_at"], "classes": ["collapse"]}),
 	]
+
+	def get_urls(self):
+		urls = super().get_urls()
+		custom_urls = [
+			path(
+				"<int:campaign_id>/build-queue/",
+				self.admin_site.admin_view(self.build_queue_view),
+				name="subscriptions_authoroutreachcampaign_build_queue",
+			),
+		]
+		return custom_urls + urls
+
+	def build_queue_view(self, request, campaign_id):
+		"""
+		The admin's equivalent of `build_author_outreach --campaign <slug>`,
+		so the queue can be built without shell access to the container —
+		see docs/author-outreach.md "Building the queue from the admin".
+
+		GET is the preview: it calls `eligible_authors`, which is read-only
+		by contract (see that module's docstring, which names the admin
+		preview as one of its intended callers), and lists exactly who a
+		real run would queue. That is the `--dry-run` the runbook asks for
+		before every real build, shown on the page that then does the
+		build, so nobody can skip it.
+
+		POST does the write by calling the management command rather than
+		reimplementing it. The `enabled` guard, the basis_note wording, and
+		the row shape therefore have exactly one implementation, shared
+		with the cron schedule — a button that drifted from the command
+		would be a second, untested way to write rows that carry a GDPR
+		lawful-basis note.
+
+		Deliberately not offered here: --featured-since (dry-run-only, and
+		the preview above already re-evaluates the campaign's own stored
+		window) and --limit (a partial queue built by hand is harder to
+		reason about than a full one reviewed row by row, which is what
+		AuthorOutreachAdmin is for).
+		"""
+		campaign = get_object_or_404(AuthorOutreachCampaign, pk=campaign_id)
+		if not self.has_change_permission(request, campaign):
+			return HttpResponseForbidden("Access denied.")
+
+		change_url = reverse(
+			"admin:subscriptions_authoroutreachcampaign_change", args=[campaign.pk]
+		)
+
+		if request.method == "POST":
+			# stderr is folded into the same buffer: CommandError is raised,
+			# not printed, so anything the command writes to stderr is
+			# commentary that belongs with its stdout in one message.
+			output = StringIO()
+			try:
+				call_command(
+					"build_author_outreach",
+					campaign=campaign.utm_campaign_slug,
+					stdout=output,
+					stderr=output,
+				)
+			except CommandError as exc:
+				self.message_user(
+					request, f"Queue not built: {exc}", level=messages.ERROR
+				)
+				return redirect(change_url)
+
+			self.message_user(
+				request,
+				output.getvalue().strip() or "build_author_outreach finished.",
+				level=messages.SUCCESS,
+			)
+			# Land on this campaign's pending rows: reviewing them is the
+			# next step of the runbook, and nothing is sent until a human
+			# approves them there. Permission on the campaign doesn't imply
+			# permission on the queue, though, so someone who can't open
+			# that changelist goes back to the campaign instead of into a
+			# 403 for work that actually succeeded.
+			can_see_queue = request.user.has_perm(
+				"subscriptions.view_authoroutreach"
+			) or request.user.has_perm("subscriptions.change_authoroutreach")
+			if not can_see_queue:
+				return redirect(change_url)
+			queue_url = reverse("admin:subscriptions_authoroutreach_changelist")
+			return redirect(
+				f"{queue_url}?campaign__id__exact={campaign.pk}"
+				f"&status__exact={AuthorOutreach.STATUS_PENDING}"
+			)
+
+		candidates = eligible_authors(campaign)
+		context = {
+			**self.admin_site.each_context(request),
+			"opts": self.model._meta,
+			"original": campaign,
+			"campaign": campaign,
+			"candidates": candidates,
+			"candidate_count": len(candidates),
+			"change_url": change_url,
+			"title": f"Build outreach queue: {campaign.name}",
+		}
+		return render(
+			request,
+			"admin/subscriptions/authoroutreachcampaign/build_queue.html",
+			context,
+		)
 
 
 class AuthorOutreachArticlesInline(admin.TabularInline):

--- a/django/subscriptions/tests/test_author_outreach_admin.py
+++ b/django/subscriptions/tests/test_author_outreach_admin.py
@@ -7,6 +7,8 @@ eligibility/send rules had closed. Also covers the "no bulk delete, no
 manual add" invariants for this queue.
 """
 
+from unittest.mock import patch
+
 from django.contrib.admin.sites import site as admin_site
 from django.contrib.auth.models import Permission, User
 from django.contrib.sites.models import Site
@@ -14,9 +16,10 @@ from django.test import Client, RequestFactory, TestCase
 from django.urls import reverse
 from django.utils import timezone
 
-from gregory.models import Authors
+from gregory.models import Articles, Authors
 from subscriptions.admin import AuthorOutreachAdmin
 from subscriptions.models import AuthorOutreach, AuthorOutreachCampaign, EmailMessage
+from subscriptions.utils.author_outreach import EligibleAuthor
 
 CHANGELIST_URL = reverse("admin:subscriptions_authoroutreach_changelist")
 
@@ -299,3 +302,154 @@ class NoBulkDeleteOrManualAddTest(_AuthorOutreachAdminBase):
 		request.user = self.superuser
 		admin = AuthorOutreachAdmin(AuthorOutreach, admin_site)
 		self.assertFalse(admin.has_add_permission(request))
+
+
+class BuildQueueButtonTest(_AuthorOutreachAdminBase):
+	"""
+	The "Preview & build queue" button on AuthorOutreachCampaign — the
+	admin's equivalent of `build_author_outreach --campaign <slug>`, so the
+	queue can be built without shell access to the container.
+
+	What the command itself writes is covered by
+	test_build_author_outreach_command.py; this file covers the admin layer
+	on top of it: who may reach it, that GET previews without writing, and
+	that POST really does go through the command (guard rails included)
+	rather than a second implementation of the write path.
+	"""
+
+	@classmethod
+	def setUpTestData(cls):
+		super().setUpTestData()
+		cls.campaign_staff = User.objects.create_user(
+			username="outreach_campaign_staff",
+			password="pw",
+			email="campaign@example.com",
+			is_staff=True,
+		)
+		cls.campaign_staff.user_permissions.add(
+			Permission.objects.get(codename="change_authoroutreachcampaign"),
+			Permission.objects.get(codename="view_authoroutreachcampaign"),
+			# Whoever builds a queue reviews it: the view lands on the
+			# queue changelist afterwards.
+			Permission.objects.get(codename="view_authoroutreach"),
+		)
+		# Same campaign rights, no rights on the queue itself — the
+		# post-build redirect has to notice.
+		cls.campaign_only_staff = User.objects.create_user(
+			username="outreach_campaign_only",
+			password="pw",
+			email="campaign-only@example.com",
+			is_staff=True,
+		)
+		cls.campaign_only_staff.user_permissions.add(
+			Permission.objects.get(codename="change_authoroutreachcampaign"),
+			Permission.objects.get(codename="view_authoroutreachcampaign"),
+		)
+
+	def setUp(self):
+		self.client = Client()
+		self.client.force_login(self.campaign_staff)
+		self.url = reverse(
+			"admin:subscriptions_authoroutreachcampaign_build_queue",
+			args=[self.campaign.pk],
+		)
+
+	def _candidate(self, author):
+		article = Articles.objects.create(
+			title="A qualifying paper",
+			link="https://example.com/qualifying-paper",
+			doi="10.9999/qualifying-paper",
+		)
+		return EligibleAuthor(author=author, email=author.emails[0], articles=[article])
+
+	def test_preview_lists_candidates_and_writes_nothing(self):
+		author = self._author("Ada", "Preview", "0000-0000-0000-0031", "ada.preview@example.com")
+		candidate = self._candidate(author)
+		with patch("subscriptions.admin.eligible_authors", return_value=[candidate]):
+			response = self.client.get(self.url)
+		self.assertEqual(response.status_code, 200)
+		self.assertContains(response, "ada.preview@example.com")
+		self.assertContains(response, "A qualifying paper")
+		self.assertEqual(AuthorOutreach.objects.count(), 0)
+
+	def test_preview_is_readable_for_a_campaign_with_no_candidates(self):
+		response = self.client.get(self.url)
+		self.assertEqual(response.status_code, 200)
+		self.assertContains(response, "No author qualifies right now")
+		self.assertEqual(AuthorOutreach.objects.count(), 0)
+
+	def test_staff_without_change_permission_is_refused(self):
+		self.client.force_login(self.staff)
+		self.assertEqual(self.client.get(self.url).status_code, 403)
+		self.assertEqual(self.client.post(self.url).status_code, 403)
+		self.assertEqual(AuthorOutreach.objects.count(), 0)
+
+	def test_post_writes_pending_rows_through_the_command(self):
+		author = self._author("Ada", "Queued", "0000-0000-0000-0032", "ada.queued@example.com")
+		candidate = self._candidate(author)
+		# enabled is set directly: the model's clean() requires the site's
+		# CustomSetting.has_author_pages, which this fixture has no reason
+		# to build — the guard is tested on the model, not here.
+		AuthorOutreachCampaign.objects.filter(pk=self.campaign.pk).update(enabled=True)
+		with patch(
+			"subscriptions.management.commands.build_author_outreach.eligible_authors",
+			return_value=[candidate],
+		):
+			response = self.client.post(self.url, follow=True)
+		self.assertEqual(response.status_code, 200)
+		row = AuthorOutreach.objects.get(author=author)
+		self.assertEqual(row.status, AuthorOutreach.STATUS_PENDING)
+		self.assertEqual(row.campaign, self.campaign)
+		self.assertEqual(row.site, self.campaign.site)
+		self.assertEqual(list(row.articles.all()), candidate.articles)
+		# GDPR lawful-basis note comes from the command, not from a second
+		# implementation living in the admin.
+		self.assertIn("legitimate interest", row.basis_note)
+		self.assertContains(response, "Queued 1 author")
+		self.assertEqual(
+			response.redirect_chain[-1][0],
+			f"{reverse('admin:subscriptions_authoroutreach_changelist')}"
+			f"?campaign__id__exact={self.campaign.pk}"
+			f"&status__exact={AuthorOutreach.STATUS_PENDING}",
+		)
+
+	def test_post_returns_to_the_campaign_when_the_queue_is_off_limits(self):
+		author = self._author("Ada", "NoQueue", "0000-0000-0000-0034", "ada.noqueue@example.com")
+		candidate = self._candidate(author)
+		AuthorOutreachCampaign.objects.filter(pk=self.campaign.pk).update(enabled=True)
+		self.client.force_login(self.campaign_only_staff)
+		with patch(
+			"subscriptions.management.commands.build_author_outreach.eligible_authors",
+			return_value=[candidate],
+		):
+			response = self.client.post(self.url, follow=True)
+		self.assertEqual(response.status_code, 200)
+		self.assertEqual(AuthorOutreach.objects.filter(author=author).count(), 1)
+		self.assertEqual(
+			response.redirect_chain[-1][0],
+			reverse(
+				"admin:subscriptions_authoroutreachcampaign_change",
+				args=[self.campaign.pk],
+			),
+		)
+
+	def test_post_on_a_disabled_campaign_writes_nothing(self):
+		author = self._author("Ada", "Disabled", "0000-0000-0000-0033", "ada.disabled@example.com")
+		candidate = self._candidate(author)
+		with patch(
+			"subscriptions.management.commands.build_author_outreach.eligible_authors",
+			return_value=[candidate],
+		):
+			response = self.client.post(self.url, follow=True)
+		self.assertEqual(AuthorOutreach.objects.count(), 0)
+		self.assertContains(response, "not enabled")
+
+	def test_change_form_shows_the_button(self):
+		response = self.client.get(
+			reverse(
+				"admin:subscriptions_authoroutreachcampaign_change",
+				args=[self.campaign.pk],
+			)
+		)
+		self.assertContains(response, self.url)
+		self.assertContains(response, "Preview &amp; build queue")

--- a/django/templates/admin/subscriptions/authoroutreachcampaign/build_queue.html
+++ b/django/templates/admin/subscriptions/authoroutreachcampaign/build_queue.html
@@ -1,0 +1,96 @@
+{% extends "admin/base_site.html" %}
+{% load i18n %}
+
+{% block title %}Build outreach queue: {{ campaign.name }}{% endblock %}
+
+{% block content %}
+<div style="max-width: 900px; margin: 20px auto; padding: 20px;">
+	<h2>Build outreach queue</h2>
+
+	<div style="margin: 20px 0; padding: 15px; background: #f8fafc; border: 1px solid #e2e8f0; border-radius: 6px;">
+		<strong>{{ campaign.name }}</strong> — {{ campaign.get_mode_display }}<br>
+		<small style="color: #6b7280;">
+			Site: {{ campaign.site.domain }} ·
+			Campaign slug: <code>{{ campaign.utm_campaign_slug }}</code> ·
+			Up to {{ campaign.max_articles_per_email }} paper{{ campaign.max_articles_per_email|pluralize }} per email
+			{% if campaign.mode == "retrospective" %} · Featured within {{ campaign.featured_within_days }} days{% endif %}
+		</small>
+	</div>
+
+	<p style="color: #475569;">
+		This is the preview — nothing has been written. It runs the same eligibility rules as
+		<code>build_author_outreach --campaign {{ campaign.utm_campaign_slug }}</code>, so what is listed below is
+		exactly what confirming would queue. Queued rows are <strong>pending</strong>: they are not emailed until
+		someone approves them in the outreach queue and <code>send_author_outreach</code> runs.
+	</p>
+
+	{% if not campaign.enabled %}
+	<div style="margin: 20px 0; padding: 15px; background: #fef2f2; border: 1px solid #fca5a5; border-radius: 6px;">
+		<strong>This campaign is not enabled.</strong> A real queue is only ever built for an enabled campaign — the
+		preview below is safe to read while the campaign is still being configured, but there is nothing to confirm
+		until you enable it on the campaign page.
+	</div>
+	{% endif %}
+
+	{% if campaign.halted %}
+	<div style="margin: 20px 0; padding: 15px; background: #fef3c7; border: 1px solid #f59e0b; border-radius: 6px;">
+		<strong>⚠️ This campaign is halted.</strong> Building a queue is still allowed — halting stops sending, not
+		queueing — but nothing queued now goes out until the halt is cleared.
+		{% if campaign.halted_reason %}<br><small style="color: #6b7280;">{{ campaign.halted_reason }}</small>{% endif %}
+	</div>
+	{% endif %}
+
+	<h3>{{ candidate_count }} author{{ candidate_count|pluralize }} would be queued</h3>
+
+	{% if candidates %}
+	<table style="width: 100%; border-collapse: collapse; margin-bottom: 20px;">
+		<thead>
+			<tr style="background: #f1f5f9;">
+				<th style="padding: 10px; text-align: left; border-bottom: 2px solid #e2e8f0;">Author</th>
+				<th style="padding: 10px; text-align: left; border-bottom: 2px solid #e2e8f0;">Email</th>
+				<th style="padding: 10px; text-align: left; border-bottom: 2px solid #e2e8f0;">Qualifying papers</th>
+			</tr>
+		</thead>
+		<tbody>
+			{% for candidate in candidates %}
+			<tr>
+				<td style="padding: 10px; border-bottom: 1px solid #e2e8f0; vertical-align: top;">
+					{{ candidate.author }}
+					{% if candidate.author.ORCID %}<br><small style="color: #6b7280;">{{ candidate.author.ORCID }}</small>{% endif %}
+				</td>
+				<td style="padding: 10px; border-bottom: 1px solid #e2e8f0; vertical-align: top;">{{ candidate.email }}</td>
+				<td style="padding: 10px; border-bottom: 1px solid #e2e8f0;">
+					<ul style="margin: 0; padding-left: 18px;">
+						{% for article in candidate.articles %}
+						<li>{{ article.title }}</li>
+						{% endfor %}
+					</ul>
+				</td>
+			</tr>
+			{% endfor %}
+		</tbody>
+	</table>
+	{% else %}
+	<div style="margin: 20px 0; padding: 15px; background: #eff6ff; border: 1px solid #93c5fd; border-radius: 6px;">
+		<strong>No author qualifies right now.</strong> Nothing would be written, so there is nothing to confirm.
+		An author already contacted on this site never qualifies again, by design.
+	</div>
+	{% endif %}
+
+	<form method="post">
+		{% csrf_token %}
+		<div style="margin-top: 20px;">
+			<a href="{{ change_url }}"
+			   style="display: inline-block; padding: 8px 20px; background: #6b7280; color: white; text-decoration: none; border-radius: 5px; margin-right: 10px;">
+				Cancel
+			</a>
+			{% if candidates and campaign.enabled %}
+			<button type="submit"
+					style="padding: 8px 20px; background: #10b981; color: white; border: none; border-radius: 5px; cursor: pointer; font-size: 14px;">
+				Queue {{ candidate_count }} author{{ candidate_count|pluralize }} as pending
+			</button>
+			{% endif %}
+		</div>
+	</form>
+</div>
+{% endblock %}

--- a/django/templates/admin/subscriptions/authoroutreachcampaign/change_form.html
+++ b/django/templates/admin/subscriptions/authoroutreachcampaign/change_form.html
@@ -1,0 +1,22 @@
+{% extends "admin/change_form.html" %}
+
+{% block after_related_objects %}
+{{ block.super }}
+{% if original.pk and has_change_permission %}
+<div style="margin: 20px 0; padding: 20px; background: #f0f9ff; border: 1px solid #bae6fd; border-radius: 8px;">
+	<h3 style="margin: 0 0 10px 0; color: #0c4a6e;">Outreach Queue</h3>
+	<p style="margin: 0 0 15px 0; color: #475569;">
+		Same thing as <code>build_author_outreach --campaign {{ original.utm_campaign_slug }}</code> on the server.
+		The next page previews every author who currently qualifies and writes nothing until you confirm.
+	</p>
+	<a href="{% url 'admin:subscriptions_authoroutreachcampaign_build_queue' original.pk %}"
+	   style="display: inline-block; padding: 8px 20px; background: #3b82f6; color: white; text-decoration: none; border-radius: 5px; margin-right: 10px;">
+		Preview &amp; build queue
+	</a>
+	<a href="{% url 'admin:subscriptions_authoroutreach_changelist' %}?campaign__id__exact={{ original.pk }}"
+	   style="display: inline-block; padding: 8px 20px; background: #6b7280; color: white; text-decoration: none; border-radius: 5px;">
+		View this campaign's queue
+	</a>
+</div>
+{% endif %}
+{% endblock %}

--- a/docs/author-outreach.md
+++ b/docs/author-outreach.md
@@ -268,7 +268,9 @@ Two management commands, two phases, exactly one human step in between.
 1. `build_author_outreach --campaign <slug>` evaluates every eligibility
    rule above against the live database and writes `AuthorOutreach` rows
    with `status="pending"`. It never sends anything and never touches an
-   existing row.
+   existing row. The **Preview & build queue** button on the campaign in
+   Django admin runs this same command — see
+   [Building the queue from the admin](#building-the-queue-from-the-admin).
 2. A human reviews the queue in Django admin
    (Subscriptions → Author Outreach) and runs the **Approve selected**
    action on the rows that should go out, or **Skip selected** on rows
@@ -285,6 +287,39 @@ at queue-build time) and re-evaluates the campaign's circuit breakers
 against its live `EmailMessage` aggregates. Either can stop a row that
 looked fine when the queue was built, or even one row earlier in the same
 run.
+
+### Building the queue from the admin
+
+The queue can be built without shell access to the container:
+**Subscriptions → Author Outreach Campaigns → ‹campaign› → Preview & build
+queue**.
+
+The button opens a preview first. It lists every author who qualifies right
+now, with the papers their email would name — the same `--dry-run` the
+runbook asks for before every real build, on the page that then does the
+build, so it cannot be skipped. Nothing is written until **Queue N authors
+as pending** is confirmed, and confirming calls `build_author_outreach`
+itself rather than a second implementation: the `enabled` guard, the GDPR
+lawful-basis `basis_note`, and the row shape are identical to what cron
+writes.
+
+Consequences of that shared implementation, all deliberate:
+
+- A campaign that is not `enabled` shows the preview but offers no confirm
+  button — a real queue is only ever built for an enabled campaign, and a
+  preview stays useful while one is still being configured.
+- A halted campaign can still be queued. Halting stops sending, not
+  queueing; the preview says so.
+- Building needs change permission on the campaign. After a successful
+  build you land on this campaign's `pending` rows, or back on the campaign
+  if you have no permission on the queue itself.
+- `--featured-since` and `--limit` are CLI-only. The preview already
+  re-evaluates the campaign's own stored window, and a partial queue built
+  by hand is harder to reason about than a full one reviewed row by row.
+
+The button does not replace the cron schedule below — it is the manual
+path for a first run, a back-catalogue campaign, or a rebuild after
+changing a campaign's subjects.
 
 ### Admin actions
 
@@ -396,12 +431,14 @@ pipeline end to end before `upcoming` mode starts running on a schedule.
    past tense, for anything already featured. A `retrospective` campaign
    left with a blank `body_template` refuses to render rather than
    silently falling back to that copy.
-2. Run `build_author_outreach --campaign <slug> --dry-run` first and read
-   the printed list of candidates. This never writes a row, so it is safe
-   to run repeatedly while tuning the campaign's subjects or window.
-3. Enable the campaign, then run `build_author_outreach --campaign <slug>`
-   for real. Review the queue in the admin — every candidate the dry run
-   showed should now be a `pending` `AuthorOutreach` row.
+2. Open **Preview & build queue** on the campaign (or run
+   `build_author_outreach --campaign <slug> --dry-run`) and read the list
+   of candidates. This never writes a row, so it is safe to look
+   repeatedly while tuning the campaign's subjects or window.
+3. Enable the campaign, then build the queue for real — confirm on that
+   same preview page, or run `build_author_outreach --campaign <slug>`.
+   Review the queue in the admin — every candidate the preview showed
+   should now be a `pending` `AuthorOutreach` row.
 4. Approve exactly **one** row.
 5. Run `send_author_outreach --campaign <slug> --limit 1`.
 6. Watch for the Delivery webhook on that message before approving or
@@ -544,6 +581,11 @@ build_author_outreach --campaign <slug> [--featured-since DAYS] [--dry-run] [--l
 - `--dry-run` — evaluates and prints eligibility; writes nothing. Allowed
   even when `campaign.enabled` is `False`.
 - `--limit N` — stop after this many authors.
+
+The **Preview & build queue** button on an `AuthorOutreachCampaign` in
+Django admin runs this command with `--campaign` alone (see
+[Building the queue from the admin](#building-the-queue-from-the-admin));
+`--featured-since` and `--limit` stay CLI-only.
 
 ```text
 send_author_outreach --campaign <slug> [--limit N] [--dry-run] [--test-to ADDRESS]


### PR DESCRIPTION
Adds a **Preview & build queue** button to `AuthorOutreachCampaign`, so the outreach queue can be built without shell access to the container. Until now the only way was `docker exec gregory python manage.py build_author_outreach --campaign <slug>`.

## How it works

- **GET** is the preview: it calls `eligible_authors` — read-only by contract — and lists every author who currently qualifies with the papers their email would name. That is the `--dry-run` the runbook already asks for before every real build, shown on the page that then does the build, so it cannot be skipped.
- **POST** calls the management command rather than reimplementing it. The `enabled` guard, the GDPR lawful-basis `basis_note`, and the row shape therefore have exactly one implementation, shared with cron — a button that drifted from the command would be a second, untested way to write rows that carry a lawful-basis note.

No `docker exec`: the admin runs inside the same container, so `call_command` is the whole mechanism.

## Behaviour

- A campaign that is not `enabled` shows the preview but offers no confirm button — matching the command, which refuses to build a real queue while disabled.
- A halted campaign can still be queued, with a warning: halting stops sending, not queueing.
- `--featured-since` and `--limit` stay CLI-only. The preview already re-evaluates the campaign's stored window, and a partial queue built by hand is harder to review row by row.
- Building needs change permission on the campaign. After a build you land on this campaign's `pending` rows — or back on the campaign, if you have no permission on the queue itself (an earlier draft redirected unconditionally and 403'd that user for work that had actually succeeded).
- Building twice is harmless: already-queued authors are excluded by shared rule 7.

## Tests

7 new tests in `test_author_outreach_admin.py` covering permissions, that GET writes nothing, that POST goes through the command (lawful-basis note included), the disabled-campaign refusal, and both redirect targets. `test_author_outreach_admin` + `test_build_author_outreach_command`: 32 pass.

Full `subscriptions` suite: 635 run, 4 errors — all pre-existing `CKEditorUploadViewTests`, which write to `/code/media`, the container path, absent when running on macOS.

Verified through the test client, not visually in a browser.

## Docs

`docs/author-outreach.md` gets a "Building the queue from the admin" section; the approval workflow, first-run runbook, and command reference now name the button. No API surface changed, so `schema.yml` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)