### PR TITLE
docs: correct the stale subject-coverage figure on /stats/

### DIFF
--- a/docs/03-api-and-rss-feeds.md
+++ b/docs/03-api-and-rss-feeds.md
@@ -399,7 +399,7 @@ When both `organization` and `team` are given the effective scope is their **int
 - Per-subject counts are `articles`, `trials`, `authors`, `sources` — **no per-subject `subscribers`**. With `Lists` as the only path from a subscriber to a subject, that number would describe list-tagging more than the subject itself.
 - `sources` counts distinct **domains** (matching the top-level `sources.total` semantics), not feed rows — two RSS feeds on the same domain count once. A `Sources` row with `subject` unset (`null`) is excluded from every `by_subject` row and, when `?subject=` is applied, from the filtered totals too.
 - Neither `authors` nor `sources` in a `by_subject` row sums to the top-level total, and that's correct: both are *distinct within that subject*. An author publishing under two subjects appears in both rows and once at the top; a domain feeding two subjects likewise.
-- Roughly 42% of trials in this dataset have no subject assigned — a subject-filtered `trials` count is expected to be substantially lower than the team-scoped one; that's coverage, not a bug.
+- A trial with no subject assigned is excluded from every `by_subject` row, so a subject-filtered `trials` count can be lower than the team-scoped one. Coverage is now near-complete — measured 2026-09-09, 63 of 17,404 trials (0.4%) and 372 of 53,054 articles (0.7%) carry no subject — so the gap is small, but it is a gap, not a bug.
 
 #### Error responses
 

--- a/docs/spec-stats-subject-filter.md
+++ b/docs/spec-stats-subject-filter.md
@@ -55,6 +55,20 @@ The trials figure matters: any subject-filtered trial count drops ~42% relative
 to the team-scoped one, and that is correct, not a bug. Worth a line in the docs
 so nobody files it as one.
 
+> **Superseded 2026-09-09.** The table above stands as a record of 2026-08-04 and is
+> deliberately not rewritten. The 42.5% no longer holds: measured against a
+> production-synced dev database, **63 of 17,404 trials (0.4%)** and 372 of 53,054
+> articles (0.7%) carry no subject.
+>
+> The change was not curation. Orphan trials — those with no source — were pruned on
+> 2026-09-08, and the arithmetic shows they were almost exactly the subject-less
+> population: 12,765 trials removed in total, of which 12,766 were the subject-less
+> ones. Practically every trial deleted was one of these rows.
+>
+> So the caveat this section asked for is still true in principle — a subject-filtered
+> trial count *can* be lower than a team-scoped one — but the magnitude is now
+> negligible. `docs/03-api-and-rss-feeds.md` carries the current wording.
+
 ## 2 — Decisions taken
 
 Confirmed with Bruno before drafting:
@@ -320,7 +334,7 @@ together. `EXPLAIN ANALYZE` it on a prod-sized copy before merging (§6).
 |:-----|:-------|
 | `django/api/views.py` | `StatsView.get` — §4.1 to §4.5; extend the class docstring's Filters section with `?subject=` and the 404-vs-zero rule |
 | `django/api/tests/test_visibility_stats.py` | new test classes (§6); raise the query ceiling and fix its breakdown comment |
-| `docs/03-api-and-rss-feeds.md` | endpoint table row (line 194) → add `subject`; Stats section (lines 322-360) → new example URLs, `by_subject` in the sample payload, `subject` row in the filter-parameter table, drop the "unchanged across all filter combinations" claim, note the 42%-of-trials-have-no-subject caveat |
+| `docs/03-api-and-rss-feeds.md` | endpoint table row (line 194) → add `subject`; Stats section (lines 322-360) → new example URLs, `by_subject` in the sample payload, `subject` row in the filter-parameter table, drop the "unchanged across all filter combinations" claim, note the trials-without-subject caveat (originally phrased as "42%"; reworded to measured figures on 2026-09-09, see §1.2) |
 
 No migration. No model change. No new dependency.
 


### PR DESCRIPTION
The `by_subject` note in `docs/03-api-and-rss-feeds.md` claimed **"roughly 42% of trials in this dataset have no subject assigned."**

Measured against a dev database freshly synced from production on 2026-09-09:

| | Total | No subject |
|:---|---:|---:|
| Articles | 53,054 | 372 (**0.7%**) |
| Trials | 17,404 | 63 (**0.4%**) |

Confirmed by both the ORM and raw SQL. The 42% dates from `da433ffa`, when `/stats/` was built; coverage has improved by roughly two orders of magnitude since and the line was never revisited.

## Why it is worth a PR

Anyone sizing a subject-scoped feature from that number reaches a badly wrong conclusion. A draft spec for site-scoped API visibility did exactly that — it treated a curation backlog as a gating prerequisite for the whole project, when the real exposure is about 1% of the corpus.

The rewording keeps the point the line was making (subject-filtered counts can legitimately be lower than team-scoped ones) and replaces the figure with a measured one, dated so the next reader knows how fresh it is.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)