### PR TITLE
Phase 2: API scoping primitives for site-scoped visibility

### DIFF
--- a/django/admin/urls.py
+++ b/django/admin/urls.py
@@ -44,6 +44,7 @@ from api.views import (
 	AuthorSearchView,
 	CategoriesByTeamAndSubject,
 	StatsView,
+	PublicSitesView,
 )
 from rss.views import ArticlesByAuthorFeed, TrialsBySubjectFeed
 from rss.sitemaps import sitemap_index, sitemap_section
@@ -199,6 +200,10 @@ urlpatterns = (
 		path("authors/search/", AuthorSearchView.as_view(), name="author-search"),
 		# Stats endpoint
 		path("stats/", StatsView.as_view(), name="stats"),
+		# Discovery entry point for site-scoped visibility: unscoped by design,
+		# because a caller needs a site_id and nothing else would tell it which
+		# exist. See SITE-API-VISIBILITY-SPEC.md (local planning doc).
+		path("sites/", PublicSitesView.as_view(), name="public_sites"),
 		# Gregory app routes
 		path("", include("gregory.urls")),
 		# Include router routes

--- a/django/api/filters.py
+++ b/django/api/filters.py
@@ -274,10 +274,13 @@ class ArticleFilter(SubjectFilterMixin, filters.FilterSet):
 		label="Relevant",
 		help_text=(
 			"Filter for relevant articles (true/false). When combined with "
-			"subject_id, relevance is scoped to that specific subject — only "
-			"articles relevant *for that subject* (via ML predictions or manual "
-			"marking) are returned. Without subject_id, relevance is checked "
-			"across all subjects."
+			"subject_id, subjects, and/or subjects_any, relevance is scoped to "
+			"that subject or subjects — only articles relevant *for one of "
+			"those subjects* (via ML predictions or manual marking) are "
+			"returned. Without any of those, relevance is checked across every "
+			"subject in the database, so a caller that also scopes the query by "
+			"subject should always pass the same subject(s) here to avoid "
+			"picking up relevance decided by an unrelated subject."
 		),
 	)
 	ml_threshold = filters.NumberFilter(
@@ -285,8 +288,8 @@ class ArticleFilter(SubjectFilterMixin, filters.FilterSet):
 		label="ML Threshold (0.0-1.0)",
 		help_text=(
 			"Minimum ML prediction confidence (0.0-1.0, e.g. 0.75). Also scoped "
-			"to subject_id when provided. Defaults to 0.8 when relevant=true and "
-			"this is omitted."
+			"to subject_id/subjects/subjects_any when provided. Defaults to 0.8 "
+			"when relevant=true and this is omitted."
 		),
 		widget=forms.NumberInput(attrs={"step": "0.01", "min": "0.0", "max": "1.0"}),
 	)
@@ -439,12 +442,51 @@ class ArticleFilter(SubjectFilterMixin, filters.FilterSet):
 		except (ValueError, TypeError):
 			return default  # Use default if conversion fails
 
-	def _get_ml_relevant_articles_query(self, threshold=0.8, filtered_subject_id=None):
+	def _request_subject_ids(self):
+		"""
+		Collect the subject IDs the current request already scopes the query
+		to, from ``subject_id`` (singular), ``subjects`` (AND list) and
+		``subjects_any`` (OR list) -- whichever of the three the caller used.
+
+		``filter_relevant``/``filter_ml_threshold`` need this because
+		``ml_relevant_articles_q`` defaults to checking consensus across
+		*every* auto_predict subject in the database when given no subject
+		list. Previously these two filters only ever read ``subject_id``
+		singular, so a request combining ``relevant=true`` with
+		``subjects``/``subjects_any`` (or, under site-scoped visibility, any
+		future subject-list scoping) had its relevance check silently widen
+		back to the whole database -- an article could be returned as
+		"relevant" on the strength of ML consensus reached for a completely
+		different, unrelated subject. Returns ``None`` when the request names
+		no subject at all, which preserves the original "check every
+		auto_predict subject" behaviour for an unscoped request.
+		"""
+		ids = set()
+		subject_id = self.request.GET.get("subject_id")
+		if subject_id:
+			try:
+				ids.add(int(subject_id))
+			except (TypeError, ValueError):
+				pass
+		for param in ("subjects", "subjects_any"):
+			raw = self.request.GET.get(param)
+			if not raw:
+				continue
+			for piece in raw.split(","):
+				piece = piece.strip()
+				if not piece:
+					continue
+				try:
+					ids.add(int(piece))
+				except (TypeError, ValueError):
+					continue
+		return sorted(ids) if ids else None
+
+	def _get_ml_relevant_articles_query(self, threshold=0.8, subject_ids=None):
 		"""Build a database-level query to find ML-relevant articles based on consensus logic.
 
-		If filtered_subject_id is provided, only check relevance for that specific subject.
+		If subject_ids is provided, only check relevance for those subjects.
 		"""
-		subject_ids = None if filtered_subject_id is None else [filtered_subject_id]
 		return ml_relevant_articles_q(threshold, subject_ids)
 
 	def filter_relevant(self, queryset, name, value):
@@ -452,26 +494,21 @@ class ArticleFilter(SubjectFilterMixin, filters.FilterSet):
 		Filter for relevant articles (ML predictions with consensus or manual selection)
 		Uses ml_threshold parameter if provided, otherwise defaults to 0.8
 
-		When subject_id is provided, only checks relevance for that specific subject.
+		When subject_id, subjects, and/or subjects_any is provided, only checks
+		relevance for those specific subjects (see _request_subject_ids).
 		"""
-		# Get subject_id from request to scope relevance checks
-		filtered_subject_id = self.request.GET.get("subject_id")
-		if filtered_subject_id:
-			try:
-				filtered_subject_id = int(filtered_subject_id)
-			except (ValueError, TypeError):
-				filtered_subject_id = None
+		subject_ids = self._request_subject_ids()
 
 		if value:
 			# Get ML threshold from request parameters, default to 0.8
 			threshold = self._parse_ml_threshold(0.8)
 
 			# Get articles that are either:
-			# 1. Manually marked as relevant (scoped to subject if provided)
-			if filtered_subject_id:
+			# 1. Manually marked as relevant (scoped to subject(s) if provided)
+			if subject_ids:
 				manually_relevant = models.Q(
 					article_subject_relevances__is_relevant=True,
-					article_subject_relevances__subject_id=filtered_subject_id,
+					article_subject_relevances__subject_id__in=subject_ids,
 				)
 			else:
 				manually_relevant = models.Q(
@@ -480,24 +517,24 @@ class ArticleFilter(SubjectFilterMixin, filters.FilterSet):
 
 			# 2. ML-relevant based on subject-specific consensus settings and threshold
 			ml_relevant_q = self._get_ml_relevant_articles_query(
-				threshold, filtered_subject_id
+				threshold, subject_ids
 			)
 
 			return queryset.filter(manually_relevant | ml_relevant_q).distinct()
 		else:
 			# Exclude articles that are either manually relevant or ML-relevant
 			threshold = self._parse_ml_threshold(0.8)
-			if filtered_subject_id:
+			if subject_ids:
 				manually_relevant = models.Q(
 					article_subject_relevances__is_relevant=True,
-					article_subject_relevances__subject_id=filtered_subject_id,
+					article_subject_relevances__subject_id__in=subject_ids,
 				)
 			else:
 				manually_relevant = models.Q(
 					article_subject_relevances__is_relevant=True
 				)
 			ml_relevant_q = self._get_ml_relevant_articles_query(
-				threshold, filtered_subject_id
+				threshold, subject_ids
 			)
 
 			return queryset.exclude(manually_relevant | ml_relevant_q).distinct()
@@ -513,17 +550,12 @@ class ArticleFilter(SubjectFilterMixin, filters.FilterSet):
 				# Invalid threshold, return empty queryset
 				return queryset.none()
 
-			# Scope to subject_id if provided
-			filtered_subject_id = self.request.GET.get("subject_id")
-			if filtered_subject_id:
-				try:
-					filtered_subject_id = int(filtered_subject_id)
-				except (ValueError, TypeError):
-					filtered_subject_id = None
+			# Scope to subject_id/subjects/subjects_any if provided
+			subject_ids = self._request_subject_ids()
 
 			# Use efficient database-level query instead of Python loop
 			ml_relevant_q = self._get_ml_relevant_articles_query(
-				threshold, filtered_subject_id
+				threshold, subject_ids
 			)
 			return queryset.filter(ml_relevant_q)
 
@@ -1264,6 +1296,16 @@ class AuthorFilter(filters.FilterSet):
 		help_text="Exact match against the author's country code.",
 	)
 
+	subjects_any = filters.BaseInFilter(
+		method="filter_subjects_any",
+		label="Subjects (any)",
+		help_text=(
+			"Comma-separated subject IDs, OR semantics: authors with at least "
+			"one article in ANY of the listed subjects, e.g. ?subjects_any=1,10. "
+			"An author is reached only through their articles, so this is an "
+			"Exists() over articles rather than a direct field."
+		),
+	)
 	class Meta:
 		model = Authors
 		fields = [
@@ -1273,6 +1315,7 @@ class AuthorFilter(filters.FilterSet):
 			"author_id",
 			"orcid",
 			"country",
+			"subjects_any",
 		]
 
 	def filter_full_name(self, queryset, name, value):
@@ -1281,6 +1324,28 @@ class AuthorFilter(filters.FilterSet):
 		upper_value = value.upper()
 		return queryset.filter(ufull_name__contains=upper_value)
 
+	def filter_subjects_any(self, queryset, name, value: list[str]):
+		"""Authors with at least one article in ANY of the given subjects.
+
+		Exists() over Articles rather than a join on articles__subjects:
+		an author with several qualifying articles would otherwise be
+		returned once per article. Same reasoning as the other
+		subjects_any filters.
+		"""
+		if not value:
+			return queryset
+		ids = set()
+		for raw in value:
+			try:
+				ids.add(int(raw))
+			except (TypeError, ValueError):
+				continue
+		if not ids:
+			return queryset.none()
+		subquery = Articles.objects.filter(
+			authors=models.OuterRef("pk"), subjects__id__in=ids
+		)
+		return queryset.filter(models.Exists(subquery))
 
 class SourceFilter(filters.FilterSet):
 	"""
@@ -1338,10 +1403,62 @@ class SponsorFilter(filters.FilterSet):
 		label="Sponsor type",
 		help_text="Exact match against the canonical sponsor type (see SponsorType values).",
 	)
+	subject_id = filters.NumberFilter(
+		method="filter_subject_id",
+		label="Subject ID",
+		help_text=(
+			"Restrict to sponsors with at least one trial in this subject "
+			"(see /subjects/). A Sponsor carries no subject of its own — it "
+			"is reached only through its trials, via Exists() on "
+			"Trials.primary_sponsor_normalized (see SITE-API-VISIBILITY "
+			"project, site-scoped API visibility)."
+		),
+	)
+	subjects_any = filters.BaseInFilter(
+		method="filter_subjects_any",
+		label="Any subject IDs (comma-separated, OR match)",
+		help_text=(
+			"Comma-separated list of subject IDs, OR semantics — restrict to "
+			"sponsors with at least one trial in any of the listed subjects, "
+			"e.g. ?subjects_any=1,2. Same Exists()-on-trials approach as "
+			"subject_id."
+		),
+	)
 
 	class Meta:
 		model = Sponsor
 		fields = ["sponsor_type"]
+
+	def filter_subject_id(self, queryset, name, value):
+		"""
+		Sponsors with >=1 trial tagged with this subject.
+
+		Uses Exists() rather than a plain `trials__subjects__id` join filter:
+		a sponsor with several qualifying trials would otherwise be
+		duplicated by the join (same reasoning as ArticleFilter.filter_site /
+		OrgVisibilityMixin elsewhere in this API).
+		"""
+		subquery = Trials.objects.filter(
+			primary_sponsor_normalized=OuterRef("pk"), subjects__id=value
+		)
+		return queryset.filter(Exists(subquery))
+
+	def filter_subjects_any(self, queryset, name, value: list[str]):
+		"""OR-semantics equivalent of filter_subject_id for multiple subjects."""
+		if not value:
+			return queryset
+		ids = set()
+		for raw in value:
+			try:
+				ids.add(int(raw))
+			except (TypeError, ValueError):
+				continue
+		if not ids:
+			return queryset.none()
+		subquery = Trials.objects.filter(
+			primary_sponsor_normalized=OuterRef("pk"), subjects__id__in=ids
+		)
+		return queryset.filter(Exists(subquery))
 
 
 class SubjectFilter(filters.FilterSet):
@@ -1384,6 +1501,16 @@ class CategoryFilter(filters.FilterSet):
 		label="Subject ID",
 		help_text="Filter by subject ID (see /subjects/).",
 	)
+	subjects_any = filters.BaseInFilter(
+		method="filter_subjects_any",
+		label="Subjects (any)",
+		help_text=(
+			"Comma-separated subject IDs, OR semantics: categories used within "
+			"ANY of the listed subjects, e.g. ?subjects_any=1,10. Uses Exists() "
+			"rather than a join so a category tagged with several of the listed "
+			"subjects appears once without DISTINCT-ing the outer query."
+		),
+	)
 	category_terms = filters.CharFilter(
 		method="filter_category_terms",
 		label="Category Terms",
@@ -1392,7 +1519,36 @@ class CategoryFilter(filters.FilterSet):
 
 	class Meta:
 		model = TeamCategory
-		fields = ["category_id", "team_id", "subject_id", "category_terms"]
+		fields = [
+			"category_id",
+			"team_id",
+			"subject_id",
+			"subjects_any",
+			"category_terms",
+		]
+
+	def filter_subjects_any(self, queryset, name, value: list[str]):
+		"""Categories used within ANY of the given subjects.
+
+		Exists() rather than a join filter: TeamCategory.subjects is an
+		M2M, so a category tagged with two of the listed subjects would
+		otherwise be returned twice. Same reasoning as ArticleFilter and
+		OrgVisibilityMixin.
+		"""
+		if not value:
+			return queryset
+		ids = set()
+		for raw in value:
+			try:
+				ids.add(int(raw))
+			except (TypeError, ValueError):
+				continue
+		if not ids:
+			return queryset.none()
+		subquery = TeamCategory.objects.filter(
+			pk=models.OuterRef("pk"), subjects__id__in=ids
+		)
+		return queryset.filter(models.Exists(subquery))
 
 	def filter_category_terms(self, queryset, name, value):
 		"""Filter by category terms using array overlap"""

--- a/django/api/serializers/__init__.py
+++ b/django/api/serializers/__init__.py
@@ -553,6 +553,7 @@ class SponsorSerializer(serializers.ModelSerializer):
 
 
 class TrialSerializer(OrgScopedSerializerMixin, serializers.HyperlinkedModelSerializer):
+	subjects = SubjectsSerializer(many=True, read_only=True)
 	sources = serializers.SlugRelatedField(many=True, read_only=True, slug_field="name")
 	team_categories = TeamCategorySerializer(many=True, read_only=True)
 	articles = serializers.SerializerMethodField()
@@ -649,6 +650,7 @@ class TrialSerializer(OrgScopedSerializerMixin, serializers.HyperlinkedModelSeri
 			"countries_decision_date",
 			"takeaways",
 			"articles",
+			"subjects",
 		]
 		read_only_fields = ("discovery_date", "articles")
 
@@ -912,3 +914,20 @@ class OrganizationSerializer(serializers.ModelSerializer):
 	class Meta:
 		model = Organization
 		fields = ["id", "name", "slug", "is_active"]
+
+
+class PublicSiteSerializer(serializers.Serializer):
+	"""A publicly readable site, for the GET /sites/ discovery endpoint.
+
+	Deliberately minimal: just enough for a caller to learn which site IDs
+	exist so it can pass ?site_id=. Everything here is already public.
+
+	The MCP multi-tenancy spec proposes a richer per-site config endpoint
+	carrying subjects, prompts and documents. That project is unstarted; when
+	it lands, the two should converge on one endpoint rather than duplicate --
+	this payload is a strict subset of that one.
+	"""
+
+	site_id = serializers.IntegerField(source="site.id", read_only=True)
+	domain = serializers.CharField(source="site.domain", read_only=True)
+	name = serializers.CharField(source="site.name", read_only=True)

--- a/django/api/tests/test_author_api.py
+++ b/django/api/tests/test_author_api.py
@@ -165,15 +165,65 @@ class AuthorAPITest(TestCase):
 		self.assertEqual(response.data["count"], 1)
 		self.assertEqual(response.data["results"][0]["author_id"], author.author_id)
 
-	def test_authors_filtering_validation_subject_without_team(self):
-		"""Test that filtering by subject_id without team_id returns empty results"""
+	def test_authors_filtering_by_subject_without_team_works(self):
+		"""
+		subject_id alone (no team_id) must work -- site-scoped API visibility,
+		Phase 2 item 2. A caller scoped to a site knows subjects, not team_ids
+		(Subject.team is a plain FK, so subject_id already resolves to exactly
+		one team with no ambiguity), so requiring team_id here would make
+		subject filtering unusable for that caller.
+		"""
 		response = self.client.get(
 			f"/authors/?subject_id={self.subject.id}&sort_by=article_count"
 		)
 
 		self.assertEqual(response.status_code, status.HTTP_200_OK)
+		# Both author1 (2 articles) and author2 (1 article) are tagged with
+		# this subject.
+		self.assertEqual(response.data["count"], 2)
+		results = response.data["results"]
+		self.assertEqual(results[0]["author_id"], self.author1.author_id)
+		self.assertEqual(results[1]["author_id"], self.author2.author_id)
+
+	def test_authors_filtering_by_subjects_any_without_team_works(self):
+		"""?subjects_any=<id> (no team_id) is the OR-list equivalent of subject_id."""
+		response = self.client.get(
+			f"/authors/?subjects_any={self.subject.id}&sort_by=article_count"
+		)
+
+		self.assertEqual(response.status_code, status.HTTP_200_OK)
+		self.assertEqual(response.data["count"], 2)
+
+	def test_authors_filtering_by_subjects_any_multiple_ids(self):
+		"""?subjects_any=A,B returns authors tagged with either subject."""
+		other_subject = Subject.objects.create(
+			subject_name="Other Subject", subject_slug="other-subject", team=self.team
+		)
+		other_author = Authors.objects.create(
+			given_name="Extra", family_name="Author"
+		)
+		other_article = Articles.objects.create(
+			title="Other subject article",
+			link="http://example.com/other-subject-article",
+		)
+		other_article.authors.add(other_author)
+		other_article.teams.add(self.team)
+		other_article.subjects.add(other_subject)
+
+		response = self.client.get(
+			f"/authors/?subjects_any={self.subject.id},{other_subject.id}"
+		)
+		self.assertEqual(response.status_code, status.HTTP_200_OK)
+		ids = {r["author_id"] for r in response.data["results"]}
+		self.assertIn(self.author1.author_id, ids)
+		self.assertIn(self.author2.author_id, ids)
+		self.assertIn(other_author.author_id, ids)
+
+	def test_authors_filtering_by_subjects_any_all_invalid_returns_empty(self):
+		"""?subjects_any=foo,bar (all non-numeric) matches nothing, not an error."""
+		response = self.client.get("/authors/?subjects_any=foo,bar")
+		self.assertEqual(response.status_code, status.HTTP_200_OK)
 		self.assertEqual(response.data["count"], 0)
-		self.assertEqual(len(response.data["results"]), 0)
 
 	def test_authors_filtering_validation_category_without_team(self):
 		"""Test that filtering by category_slug without team_id returns empty results"""
@@ -335,9 +385,10 @@ class AuthorAPITest(TestCase):
 
 	def test_team_id_requirement_validation(self):
 		"""
-		Test that team_id is required when filtering by category_slug or subject_id.
-		This enforces the business rule that authors must be filtered within a team context
-		when using subject or category filters.
+		Test that team_id is required when filtering by category_slug, but NOT
+		when filtering by subject_id (site-scoped API visibility, Phase 2 item
+		2 -- see AuthorsViewSet.get_queryset for why the two are no longer
+		symmetric).
 		"""
 		# Test 1: Basic endpoint without filters (should work)
 		response = self.client.get("/authors/?sort_by=article_count")
@@ -349,17 +400,17 @@ class AuthorAPITest(TestCase):
 		)
 		self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-		# Test 3: With subject_id but no team_id (should return empty results)
+		# Test 3: With subject_id but no team_id (should now work, and return
+		# both authors tagged with this subject)
 		response = self.client.get(
 			f"/authors/?subject_id={self.subject.id}&sort_by=article_count"
 		)
 		self.assertEqual(response.status_code, status.HTTP_200_OK)
 		self.assertEqual(
 			response.data["count"],
-			0,
-			"Should return empty results when subject_id is used without team_id",
+			2,
+			"subject_id without team_id should work, not return empty results",
 		)
-		self.assertEqual(len(response.data["results"]), 0)
 
 		# Test 4: With category_slug but no team_id (should return empty results)
 		response = self.client.get(
@@ -387,7 +438,9 @@ class AuthorAPITest(TestCase):
 		self.assertEqual(response.status_code, status.HTTP_200_OK)
 		# Note: Results depend on test data, but request should be valid
 
-		# Test 7: Both subject_id and category_slug without team_id (should return empty)
+		# Test 7: subject_id + category_slug without team_id -- still empty,
+		# but now solely because of category_slug's requirement (subject_id
+		# alone would not trigger it; see Test 3).
 		response = self.client.get(
 			f"/authors/?subject_id={self.subject.id}&category_slug={self.category.category_slug}&sort_by=article_count"
 		)
@@ -395,7 +448,7 @@ class AuthorAPITest(TestCase):
 		self.assertEqual(
 			response.data["count"],
 			0,
-			"Should return empty results when both subject_id and category_slug are used without team_id",
+			"category_slug without team_id should still return empty results",
 		)
 		self.assertEqual(len(response.data["results"]), 0)
 
@@ -417,26 +470,50 @@ class AuthorAPITest(TestCase):
 
 	def test_team_id_requirement_with_timeframe_filters(self):
 		"""
-		Test that team_id requirement is enforced even when using timeframe filters
+		category_slug still requires team_id even alongside a date/timeframe
+		filter; subject_id does not (Phase 2 item 2).
 		"""
 		from datetime import datetime, timedelta
 
-		# Date filters
+		from django.utils import timezone as django_timezone
+
+		# Give article1/article2 a published_date inside the date window so
+		# the subject_id case below has something to actually find -- without
+		# this, an all-NULL published_date would return empty regardless of
+		# the team_id coupling being tested here, masking the behaviour.
+		# One day back, deliberately: /authors/ parses date_to into a plain
+		# date, so `published_date__lte` compares against midnight. An
+		# article published at any time TODAY sorts after that boundary and
+		# falls outside its own window -- which would make this test fail
+		# for a reason unrelated to the team_id coupling it exists to check.
+		# (Note /articles/ documents published_date_before as including the
+		# full day; /authors/ does not. Pre-existing inconsistency.)
+		now = django_timezone.now() - timedelta(days=1)
+		Articles.objects.filter(
+			pk__in=[self.article1.pk, self.article2.pk]
+		).update(published_date=now)
+
 		date_from = (datetime.now() - timedelta(days=30)).strftime("%Y-%m-%d")
 		date_to = datetime.now().strftime("%Y-%m-%d")
 
-		# Test with subject_id and date filters but no team_id (should return empty)
+		# subject_id + date filters, no team_id -- now works, since team_id is
+		# not required for subject-based filtering.
 		response = self.client.get(
 			f"/authors/?subject_id={self.subject.id}&date_from={date_from}&date_to={date_to}"
 		)
 		self.assertEqual(response.status_code, status.HTTP_200_OK)
 		self.assertEqual(
 			response.data["count"],
-			0,
-			"Should return empty results when subject_id is used with date filters but without team_id",
+			1,
+			"subject_id + date filters without team_id should find author1 "
+			"(the only author with articles published in the window)",
+		)
+		self.assertEqual(
+			response.data["results"][0]["author_id"], self.author1.author_id
 		)
 
-		# Test with category_slug and timeframe but no team_id (should return empty)
+		# category_slug + timeframe, no team_id -- still empty; category_slug
+		# keeps the team_id requirement.
 		response = self.client.get(
 			f"/authors/?category_slug={self.category.category_slug}&timeframe=last_month"
 		)

--- a/django/api/tests/test_multi_subject_filter.py
+++ b/django/api/tests/test_multi_subject_filter.py
@@ -11,6 +11,7 @@ from gregory.models import (
 	Organization,
 	ArticleSubjectRelevance,
 	OrganizationApiSettings,
+	MLPredictions,
 )
 
 
@@ -526,3 +527,120 @@ class TrialSubjectAnyFilterTests(TestCase):
 		response = self.client.get("/trials/?subjects_any=foo,bar")
 		self.assertEqual(response.status_code, status.HTTP_200_OK)
 		self.assertEqual(response.data["count"], 0)
+
+
+class RelevantFilterSubjectScopingTests(TestCase):
+	"""
+	``relevant=true``/``ml_threshold`` must scope ML-consensus relevance to the
+	same subject(s) the rest of the request is already scoped to (subject_id,
+	subjects, or subjects_any) -- not silently check consensus across every
+	auto_predict subject in the database.
+
+	See SITE-API-VISIBILITY-PLAN.md Phase 2 item 3: under a site scope,
+	unscoped relevance checking would leak an article flagged relevant only
+	for another tenant's subject into a query scoped to a different subject.
+	The bug is reachable today too, without any site scoping, whenever a
+	caller combines relevant=true with subjects/subjects_any instead of the
+	legacy singular subject_id.
+	"""
+
+	@classmethod
+	def setUpTestData(cls):
+		cls.org = Organization.objects.create(
+			name="Relevance Scope Org", slug="relevance-scope-org"
+		)
+		OrganizationApiSettings.objects.filter(organization=cls.org).update(
+			make_api_public=True
+		)
+		cls.team = Team.objects.create(
+			name="Relevance Scope Team",
+			slug="relevance-scope-team",
+			organization=cls.org,
+		)
+
+		# Two independent auto_predict subjects with "any" consensus (a single
+		# algorithm reaching threshold is enough).
+		cls.subject_x = Subject.objects.create(
+			subject_name="Relevance Subject X",
+			subject_slug="relevance-subject-x",
+			team=cls.team,
+			auto_predict=True,
+			ml_consensus_type="any",
+		)
+		cls.subject_y = Subject.objects.create(
+			subject_name="Relevance Subject Y",
+			subject_slug="relevance-subject-y",
+			team=cls.team,
+			auto_predict=True,
+			ml_consensus_type="any",
+		)
+
+		# Tagged with BOTH subjects, but only ML-consensus-relevant for X.
+		cls.article = Articles.objects.create(
+			title="Cross-subject relevance article",
+			link="https://example.com/cross-subject-relevance",
+		)
+		cls.article.subjects.add(cls.subject_x, cls.subject_y)
+		cls.article.teams.add(cls.team)
+		MLPredictions.objects.create(
+			article=cls.article,
+			subject=cls.subject_x,
+			algorithm="pubmed_bert",
+			probability_score=0.95,
+			predicted_relevant=True,
+		)
+
+	def setUp(self):
+		self.client = APIClient()
+
+	def test_relevant_scoped_to_subjects_any_excludes_other_subjects_consensus(self):
+		"""
+		?subjects_any=Y&relevant=true must NOT return an article that is only
+		ML-relevant for X, even though the article is tagged with Y too.
+		"""
+		url = f"/articles/?subjects_any={self.subject_y.id}&relevant=true"
+		response = self.client.get(url)
+		self.assertEqual(response.status_code, status.HTTP_200_OK)
+		ids = {r["article_id"] for r in response.data["results"]}
+		self.assertNotIn(
+			self.article.article_id,
+			ids,
+			"relevant=true leaked ML consensus decided for an out-of-scope "
+			"subject (X) into a query scoped to a different subject (Y) via "
+			"subjects_any",
+		)
+
+	def test_relevant_scoped_to_subjects_any_includes_matching_subject(self):
+		"""?subjects_any=X&relevant=true still returns the article (sanity check)."""
+		url = f"/articles/?subjects_any={self.subject_x.id}&relevant=true"
+		response = self.client.get(url)
+		self.assertEqual(response.status_code, status.HTTP_200_OK)
+		ids = {r["article_id"] for r in response.data["results"]}
+		self.assertIn(self.article.article_id, ids)
+
+	def test_relevant_scoped_to_subjects_all_excludes_other_subjects_consensus(self):
+		"""Same leak, reached via the AND-list ``subjects`` param instead."""
+		url = f"/articles/?subjects={self.subject_y.id}&relevant=true"
+		response = self.client.get(url)
+		self.assertEqual(response.status_code, status.HTTP_200_OK)
+		ids = {r["article_id"] for r in response.data["results"]}
+		self.assertNotIn(self.article.article_id, ids)
+
+	def test_ml_threshold_scoped_to_subjects_any_excludes_other_subjects(self):
+		"""Same leak, via ml_threshold instead of relevant=true."""
+		url = f"/articles/?subjects_any={self.subject_y.id}&ml_threshold=0.5"
+		response = self.client.get(url)
+		self.assertEqual(response.status_code, status.HTTP_200_OK)
+		ids = {r["article_id"] for r in response.data["results"]}
+		self.assertNotIn(self.article.article_id, ids)
+
+	def test_relevant_without_any_subject_param_still_checks_every_subject(self):
+		"""
+		No subject_id/subjects/subjects_any at all → unscoped behaviour is
+		unchanged: the article is still found relevant via X's consensus.
+		"""
+		url = "/articles/?relevant=true"
+		response = self.client.get(url)
+		self.assertEqual(response.status_code, status.HTTP_200_OK)
+		ids = {r["article_id"] for r in response.data["results"]}
+		self.assertIn(self.article.article_id, ids)

--- a/django/api/tests/test_public_sites_endpoint.py
+++ b/django/api/tests/test_public_sites_endpoint.py
@@ -1,0 +1,91 @@
+"""Tests for GET /sites/ — the site-discovery endpoint.
+
+Site-scoped API visibility fails closed when a caller names no site, which
+leaves a new consumer unable to call anything: it needs a site_id, and nothing
+else would tell it which exist. This endpoint breaks that circle, so it is
+deliberately unscoped and unauthenticated. That makes it a boundary worth
+pinning: everything it returns is public by construction, and anything it
+leaks is leaked to everyone.
+"""
+
+from django.contrib.sites.models import Site
+from django.test import TestCase
+from rest_framework.test import APIClient
+
+from sitesettings.models import CustomSetting
+
+
+class PublicSitesEndpointTests(TestCase):
+	def setUp(self):
+		self.client = APIClient()
+
+		self.public_site = Site.objects.create(
+			domain="pse-public.example.test", name="Public Site"
+		)
+		CustomSetting.objects.create(
+			site=self.public_site, title="PSE Public", api_public=True
+		)
+
+		self.private_site = Site.objects.create(
+			domain="pse-private.example.test", name="Private Site"
+		)
+		CustomSetting.objects.create(
+			site=self.private_site, title="PSE Private", api_public=False
+		)
+
+	def test_anonymous_callers_may_read_it(self):
+		"""Unauthenticated access is the whole point — a caller with no
+		credential and no site_id has to be able to bootstrap from here."""
+		response = self.client.get("/sites/")
+		self.assertEqual(response.status_code, 200)
+
+	def test_lists_public_sites_with_the_documented_shape(self):
+		response = self.client.get("/sites/")
+		row = next(
+			r for r in response.data if r["site_id"] == self.public_site.id
+		)
+		self.assertEqual(
+			set(row.keys()), {"site_id", "domain", "name"}
+		)
+		self.assertEqual(row["domain"], "pse-public.example.test")
+		self.assertEqual(row["name"], "Public Site")
+
+	def test_excludes_sites_that_are_not_api_public(self):
+		"""api_public defaults to False, so a site is absent until someone
+		publishes it deliberately."""
+		response = self.client.get("/sites/")
+		returned = {r["site_id"] for r in response.data}
+		self.assertIn(self.public_site.id, returned)
+		self.assertNotIn(self.private_site.id, returned)
+
+	def test_a_site_with_several_settings_rows_appears_once(self):
+		"""CustomSetting.site is a plain FK, not OneToOne — sitesettings
+		already handles multiple rows per site elsewhere (see
+		test_lowest_setting_id_wins_when_multiple_rows). Iterating settings
+		rather than sites would hand clients duplicate site_ids, which
+		contradicts what this endpoint is for."""
+		CustomSetting.objects.create(
+			site=self.public_site, title="PSE Public Second", api_public=True
+		)
+
+		response = self.client.get("/sites/")
+		ids = [r["site_id"] for r in response.data]
+		self.assertEqual(
+			ids.count(self.public_site.id),
+			1,
+			f"expected one row per site, got {ids}",
+		)
+		self.assertEqual(len(ids), len(set(ids)), "site_ids must be unique")
+
+	def test_a_site_public_on_one_row_and_private_on_another_is_listed(self):
+		"""Pins the tie-break: any api_public row publishes the site. Worth
+		asserting rather than leaving to the dedup's ordering, because the
+		alternative reading — private wins — is equally defensible and this
+		is the one implemented."""
+		CustomSetting.objects.create(
+			site=self.private_site, title="PSE Private Second", api_public=True
+		)
+
+		response = self.client.get("/sites/")
+		returned = {r["site_id"] for r in response.data}
+		self.assertIn(self.private_site.id, returned)

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -1868,6 +1868,8 @@ class CategoryViewSet(viewsets.ReadOnlyModelViewSet):
 	# Query Parameters:
 	- **team_id** - filter by team ID
 	- **subject_id** - filter by subject ID
+	- **subjects_any** - comma-separated subject IDs, OR semantics: categories used
+	  within ANY of the listed subjects (e.g. 1,10)
 	- **category_id** - filter by specific category ID
 	- **get_categories** - comma-separated list of category IDs (e.g., 1,2,3)
 	- **include_authors** - Include top authors data (default: true)
@@ -1900,6 +1902,7 @@ class CategoryViewSet(viewsets.ReadOnlyModelViewSet):
 	- `/categories/{id}/authors/` - Get detailed author statistics for a specific category
 
 	# Examples:
+	- Categories in either subject: `/categories/?subjects_any=1,10`
 	- Basic: `GET /categories/?team_id=1`
 	- With subject: `GET /categories/?team_id=1&subject_id=2`
 	- Date filtered: `GET /categories/?team_id=1&timeframe=year`
@@ -2481,10 +2484,11 @@ class TrialViewSet(
 				"trial_countries",
 				# TrialSerializer exposes nested subjects (added for site-scoped
 				# visibility, so a caller can check a trial's scope without a
-				# second request). Without this it is a query per row —
-				# ArticleSerializer prefetches its own "subjects" for the same
-				# reason.
-				"subjects",
+				# second request). select_related("team") is not optional:
+				# SubjectsSerializer.team_id uses source="team.id", so a plain
+				# M2M prefetch still dereferences team once per nested subject.
+				# ArticleViewSet does exactly this for the same reason.
+				Prefetch("subjects", queryset=Subject.objects.select_related("team")),
 			)
 		)
 		# trial_sites backs TrialDetailSerializer's "trial_sites" field, used only on
@@ -4044,10 +4048,12 @@ class TrialSearchView(
 			"team_categories",
 			"article_references__article",
 			"trial_countries",
-			# Nested subjects on TrialSerializer — a query per row without this.
+			# Nested subjects on TrialSerializer. select_related("team") is
+			# required because SubjectsSerializer.team_id uses source="team.id"
+			# — a plain prefetch still costs a query per nested subject.
 			# Mirrors TrialViewSet.get_queryset; this view builds its own
 			# queryset and inherits none of that.
-			"subjects",
+			Prefetch("subjects", queryset=Subject.objects.select_related("team")),
 		)
 
 		# Prefetch the caller-org's TrialOrgContent so the serializer's
@@ -4339,12 +4345,25 @@ class PublicSitesView(APIView):
 	permission_classes = [permissions.AllowAny]
 
 	def get(self, request):
+		# CustomSetting.site is a plain FK, not OneToOne — a site can carry
+		# several settings rows, which sitesettings already handles elsewhere
+		# (see test_lowest_setting_id_wins_when_multiple_rows). Iterating
+		# settings would emit one entry per row and hand clients duplicate
+		# site_ids. Collapse to one row per site, lowest setting_id winning,
+		# matching the tie-break that module already uses.
 		settings_qs = (
 			CustomSetting.objects.filter(api_public=True)
 			.select_related("site")
-			.order_by("site__domain")
+			.order_by("site__domain", "setting_id")
 		)
-		return Response(PublicSiteSerializer(settings_qs, many=True).data)
+		seen = set()
+		unique = []
+		for setting in settings_qs:
+			if setting.site_id in seen:
+				continue
+			seen.add(setting.site_id)
+			unique.append(setting)
+		return Response(PublicSiteSerializer(unique, many=True).data)
 
 
 class StatsView(APIView):

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -40,6 +40,7 @@ from api.serializers import (
 	SubjectsSerializer,
 	OrganizationSerializer,
 	SponsorSerializer,
+	PublicSiteSerializer,
 )
 from api.pagination import (
 	CappedPageNumberPagination,
@@ -114,6 +115,7 @@ from api.filters import (
 from rest_framework.response import Response
 from django.http import Http404, StreamingHttpResponse
 from rest_framework.views import APIView
+from sitesettings.models import CustomSetting
 from rest_framework_simplejwt.views import TokenObtainPairView
 from drf_spectacular.utils import (
 	extend_schema,
@@ -2477,6 +2479,12 @@ class TrialViewSet(
 				"team_categories",
 				"article_references__article",
 				"trial_countries",
+				# TrialSerializer exposes nested subjects (added for site-scoped
+				# visibility, so a caller can check a trial's scope without a
+				# second request). Without this it is a query per row —
+				# ArticleSerializer prefetches its own "subjects" for the same
+				# reason.
+				"subjects",
 			)
 		)
 		# trial_sites backs TrialDetailSerializer's "trial_sites" field, used only on
@@ -2884,6 +2892,8 @@ class SponsorViewSet(viewsets.ReadOnlyModelViewSet):
 	- **search** - search by sponsor name
 	- **sponsor_type** - filter by sponsor type; one of: industry,
 	  academic_medical, government, nonprofit, other
+	- **subject_id** - restrict to sponsors with >=1 trial in this subject
+	- **subjects_any** - comma-separated subject IDs, OR semantics
 	- **ordering** - 'name' (default) or 'trials_count' (add '-' for reverse)
 	- **page_size** - items per page (max 100)
 
@@ -2891,6 +2901,8 @@ class SponsorViewSet(viewsets.ReadOnlyModelViewSet):
 	- Filter by type: `/sponsors/?sponsor_type=industry`
 	- Search by name: `/sponsors/?search=novartis`
 	- Most-trials first: `/sponsors/?ordering=-trials_count`
+	- Sponsors active in a subject: `/sponsors/?subject_id=1`
+	- Sponsors active in either subject: `/sponsors/?subjects_any=1,2`
 	"""
 
 	queryset = Sponsor.objects.all().order_by("name")
@@ -2989,15 +3001,23 @@ _AUTHORS_LIST_PARAMS = [
 		OpenApiTypes.INT,
 		OpenApiParameter.QUERY,
 		description="Restrict to authors with at least one article on this team. "
-		"Required if subject_id, category_slug, or category_id is given — without "
-		"it, the response is an empty page rather than an error.",
+		"Required if category_slug or category_id is given — without it, the "
+		"response is an empty page rather than an error. NOT required for "
+		"subject_id/subjects_any.",
 	),
 	OpenApiParameter(
 		"subject_id",
 		OpenApiTypes.INT,
 		OpenApiParameter.QUERY,
-		description="Restrict to authors with at least one article in this subject. "
-		"Requires team_id.",
+		description="Restrict to authors with at least one article in this subject.",
+	),
+	OpenApiParameter(
+		"subjects_any",
+		OpenApiTypes.STR,
+		OpenApiParameter.QUERY,
+		description="Comma-separated subject IDs, OR semantics — restrict to "
+		"authors with at least one article in any of the listed subjects, e.g. "
+		"?subjects_any=1,10.",
 	),
 	OpenApiParameter(
 		"category_slug",
@@ -3101,10 +3121,11 @@ class AuthorsViewSet(viewsets.ReadOnlyModelViewSet):
 	- **country** - filter by country code (exact match)
 	- **sort_by** - 'article_count' (default: 'author_id')
 	- **order** - 'asc' or 'desc' (default: 'desc' for article_count, 'asc' for others)
-	- **team_id** - filter by team ID
+	- **team_id** - filter by team ID (required alongside category_slug/category_id; NOT required for subject_id/subjects_any)
 	- **subject_id** - filter by subject ID
-	- **category_slug** - filter by team category slug
-	- **category_id** - filter by team category ID
+	- **subjects_any** - comma-separated subject IDs, OR semantics (e.g. `?subjects_any=1,10`)
+	- **category_slug** - filter by team category slug (requires team_id)
+	- **category_id** - filter by team category ID (requires team_id)
 	- **date_from** - filter articles from this date (YYYY-MM-DD)
 	- **date_to** - filter articles to this date (YYYY-MM-DD)
 	- **timeframe** - 'year', 'month', 'week' (relative to current date)
@@ -3119,6 +3140,8 @@ class AuthorsViewSet(viewsets.ReadOnlyModelViewSet):
 	- Filter by country: `?country=US`
 	- Sort by article count: `?sort_by=article_count&order=desc`
 	- Filter by timeframe: `?sort_by=article_count&timeframe=year`
+	- Subject filter, no team_id needed: `?subject_id=5&sort_by=article_count`
+	- Multi-subject OR filter: `?subjects_any=1,10&sort_by=article_count`
 	- Team and subject filter: `?team_id=1&subject_id=5&sort_by=article_count`
 	- Count per category: `?team_id=1&category_slug=natalizumab&sort_by=article_count&order=desc`
 	- Category with ID: `?team_id=1&category_id=5&sort_by=article_count&order=desc`
@@ -3174,11 +3197,30 @@ class AuthorsViewSet(viewsets.ReadOnlyModelViewSet):
 		)
 		team_id = self.request.query_params.get("team_id")
 		subject_id = self.request.query_params.get("subject_id")
+		subjects_any_param = self.request.query_params.get("subjects_any")
 		category_slug = self.request.query_params.get("category_slug")
 		category_id = self.request.query_params.get("category_id")
 		date_from = self.request.query_params.get("date_from")
 		date_to = self.request.query_params.get("date_to")
 		timeframe = self.request.query_params.get("timeframe")
+
+		# Parse subjects_any into a list of ints, OR semantics -- same
+		# comma-separated, invalid-pieces-dropped convention as
+		# SubjectFilterMixin.filter_subjects_any on /articles/ and /trials/
+		# (api/filters.py). Authors has no direct `subjects` field to hang
+		# that mixin off of (it reaches subjects only via articles), so this
+		# is reimplemented inline rather than shared.
+		subjects_any_ids = None
+		if subjects_any_param:
+			subjects_any_ids = []
+			for raw in subjects_any_param.split(","):
+				raw = raw.strip()
+				if not raw:
+					continue
+				try:
+					subjects_any_ids.append(int(raw))
+				except (TypeError, ValueError):
+					continue
 
 		# Apply simple filters first
 		if author_id:
@@ -3241,9 +3283,31 @@ class AuthorsViewSet(viewsets.ReadOnlyModelViewSet):
 		# Apply team/subject/category filters using single-phase approach
 		count_filters = {}  # Used for Count annotation on Authors queryset
 
-		# Validate that team_id is provided when using subject_id or category filters
-		if (subject_id or category_slug or category_id) and not team_id:
-			# Return empty queryset if team_id is missing for subject/category filtering
+		# Validate that team_id is provided when using category filters.
+		#
+		# subject_id/subjects_any are deliberately NOT included here (site-scoped
+		# API visibility, Phase 2 item 2): a caller scoped to a site knows
+		# subjects, not team_ids -- Subject.team is a plain FK, so a subject_id
+		# already resolves unambiguously to one team with no help needed, and
+		# requiring team_id anyway would make subject-based filtering unusable
+		# for exactly that caller.
+		#
+		# category_slug/category_id keep the requirement. They ARE both
+		# globally unique identifiers on their own (TeamCategory has both a
+		# DB-level unique index on category_slug alone and one on category_id
+		# as its PK -- verified against the schema, not just the model
+		# declaration), so team_id adds nothing to disambiguate *identity*.
+		# But count_filters below ANDs `articles__teams__id` (team_id) with
+		# `articles__team_categories__id`/`__category_slug` (category) as two
+		# independent predicates over two different M2M relations -- i.e. it
+		# counts articles that are BOTH tagged to that team AND in that
+		# category, not merely articles in a category that happens to belong
+		# to that team. That is a real, separate narrowing, and TeamCategory
+		# is outside the subject-based scope model this project touches
+		# (CustomSetting.scope_subjects lists Subjects, never TeamCategory),
+		# so there is no site-visibility reason to change it here.
+		if (category_slug or category_id) and not team_id:
+			# Return empty queryset if team_id is missing for category filtering
 			return Authors.objects.none()
 
 		if team_id:
@@ -3259,6 +3323,13 @@ class AuthorsViewSet(viewsets.ReadOnlyModelViewSet):
 				count_filters["articles__subjects__id"] = subject_id
 			except ValueError:
 				pass
+
+		if subjects_any_ids:
+			count_filters["articles__subjects__id__in"] = subjects_any_ids
+		elif subjects_any_param and not subjects_any_ids:
+			# subjects_any was given but every piece was invalid -- match
+			# nothing, same convention as SubjectFilterMixin.filter_subjects_any.
+			return Authors.objects.none()
 
 		if category_slug:
 			count_filters["articles__team_categories__category_slug"] = category_slug
@@ -3969,7 +4040,14 @@ class TrialSearchView(
 
 		# Prefetch related objects to avoid N+1 queries
 		queryset = queryset.prefetch_related(
-			"sources", "team_categories", "article_references__article", "trial_countries"
+			"sources",
+			"team_categories",
+			"article_references__article",
+			"trial_countries",
+			# Nested subjects on TrialSerializer — a query per row without this.
+			# Mirrors TrialViewSet.get_queryset; this view builds its own
+			# queryset and inherits none of that.
+			"subjects",
 		)
 
 		# Prefetch the caller-org's TrialOrgContent so the serializer's
@@ -4234,6 +4312,39 @@ class AuthorSearchView(BodyParamsAsQueryParamsMixin, generics.ListAPIView):
 ###
 # STATS
 ###
+
+
+@extend_schema(
+	summary="List publicly readable sites",
+	description=(
+		"Sites whose API is public, as {site_id, domain, name}. This is the "
+		"discovery entry point for callers that need a site_id and do not have "
+		"one, so it is deliberately UNSCOPED -- it cannot require the thing it "
+		"exists to provide. Everything it returns is already public."
+	),
+	responses=PublicSiteSerializer(many=True),
+)
+class PublicSitesView(APIView):
+	"""Sites with `api_public = True`.
+
+	Unscoped by design. Site-scoped API visibility fails closed when a caller
+	names no site, which leaves a new consumer unable to call anything: it
+	needs a site_id, and nothing else would tell it which exist. This endpoint
+	breaks that circle.
+
+	Read-only, no auth, no pagination -- the list is a handful of rows and
+	changes when a site is onboarded, which is rare.
+	"""
+
+	permission_classes = [permissions.AllowAny]
+
+	def get(self, request):
+		settings_qs = (
+			CustomSetting.objects.filter(api_public=True)
+			.select_related("site")
+			.order_by("site__domain")
+		)
+		return Response(PublicSiteSerializer(settings_qs, many=True).data)
 
 
 class StatsView(APIView):

--- a/django/schema.yml
+++ b/django/schema.yml
@@ -203,8 +203,8 @@ paths:
         schema:
           type: number
         description: Minimum ML prediction confidence (0.0-1.0, e.g. 0.75). Also scoped
-          to subject_id when provided. Defaults to 0.8 when relevant=true and this
-          is omitted.
+          to subject_id/subjects/subjects_any when provided. Defaults to 0.8 when
+          relevant=true and this is omitted.
       - in: query
         name: open_access
         schema:
@@ -265,9 +265,12 @@ paths:
         schema:
           type: boolean
         description: Filter for relevant articles (true/false). When combined with
-          subject_id, relevance is scoped to that specific subject — only articles
-          relevant *for that subject* (via ML predictions or manual marking) are returned.
-          Without subject_id, relevance is checked across all subjects.
+          subject_id, subjects, and/or subjects_any, relevance is scoped to that subject
+          or subjects — only articles relevant *for one of those subjects* (via ML
+          predictions or manual marking) are returned. Without any of those, relevance
+          is checked across every subject in the database, so a caller that also scopes
+          the query by subject should always pass the same subject(s) here to avoid
+          picking up relevance decided by an unrelated subject.
       - in: query
         name: search
         schema:
@@ -804,8 +807,8 @@ paths:
         schema:
           type: number
         description: Minimum ML prediction confidence (0.0-1.0, e.g. 0.75). Also scoped
-          to subject_id when provided. Defaults to 0.8 when relevant=true and this
-          is omitted.
+          to subject_id/subjects/subjects_any when provided. Defaults to 0.8 when
+          relevant=true and this is omitted.
       - in: query
         name: open_access
         schema:
@@ -849,9 +852,12 @@ paths:
         schema:
           type: boolean
         description: Filter for relevant articles (true/false). When combined with
-          subject_id, relevance is scoped to that specific subject — only articles
-          relevant *for that subject* (via ML predictions or manual marking) are returned.
-          Without subject_id, relevance is checked across all subjects.
+          subject_id, subjects, and/or subjects_any, relevance is scoped to that subject
+          or subjects — only articles relevant *for one of those subjects* (via ML
+          predictions or manual marking) are returned. Without any of those, relevance
+          is checked across every subject in the database, so a caller that also scopes
+          the query by subject should always pass the same subject(s) here to avoid
+          picking up relevance decided by an unrelated subject.
       - in: query
         name: search
         schema:
@@ -1051,15 +1057,18 @@ paths:
                 relevant:
                   type: boolean
                   description: Filter for relevant articles (true/false). When combined
-                    with subject_id, relevance is scoped to that specific subject
-                    — only articles relevant *for that subject* (via ML predictions
-                    or manual marking) are returned. Without subject_id, relevance
-                    is checked across all subjects.
+                    with subject_id, subjects, and/or subjects_any, relevance is scoped
+                    to that subject or subjects — only articles relevant *for one
+                    of those subjects* (via ML predictions or manual marking) are
+                    returned. Without any of those, relevance is checked across every
+                    subject in the database, so a caller that also scopes the query
+                    by subject should always pass the same subject(s) here to avoid
+                    picking up relevance decided by an unrelated subject.
                 ml_threshold:
                   type: number
                   description: Minimum ML prediction confidence (0.0-1.0, e.g. 0.75).
-                    Also scoped to subject_id when provided. Defaults to 0.8 when
-                    relevant=true and this is omitted.
+                    Also scoped to subject_id/subjects/subjects_any when provided.
+                    Defaults to 0.8 when relevant=true and this is omitted.
                 open_access:
                   type: boolean
                   description: Filter for open access articles (true/false).
@@ -1197,10 +1206,11 @@ paths:
         - **country** - filter by country code (exact match)
         - **sort_by** - 'article_count' (default: 'author_id')
         - **order** - 'asc' or 'desc' (default: 'desc' for article_count, 'asc' for others)
-        - **team_id** - filter by team ID
+        - **team_id** - filter by team ID (required alongside category_slug/category_id; NOT required for subject_id/subjects_any)
         - **subject_id** - filter by subject ID
-        - **category_slug** - filter by team category slug
-        - **category_id** - filter by team category ID
+        - **subjects_any** - comma-separated subject IDs, OR semantics (e.g. `?subjects_any=1,10`)
+        - **category_slug** - filter by team category slug (requires team_id)
+        - **category_id** - filter by team category ID (requires team_id)
         - **date_from** - filter articles from this date (YYYY-MM-DD)
         - **date_to** - filter articles to this date (YYYY-MM-DD)
         - **timeframe** - 'year', 'month', 'week' (relative to current date)
@@ -1215,6 +1225,8 @@ paths:
         - Filter by country: `?country=US`
         - Sort by article count: `?sort_by=article_count&order=desc`
         - Filter by timeframe: `?sort_by=article_count&timeframe=year`
+        - Subject filter, no team_id needed: `?subject_id=5&sort_by=article_count`
+        - Multi-subject OR filter: `?subjects_any=1,10&sort_by=article_count`
         - Team and subject filter: `?team_id=1&subject_id=5&sort_by=article_count`
         - Count per category: `?team_id=1&category_slug=natalizumab&sort_by=article_count&order=desc`
         - Category with ID: `?team_id=1&category_id=5&sort_by=article_count&order=desc`
@@ -1328,14 +1340,19 @@ paths:
         schema:
           type: integer
         description: Restrict to authors with at least one article in this subject.
-          Requires team_id.
+      - in: query
+        name: subjects_any
+        schema:
+          type: string
+        description: Comma-separated subject IDs, OR semantics — restrict to authors
+          with at least one article in any of the listed subjects, e.g. ?subjects_any=1,10.
       - in: query
         name: team_id
         schema:
           type: integer
         description: Restrict to authors with at least one article on this team. Required
-          if subject_id, category_slug, or category_id is given — without it, the
-          response is an empty page rather than an error.
+          if category_slug or category_id is given — without it, the response is an
+          empty page rather than an error. NOT required for subject_id/subjects_any.
       - in: query
         name: timeframe
         schema:
@@ -1379,10 +1396,11 @@ paths:
         - **country** - filter by country code (exact match)
         - **sort_by** - 'article_count' (default: 'author_id')
         - **order** - 'asc' or 'desc' (default: 'desc' for article_count, 'asc' for others)
-        - **team_id** - filter by team ID
+        - **team_id** - filter by team ID (required alongside category_slug/category_id; NOT required for subject_id/subjects_any)
         - **subject_id** - filter by subject ID
-        - **category_slug** - filter by team category slug
-        - **category_id** - filter by team category ID
+        - **subjects_any** - comma-separated subject IDs, OR semantics (e.g. `?subjects_any=1,10`)
+        - **category_slug** - filter by team category slug (requires team_id)
+        - **category_id** - filter by team category ID (requires team_id)
         - **date_from** - filter articles from this date (YYYY-MM-DD)
         - **date_to** - filter articles to this date (YYYY-MM-DD)
         - **timeframe** - 'year', 'month', 'week' (relative to current date)
@@ -1397,6 +1415,8 @@ paths:
         - Filter by country: `?country=US`
         - Sort by article count: `?sort_by=article_count&order=desc`
         - Filter by timeframe: `?sort_by=article_count&timeframe=year`
+        - Subject filter, no team_id needed: `?subject_id=5&sort_by=article_count`
+        - Multi-subject OR filter: `?subjects_any=1,10&sort_by=article_count`
         - Team and subject filter: `?team_id=1&subject_id=5&sort_by=article_count`
         - Count per category: `?team_id=1&category_slug=natalizumab&sort_by=article_count&order=desc`
         - Category with ID: `?team_id=1&category_id=5&sort_by=article_count&order=desc`
@@ -1639,6 +1659,18 @@ paths:
         description: A search term.
         schema:
           type: string
+      - in: query
+        name: subjects_any
+        schema:
+          type: array
+          items:
+            type: string
+        description: 'Comma-separated subject IDs, OR semantics: authors with at least
+          one article in ANY of the listed subjects, e.g. ?subjects_any=1,10. An author
+          is reached only through their articles, so this is an Exists() over articles
+          rather than a direct field.'
+        explode: false
+        style: form
       tags:
       - authors
       security:
@@ -1709,6 +1741,14 @@ paths:
                 country:
                   type: string
                   description: Exact match against the author's country code.
+                subjects_any:
+                  type: array
+                  items:
+                    type: string
+                  description: 'Comma-separated subject IDs, OR semantics: authors
+                    with at least one article in ANY of the listed subjects, e.g.
+                    ?subjects_any=1,10. An author is reached only through their articles,
+                    so this is an Exists() over articles rather than a direct field.'
               required:
               - team_id
               - subject_id
@@ -1899,6 +1939,18 @@ paths:
         schema:
           type: integer
         description: Filter by subject ID (see /subjects/).
+      - in: query
+        name: subjects_any
+        schema:
+          type: array
+          items:
+            type: string
+        description: 'Comma-separated subject IDs, OR semantics: categories used within
+          ANY of the listed subjects, e.g. ?subjects_any=1,10. Uses Exists() rather
+          than a join so a category tagged with several of the listed subjects appears
+          once without DISTINCT-ing the outer query.'
+        explode: false
+        style: form
       - in: query
         name: team_id
         schema:
@@ -2131,6 +2183,43 @@ paths:
                 type: object
                 additionalProperties: {}
           description: ''
+  /sites/:
+    get:
+      operationId: sites_list
+      description: Sites whose API is public, as {site_id, domain, name}. This is
+        the discovery entry point for callers that need a site_id and do not have
+        one, so it is deliberately UNSCOPED -- it cannot require the thing it exists
+        to provide. Everything it returns is already public.
+      summary: List publicly readable sites
+      parameters:
+      - in: query
+        name: format
+        schema:
+          type: string
+          enum:
+          - csv
+          - json
+      tags:
+      - sites
+      security:
+      - basicAuth: []
+      - cookieAuth: []
+      - jwtAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PublicSite'
+            text/csv:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PublicSite'
+          description: ''
   /sources/:
     get:
       operationId: sources_list
@@ -2279,6 +2368,8 @@ paths:
         - **search** - search by sponsor name
         - **sponsor_type** - filter by sponsor type; one of: industry,
           academic_medical, government, nonprofit, other
+        - **subject_id** - restrict to sponsors with >=1 trial in this subject
+        - **subjects_any** - comma-separated subject IDs, OR semantics
         - **ordering** - 'name' (default) or 'trials_count' (add '-' for reverse)
         - **page_size** - items per page (max 100)
 
@@ -2286,6 +2377,8 @@ paths:
         - Filter by type: `/sponsors/?sponsor_type=industry`
         - Search by name: `/sponsors/?search=novartis`
         - Most-trials first: `/sponsors/?ordering=-trials_count`
+        - Sponsors active in a subject: `/sponsors/?subject_id=1`
+        - Sponsors active in either subject: `/sponsors/?subjects_any=1,2`
       parameters:
       - in: query
         name: format
@@ -2347,6 +2440,25 @@ paths:
           * `government` - Government
           * `nonprofit` - Non-profit / patient organisation
           * `other` - Other
+      - in: query
+        name: subject_id
+        schema:
+          type: number
+        description: Restrict to sponsors with at least one trial in this subject
+          (see /subjects/). A Sponsor carries no subject of its own — it is reached
+          only through its trials, via Exists() on Trials.primary_sponsor_normalized
+          (see SITE-API-VISIBILITY project, site-scoped API visibility).
+      - in: query
+        name: subjects_any
+        schema:
+          type: array
+          items:
+            type: string
+        description: Comma-separated list of subject IDs, OR semantics — restrict
+          to sponsors with at least one trial in any of the listed subjects, e.g.
+          ?subjects_any=1,2. Same Exists()-on-trials approach as subject_id.
+        explode: false
+        style: form
       tags:
       - sponsors
       security:
@@ -2377,6 +2489,8 @@ paths:
         - **search** - search by sponsor name
         - **sponsor_type** - filter by sponsor type; one of: industry,
           academic_medical, government, nonprofit, other
+        - **subject_id** - restrict to sponsors with >=1 trial in this subject
+        - **subjects_any** - comma-separated subject IDs, OR semantics
         - **ordering** - 'name' (default) or 'trials_count' (add '-' for reverse)
         - **page_size** - items per page (max 100)
 
@@ -2384,6 +2498,8 @@ paths:
         - Filter by type: `/sponsors/?sponsor_type=industry`
         - Search by name: `/sponsors/?search=novartis`
         - Most-trials first: `/sponsors/?ordering=-trials_count`
+        - Sponsors active in a subject: `/sponsors/?subject_id=1`
+        - Sponsors active in either subject: `/sponsors/?subjects_any=1,2`
       parameters:
       - in: query
         name: format
@@ -5861,6 +5977,32 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/TrialSiteRow'
+    PublicSite:
+      type: object
+      description: |-
+        A publicly readable site, for the GET /sites/ discovery endpoint.
+
+        Deliberately minimal: just enough for a caller to learn which site IDs
+        exist so it can pass ?site_id=. Everything here is already public.
+
+        The MCP multi-tenancy spec proposes a richer per-site config endpoint
+        carrying subjects, prompts and documents. That project is unstarted; when
+        it lands, the two should converge on one endpoint rather than duplicate --
+        this payload is a strict subset of that one.
+      properties:
+        site_id:
+          type: integer
+          readOnly: true
+        domain:
+          type: string
+          readOnly: true
+        name:
+          type: string
+          readOnly: true
+      required:
+      - domain
+      - name
+      - site_id
     Source:
       type: object
       properties:
@@ -6428,6 +6570,11 @@ components:
             by TrialViewSet via prefetch_related('article_references__article'))
             to avoid one query per trial on list responses.
           readOnly: true
+        subjects:
+          type: array
+          items:
+            $ref: '#/components/schemas/Subjects'
+          readOnly: true
       required:
       - articles
       - countries_normalized
@@ -6443,6 +6590,7 @@ components:
       - sources
       - sponsor
       - study_type_normalized
+      - subjects
       - summary_plain_english
       - takeaways
       - team_categories
@@ -6792,6 +6940,11 @@ components:
             by TrialViewSet via prefetch_related('article_references__article'))
             to avoid one query per trial on list responses.
           readOnly: true
+        subjects:
+          type: array
+          items:
+            $ref: '#/components/schemas/Subjects'
+          readOnly: true
         trial_sites:
           type: array
           items:
@@ -6812,6 +6965,7 @@ components:
       - sources
       - sponsor
       - study_type_normalized
+      - subjects
       - summary_plain_english
       - takeaways
       - team_categories

--- a/django/schema.yml
+++ b/django/schema.yml
@@ -1797,6 +1797,8 @@ paths:
         # Query Parameters:
         - **team_id** - filter by team ID
         - **subject_id** - filter by subject ID
+        - **subjects_any** - comma-separated subject IDs, OR semantics: categories used
+          within ANY of the listed subjects (e.g. 1,10)
         - **category_id** - filter by specific category ID
         - **get_categories** - comma-separated list of category IDs (e.g., 1,2,3)
         - **include_authors** - Include top authors data (default: true)
@@ -1829,6 +1831,7 @@ paths:
         - `/categories/{id}/authors/` - Get detailed author statistics for a specific category
 
         # Examples:
+        - Categories in either subject: `/categories/?subjects_any=1,10`
         - Basic: `GET /categories/?team_id=1`
         - With subject: `GET /categories/?team_id=1&subject_id=2`
         - Date filtered: `GET /categories/?team_id=1&timeframe=year`
@@ -1993,6 +1996,8 @@ paths:
         # Query Parameters:
         - **team_id** - filter by team ID
         - **subject_id** - filter by subject ID
+        - **subjects_any** - comma-separated subject IDs, OR semantics: categories used
+          within ANY of the listed subjects (e.g. 1,10)
         - **category_id** - filter by specific category ID
         - **get_categories** - comma-separated list of category IDs (e.g., 1,2,3)
         - **include_authors** - Include top authors data (default: true)
@@ -2025,6 +2030,7 @@ paths:
         - `/categories/{id}/authors/` - Get detailed author statistics for a specific category
 
         # Examples:
+        - Categories in either subject: `/categories/?subjects_any=1,10`
         - Basic: `GET /categories/?team_id=1`
         - With subject: `GET /categories/?team_id=1&subject_id=2`
         - Date filtered: `GET /categories/?team_id=1&timeframe=year`

--- a/docs/03-api-and-rss-feeds.md
+++ b/docs/03-api-and-rss-feeds.md
@@ -216,6 +216,7 @@ GET /articles/?team_id=1&subjects=1,3&published_date_after=2022-06-01&format=csv
 | RSS feeds | `GET /feed/author/{orcid}/` | `orcid` (path) | |
 | RSS feeds | `GET /feed/trials/subject/{subject_slug}/` | `subject_slug` (path) | |
 | Stats | `GET /stats/` | `team`, `organization` (alias `org`), `subject`, `include_public` | See [Stats endpoint](#stats-endpoint) below |
+| Sites | `GET /sites/` | None | Publicly readable sites as `{site_id, domain, name}`. **Unscoped by design** — it is the discovery entry point for callers that need a `site_id`, so it cannot require one. Everything returned is already public |
 | Subscriptions | `POST /subscriptions/new/` | `first_name`, `last_name`, `email`, `profile`, `list` | POST-only; `GET` returns `405` with `Allow: POST` |
 
 ### Search endpoints

--- a/mcp-server/tests/test_schema_contract.py
+++ b/mcp-server/tests/test_schema_contract.py
@@ -110,6 +110,12 @@ KNOWN_UNEXPOSED_PARAMS = {
 		"countries",  # -> country / region
 	},
 	"/authors/": {
+		# Added by site-scoped API visibility Phase 2 as the scoping primitive
+		# for that project. No MCP tool exposes it yet: the MCP server gains
+		# subject scoping through its own multi-tenancy project, which binds a
+		# subject set per tenant rather than taking one per call. Revisit when
+		# that lands -- see MCP-MULTI-TENANCY-SPEC.md (local planning doc).
+		"subjects_any",
 		"format",
 		"author_id",  # redundant with get_author(author_id)
 		# Task 5 restored team_id/subject_id; category/date scoping wasn't
@@ -126,6 +132,12 @@ KNOWN_UNEXPOSED_PARAMS = {
 		"ordering",  # 7 rows total — nothing to usefully sort
 	},
 	"/categories/": {
+		# Added by site-scoped API visibility Phase 2 as the scoping primitive
+		# for that project. No MCP tool exposes it yet: the MCP server gains
+		# subject scoping through its own multi-tenancy project, which binds a
+		# subject set per tenant rather than taking one per call. Revisit when
+		# that lands -- see MCP-MULTI-TENANCY-SPEC.md (local planning doc).
+		"subjects_any",
 		"format",
 		"page",  # list_categories always fetches every page (get_all_pages)
 		"ordering",
@@ -142,6 +154,17 @@ KNOWN_UNEXPOSED_PARAMS = {
 		"timeframe",
 	},
 	"/sponsors/": {
+		# Sponsor subject scoping arrived with site-scoped API visibility
+		# Phase 2 (a sponsor is reached only through its trials, via
+		# Exists() on primary_sponsor_normalized). list_sponsors stays
+		# unscoped for now for the same reason as subjects_any below.
+		"subject_id",
+		# Added by site-scoped API visibility Phase 2 as the scoping primitive
+		# for that project. No MCP tool exposes it yet: the MCP server gains
+		# subject scoping through its own multi-tenancy project, which binds a
+		# subject set per tenant rather than taking one per call. Revisit when
+		# that lands -- see MCP-MULTI-TENANCY-SPEC.md (local planning doc).
+		"subjects_any",
 		"format",
 		"ordering",  # list_sponsors doesn't expose a sort; search narrows results instead
 	},


### PR DESCRIPTION
All six Phase 2 items. Additive and backwards compatible — **nothing consumes any of it yet**, and no call site is converted (that is Phase 4).

## What is here

| # | Item |
|---|---|
| 1 | `subjects_any` on `/categories/`, `/authors/`, `/sponsors/` |
| 2 | `/authors/` no longer requires `team_id` alongside a subject filter |
| 3 | `filter_relevant` / `filter_ml_threshold` honour a subject **list** |
| 4 | Subject scoping on `/sponsors/` |
| 5 | `subjects` on `TrialSerializer` |
| 6 | `GET /sites/` discovery endpoint |

`/articles/stats/` and `/trials/stats/` already inherit `subjects_any` from `ArticleFilter`/`TrialFilter`, so item 1 needed no work there.

## The one that is a correctness fix, not an addition

**Item 3.** `filter_relevant` and `filter_ml_threshold` read `subject_id` *singular* off the query string. Under a site scope that means `relevant=true` evaluates relevance across **every subject in the database** — returning articles whose only relevance is to another tenant's subject. Now resolved from `subject_id`, `subjects` and `subjects_any` together.

## Three things the tests caught

**An unguarded `int()` was a 500.** The first version of the two new `subjects_any` filters did `int(v)` without a guard, so `?subjects_any=foo` raised `ValueError` and returned a 500. `SubjectFilterMixin` already had the right shape — skip non-numeric values, and return `queryset.none()` rather than silently matching everything when none are usable. Both now follow it.

**Item 5 introduced an N+1.** Nested `subjects` on `TrialSerializer` costs a query per row on list endpoints. Three query-count tests failed. Prefetched in `TrialViewSet.get_queryset` **and** `TrialSearchView` — the latter builds its own queryset and inherits none of the former's.

**A test straddled a date boundary.** It set `published_date` to `now` while filtering `date_to` to today; `/authors/` parses `date_to` into a plain date, so an article published at any time today sorts after midnight and falls outside its own window. Fixed the fixture. Worth noting as a **pre-existing inconsistency**: `/articles/` documents `published_date_before` as including the full day, `/authors/` does not.

## The reverse contract check did its job

`mcp-server`'s `test_no_new_unreviewed_schema_params` flagged the three new schema params as unreviewed — exactly what it exists for. They are recorded in `KNOWN_UNEXPOSED_PARAMS` with the reason rather than wired into tools: the MCP server gains subject scoping through its own multi-tenancy project, which binds a subject set *per tenant* rather than taking one per call.

## Verification

- 3,343 Django tests pass
- 168 mcp-server tests pass
- `schema.yml` regenerated and committed; `/sites/` documented in `docs/03-api-and-rss-feeds.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)