### PR TITLE
Make the MCP server send site_id on every upstream API call

### DIFF
--- a/docs/07-mcp-server.md
+++ b/docs/07-mcp-server.md
@@ -84,10 +84,15 @@ server — see [Risks](#risks).
 
 ## Resources
 
-Slow-changing reference data, served with a 10-minute `ttlMs` cache hint (public scope, so
-clients can share one cached copy) so repeated conversations stop refetching it. The server
-also caches these two server-side, for the same 10 minutes (`gregory_mcp/cache.py`,
-`CATALOG_CACHE_TTL_MS` — the one constant both the hint and the actual cache derive from) —
+Slow-changing reference data, served with a 10-minute `ttlMs` cache hint so repeated
+conversations stop refetching it. The list of resource URIs (`resources/list`) is `public`
+scope — it never varies by site, so clients can share one cached copy. The content each one
+reads (`resources/read`) is `private` scope instead: it varies by the resolved site (see
+[Site scoping](#site-scoping-site_id) below), and a hint can't switch per call, so it has to
+assume the conservative value in both cases rather than let a shared cache hand one site's
+catalog to another's caller. The server also caches these two server-side, for the same 10
+minutes (`gregory_mcp/cache.py`, `CATALOG_CACHE_TTL_MS` — the one constant both the hint and
+the actual cache derive from), already keyed by site there —
 `/categories/` costs about a second per request and takes 12 requests to read in full, so
 this is the difference between a call that answers instantly and one that visibly stalls.
 Per-replica, in-process, with single-flight (concurrent cold-cache callers await one fetch
@@ -118,8 +123,12 @@ with no code change. See `mcp-server/gregory_mcp/config.py`.
 
 ### Site scoping (`?site_id=`)
 
-Every upstream call carries a `site_id` query parameter, resolved once per request
-(`mcp-server/gregory_mcp/site.py`) in this order:
+Every upstream call carries a `site_id` query parameter — except `GET /sites/` itself,
+the unscoped discovery call this resolution depends on (see step 2 below); it can't require
+the thing it exists to provide, and `test_sites_call_itself_carries_no_site_id` enforces
+that it never gets one, even transitively through the same client every other call goes
+through. Otherwise, `site_id` is resolved once per request (`mcp-server/gregory_mcp/site.py`)
+in this order:
 
 1. **`GREGORY_SITE_ID`** (env) — wins outright, without ever calling the API. Set this
    for a single-tenant deployment that should always report as one site regardless of

--- a/docs/07-mcp-server.md
+++ b/docs/07-mcp-server.md
@@ -116,6 +116,32 @@ The server proxies whatever instance `GREGORY_API_URL` names — one codebase se
 brain-regeneration.com, encefalites.pt, clinicaltrialupdates.com, or a local dev instance,
 with no code change. See `mcp-server/gregory_mcp/config.py`.
 
+### Site scoping (`?site_id=`)
+
+Every upstream call carries a `site_id` query parameter, resolved once per request
+(`mcp-server/gregory_mcp/site.py`) in this order:
+
+1. **`GREGORY_SITE_ID`** (env) — wins outright, without ever calling the API. Set this
+   for a single-tenant deployment that should always report as one site regardless of
+   how it's reached.
+2. **The inbound `Host` header** this server was reached on (nginx sets
+   `proxy_set_header Host $host` — see [Deployment](#deployment)), resolved against the
+   API's `GET /sites/` discovery endpoint (`{site_id, domain, name}` for every
+   `api_public` site) the same way `django/subscriptions/views.py`'s
+   `_find_site_by_domain()` resolves a domain: exact match, then one subdomain level
+   stripped — so `gregory-ai.brain-regeneration.com` resolves via
+   `brain-regeneration.com`. `GET /sites/` is cached in-process for the same 10 minutes
+   as the subjects/categories catalogs (`CATALOG_CACHE_TTL_MS`), not fetched per call.
+3. **Neither resolves** — the parameter is omitted, exactly like today's behaviour.
+   Never guessed, never an error from this server.
+
+This exists so the server keeps working, unchanged, once the site-scoped API visibility
+project's later phase makes the API fail closed for an anonymous caller that names no
+site. An unrecognised query parameter is ignored by django-filter today, so this is a
+no-op until that phase ships. Site resolution is transport-level (`GregoryClient.get()`
+and `CatalogCache`'s cache key, not a parameter on any tool) — no tool signature changes,
+and no LLM caller ever chooses a `site_id` itself.
+
 ## Auth
 
 None. The server exposes exactly what an anonymous API caller already sees — the same

--- a/mcp-server/gregory_mcp/__main__.py
+++ b/mcp-server/gregory_mcp/__main__.py
@@ -13,6 +13,7 @@ from .client import init_client
 from .config import load_settings
 from .logging_config import configure_logging
 from .server import build_server
+from .site import init_site_resolution
 
 logger = logging.getLogger("gregory_mcp")
 
@@ -21,6 +22,7 @@ def main() -> None:
 	settings = load_settings()
 	configure_logging(settings.log_level, settings.log_dir)
 	init_client(settings)
+	init_site_resolution(settings)
 
 	logger.info("gregory_mcp_starting", extra={"path": settings.api_base})
 	server = build_server()

--- a/mcp-server/gregory_mcp/cache.py
+++ b/mcp-server/gregory_mcp/cache.py
@@ -27,6 +27,7 @@ from collections.abc import Awaitable, Callable
 from typing import Any
 
 from .client import get_client
+from .site_context import get_current_site_id
 from .telemetry import record_cache_status
 
 # The single source of truth for how long the catalog is considered fresh.
@@ -64,7 +65,13 @@ class CatalogCache:
 		# no-params call would miss each other despite requesting the same data.
 		clean = {k: v for k, v in (params or {}).items() if v is not None}
 		items = tuple(sorted(clean.items()))
-		return f"{path}?{items!r}"
+		# Mixed in regardless of whether `params` itself carries a `site_id` —
+		# GregoryClient.get() adds it transport-side (see client.py), invisible
+		# to callers of this cache, so the key must read the same source of
+		# truth or two different sites would collide on one cache entry. This
+		# is the highest-risk failure mode here: one site's subjects/categories
+		# served to another's caller because the key didn't vary by site.
+		return f"{get_current_site_id()}:{path}?{items!r}"
 
 	def _lock_for(self, key: str) -> asyncio.Lock:
 		lock = self._locks.get(key)

--- a/mcp-server/gregory_mcp/client.py
+++ b/mcp-server/gregory_mcp/client.py
@@ -17,6 +17,7 @@ from typing import Any
 import httpx2
 
 from .config import Settings
+from .site_context import get_current_site_id
 from .telemetry import record_truncation_error, record_upstream_call, record_upstream_error
 
 logger = logging.getLogger("gregory_mcp.client")
@@ -99,8 +100,17 @@ class GregoryClient:
 
 		Query params with a `None` value are dropped so tools can pass every
 		optional filter unconditionally without hand-pruning the dict.
+
+		Adds `site_id` (site.py's per-request resolution — env override,
+		else the inbound Host resolved against `GET /sites/`, else omitted)
+		to every call unless the caller already set one explicitly. See
+		site.py's module docstring for why this is a transport-level
+		concern rather than a parameter on each tool.
 		"""
 		clean_params = {k: v for k, v in (params or {}).items() if v is not None}
+		site_id = get_current_site_id()
+		if site_id is not None and "site_id" not in clean_params:
+			clean_params["site_id"] = site_id
 		attempts = self._settings.max_retries + 1
 		last_exc: Exception | None = None
 

--- a/mcp-server/gregory_mcp/config.py
+++ b/mcp-server/gregory_mcp/config.py
@@ -16,6 +16,7 @@ class Settings:
 	max_retries: int
 	log_level: str
 	log_dir: str | None
+	site_id_override: int | None
 
 	@property
 	def api_base(self) -> str:
@@ -41,4 +42,26 @@ def load_settings() -> Settings:
 		max_retries=max(0, int(os.environ.get("GREGORY_MAX_RETRIES", "2"))),
 		log_level=os.environ.get("MCP_LOG_LEVEL", "INFO").upper(),
 		log_dir=os.environ.get("MCP_LOG_DIR", "").strip() or None,
+		site_id_override=_load_site_id_override(),
 	)
+
+
+def _load_site_id_override() -> int | None:
+	"""`GREGORY_SITE_ID`: pins every upstream call to one site, bypassing
+	Host-based resolution (gregory_mcp/site.py) entirely. For a single-tenant
+	deployment that doesn't want to depend on the inbound Host header (or on
+	the API's `GET /sites/` discovery endpoint existing/being reachable) at
+	all. Unset by default — Host resolution is the fallback in that case, not
+	an error.
+
+	Invalid (non-integer) values fail loudly at startup rather than silently
+	falling back to Host resolution — a typo'd env var here should surface as
+	a crash-on-boot, not as requests quietly landing on the wrong site's data.
+	"""
+	raw = os.environ.get("GREGORY_SITE_ID", "").strip()
+	if not raw:
+		return None
+	try:
+		return int(raw)
+	except ValueError:
+		raise RuntimeError(f"GREGORY_SITE_ID must be an integer Site ID, got {raw!r}") from None

--- a/mcp-server/gregory_mcp/server.py
+++ b/mcp-server/gregory_mcp/server.py
@@ -15,6 +15,7 @@ from mcp_types import ToolAnnotations
 from .cache import CATALOG_CACHE_TTL_MS
 from .prompts import register_prompts
 from .resources import register_resources
+from .site import SiteMiddleware
 from .telemetry import TelemetryMiddleware
 from .tools import articles, authors, catalog, stats, trials
 
@@ -64,7 +65,12 @@ def build_server() -> MCPServer:
 		),
 		version="0.1.0",
 		cache_hints=CACHE_HINTS,
-		middleware=[TelemetryMiddleware()],
+		# SiteMiddleware first (outermost): it resolves this request's site_id
+		# — env override, else inbound Host via GET /sites/ — before anything
+		# else runs, so a cold-cache /sites/ fetch's latency lands outside
+		# TelemetryMiddleware's own per-tool-call accounting rather than being
+		# smeared into whichever tool call happened to trigger it.
+		middleware=[SiteMiddleware(), TelemetryMiddleware()],
 	)
 
 	server.add_tool(catalog.list_subjects, annotations=READ_ONLY)

--- a/mcp-server/gregory_mcp/server.py
+++ b/mcp-server/gregory_mcp/server.py
@@ -23,9 +23,30 @@ READ_ONLY = ToolAnnotations(read_only_hint=True, idempotent_hint=True, open_worl
 
 # Reference-data resources change slowly; let clients cache them for as long as
 # the server itself does (CATALOG_CACHE_TTL_MS, see cache.py — one constant,
-# so the client-facing hint and the server's actual cache can't drift apart)
-# and share the cached value across callers (nothing in the payload is caller-specific).
-CATALOG_CACHE = CacheHint(ttl_ms=CATALOG_CACHE_TTL_MS, scope="public")
+# so the client-facing hint and the server's actual cache can't drift apart).
+#
+# resources/list only enumerates the two URIs below (gregory://subjects,
+# gregory://categories) — that list is identical for every caller regardless
+# of site, so it's safe to share across callers ("public", the only other
+# value CacheHint accepts per the 2026-07-28 SEP-2549 caching revision —
+# there's no "scoped to one site" option to ask for here).
+CATALOG_LIST_CACHE = CacheHint(ttl_ms=CATALOG_CACHE_TTL_MS, scope="public")
+
+# resources/read is different: SiteMiddleware (site.py) makes the actual
+# subjects/categories content this returns depend on the resolved site_id
+# for whichever request read it — CatalogCache._key() (cache.py) already
+# mixes site_id into the server-side cache key so this process never serves
+# one site's catalog to a caller resolved to another. But CacheHint is one
+# static value per method, chosen once here at server construction, not per
+# call — it can't switch between "public" and "private" depending on
+# whether *this particular* call resolved a site_id. Advertising it as
+# "public" would tell a client/proxy every response is shareable, undoing
+# that isolation the moment one exists (site A's catalog handed to site B's
+# caller from a shared cache). "private" is the safe choice in both cases a
+# single call can land in — it costs a no-site-resolved caller a caching
+# optimization it could technically have shared, but a resolved-site caller
+# can never leak into another's cache.
+CATALOG_READ_CACHE = CacheHint(ttl_ms=CATALOG_CACHE_TTL_MS, scope="private")
 
 # Tool/prompt schemas and server capabilities are static *between deploys* — unlike
 # the reference data above they change only when this code changes, so they get their
@@ -47,8 +68,8 @@ STATIC_CACHE = CacheHint(ttl_ms=30 * 60 * 1000, scope="public")
 # the hints it was constructed with, and a missing entry degrades silently to
 # ttlMs=0 ("never cache"), which is indistinguishable from working.
 CACHE_HINTS = {
-	"resources/list": CATALOG_CACHE,
-	"resources/read": CATALOG_CACHE,
+	"resources/list": CATALOG_LIST_CACHE,
+	"resources/read": CATALOG_READ_CACHE,
 	"tools/list": STATIC_CACHE,
 	"prompts/list": STATIC_CACHE,
 	"server/discover": STATIC_CACHE,

--- a/mcp-server/gregory_mcp/site.py
+++ b/mcp-server/gregory_mcp/site.py
@@ -35,6 +35,7 @@ it isn't defined here.
 
 from __future__ import annotations
 
+import json
 import logging
 from typing import Any
 from urllib.parse import urlparse
@@ -110,10 +111,18 @@ async def _fetch_site_directory() -> dict[str, int]:
 	to "no domain map available" — which resolves to omitting site_id, the
 	same safe fallback as an unresolvable Host — rather than breaking every
 	tool call on this server.
+
+	GregoryAPIError covers non-2xx statuses and transport failures, but a
+	2xx response isn't guaranteed to be JSON — an intermediate proxy can
+	return an HTML error page with a 200/204 (e.g. a misconfigured gateway
+	swallowing the real status). GregoryClient.get() calls response.json()
+	unguarded, so that shows up here as json.JSONDecodeError, not
+	GregoryAPIError — caught alongside it for the same degrade-not-raise
+	reason.
 	"""
 	try:
 		data = await get_client().get("/sites/")
-	except GregoryAPIError:
+	except (GregoryAPIError, json.JSONDecodeError):
 		logger.warning("gregory_sites_directory_unavailable", exc_info=True)
 		return {}
 	if not isinstance(data, list):

--- a/mcp-server/gregory_mcp/site.py
+++ b/mcp-server/gregory_mcp/site.py
@@ -1,0 +1,190 @@
+"""Per-request site resolution: makes every upstream call carry `?site_id=`.
+
+Why this exists: the site-scoped API visibility project's next phase will
+make the Gregory API fail closed — an anonymous caller that names no site
+gets a `400` (see `SITE-API-VISIBILITY-SPEC.md`, "Resolving a site without
+being told one"). This server calls the API anonymously
+(`gregory_mcp/client.py` sends only `Accept` and `User-Agent`), so every tool
+call would break the moment that phase ships, unless it already sends
+`?site_id=` by then. An unrecognised query parameter is ignored by
+django-filter today, so sending it now — on every endpoint, not only the two
+that currently declare it (`/articles/`, `/trials/`) — is a no-op until that
+phase ships and a forward-compatible default once it does.
+
+Resolution order for a request, cheapest/most-certain first:
+
+1. `GREGORY_SITE_ID` (env, loaded once at startup into
+   `Settings.site_id_override`) — wins outright, without ever touching the
+   network. A single-tenant deployment can pin this and depend on neither
+   the inbound Host header nor `GET /sites/` existing.
+2. The inbound `Host` header the MCP server was reached on (nginx sets
+   `proxy_set_header Host $host` — see docs/07-mcp-server.md), resolved to a
+   site_id via the API's `GET /sites/` discovery endpoint (added alongside
+   the visibility project, PR #859) — matched exactly the way
+   `django/subscriptions/views.py`'s `_find_site_by_domain()` matches a
+   domain: exact match, then one subdomain level stripped. Mirrored rather
+   than imported — this is a separate deployable with no Django import path.
+3. Neither resolves — omit the parameter. Exactly today's behaviour, so
+   nothing regresses; once the API fail-closes this surfaces as its own
+   `400`, which is the correct, visible failure. Never guess, never raise.
+
+The resolved value is exposed to the rest of the request via
+`site_context.get_current_site_id()` — see that module's docstring for why
+it isn't defined here.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from urllib.parse import urlparse
+
+from mcp.server.context import CallNext, HandlerResult, ServerMiddleware, ServerRequestContext
+
+from .cache import CATALOG_CACHE_TTL_MS, CatalogCache
+from .client import GregoryAPIError, get_client
+from .config import Settings
+from .site_context import _current_site_id
+
+logger = logging.getLogger("gregory_mcp.site")
+
+# GET /sites/ is unscoped, public, and slow-changing (it lists api_public
+# sites) — cached the same way subjects/categories are, with the same TTL,
+# rather than fetched per request. Its own CatalogCache instance, not the
+# shared one from cache.py: that one is deliberately narrow to
+# /subjects/+/categories/ (see its module docstring), and /sites/ isn't a
+# catalog a tool exposes to a caller.
+_site_directory_cache = CatalogCache(ttl_ms=CATALOG_CACHE_TTL_MS)
+
+# Set once at startup by init_site_resolution(); None means "no override,
+# resolve from Host". Not part of Settings' own consumers (client.py,
+# logging_config.py) needing this — only this module does.
+_site_id_override: int | None = None
+
+
+def init_site_resolution(settings: Settings) -> None:
+	"""Call once at startup, alongside client.init_client() — see __main__.py."""
+	global _site_id_override
+	_site_id_override = settings.site_id_override
+
+
+def reset_site_resolution() -> None:
+	"""Test-only: undo init_site_resolution() and drop the cached directory,
+	so one test's GREGORY_SITE_ID/`GET /sites/` state can't leak into
+	another's (mirrors cache.reset_catalog_cache())."""
+	global _site_id_override
+	_site_id_override = None
+	_site_directory_cache.clear()
+
+
+def _normalize_host(raw: str | None) -> str | None:
+	"""Same normalisation `_find_site_by_domain` applies: strip a port or
+	IPv6 brackets via urlparse, lowercase. Returns None for an empty/missing
+	header rather than an empty string, so callers can `if host is None`."""
+	if not raw:
+		return None
+	host = urlparse(f"//{raw}").hostname
+	return host.lower() if host else None
+
+
+def _match_domain(host: str, domain_map: dict[str, int]) -> int | None:
+	"""Exact match, then one subdomain level stripped — mirrors
+	`_find_site_by_domain` exactly: 'gregory-ai.brain-regeneration.com' has
+	no exact entry in the directory, so this falls back to
+	'brain-regeneration.com'."""
+	if host in domain_map:
+		return domain_map[host]
+	parts = host.split(".")
+	if len(parts) >= 3:
+		parent = ".".join(parts[1:])
+		if parent in domain_map:
+			return domain_map[parent]
+	return None
+
+
+async def _fetch_site_directory() -> dict[str, int]:
+	"""GET /sites/ -> {domain: site_id}.
+
+	Never raises: this endpoint is new (PR #859), so an instance running
+	slightly older Gregory code, or any other upstream failure, must degrade
+	to "no domain map available" — which resolves to omitting site_id, the
+	same safe fallback as an unresolvable Host — rather than breaking every
+	tool call on this server.
+	"""
+	try:
+		data = await get_client().get("/sites/")
+	except GregoryAPIError:
+		logger.warning("gregory_sites_directory_unavailable", exc_info=True)
+		return {}
+	if not isinstance(data, list):
+		# GET /sites/ returns a plain JSON array (see schema.yml), not the
+		# {count, next, results} shape client.get_all_pages() expects —
+		# an unexpected shape here means a contract change worth knowing
+		# about, not a crash.
+		logger.warning("gregory_sites_directory_unexpected_shape", extra={"type": type(data).__name__})
+		return {}
+	domain_map: dict[str, int] = {}
+	for row in data:
+		if not isinstance(row, dict):
+			continue
+		domain, site_id = row.get("domain"), row.get("site_id")
+		if isinstance(domain, str) and isinstance(site_id, int):
+			domain_map[domain.lower()] = site_id
+	return domain_map
+
+
+async def _get_site_directory() -> dict[str, int]:
+	return await _site_directory_cache.get_or_fetch("/sites/", None, _fetch_site_directory)
+
+
+async def resolve_site_id(host_header: str | None) -> int | None:
+	"""The site_id for a request that carried `host_header` as its Host,
+	or None if nothing resolves. See the module docstring for the order."""
+	if _site_id_override is not None:
+		return _site_id_override
+	host = _normalize_host(host_header)
+	if host is None:
+		return None
+	domain_map = await _get_site_directory()
+	return _match_domain(host, domain_map)
+
+
+def _extract_host_header(ctx: ServerRequestContext[Any, Any]) -> str | None:
+	"""The inbound Host header for this request, or None on a transport that
+	carries no headers (stdio) or a request object with none set.
+
+	`ctx.request` is the transport's raw request object (a Starlette
+	`Request` for streamable-http, `None` for stdio — see
+	`mcp.shared.message.ServerMessageMetadata.request_context`); its
+	`.headers` is a case-insensitive mapping, so `.get("host")` doesn't
+	depend on how the client or an intermediate proxy cased it.
+	"""
+	headers = getattr(ctx.request, "headers", None)
+	if headers is None:
+		return None
+	return headers.get("host")
+
+
+class SiteMiddleware(ServerMiddleware[Any]):
+	"""Resolves this request's site_id once, and makes it available for the
+	rest of the request via `site_context.get_current_site_id()` — read by
+	`GregoryClient.get()` (added to every upstream call) and
+	`CatalogCache._key()` (mixed into the cache key, so the shared
+	subjects/categories cache can never serve one site's catalog to
+	another's caller).
+
+	Registered outermost relative to TelemetryMiddleware (see server.py) so
+	a cold-cache `GET /sites/` fetch's latency is never smeared into some
+	unrelated tool call's own `upstream_ms`/`upstream_calls` telemetry.
+	"""
+
+	async def __call__(self, ctx: ServerRequestContext[Any, Any], call_next: CallNext) -> HandlerResult:
+		if ctx.request_id is None:
+			return await call_next(ctx)  # notifications never call the upstream API
+
+		site_id = await resolve_site_id(_extract_host_header(ctx))
+		token = _current_site_id.set(site_id)
+		try:
+			return await call_next(ctx)
+		finally:
+			_current_site_id.reset(token)

--- a/mcp-server/gregory_mcp/site_context.py
+++ b/mcp-server/gregory_mcp/site_context.py
@@ -1,0 +1,36 @@
+"""The in-flight request's resolved `site_id`, threaded via `ContextVar`
+rather than a parameter added to every tool signature — the same pattern
+`telemetry._accumulator` uses, and for the same reason (see telemetry.py's
+module docstring): `GregoryClient.get()` and `CatalogCache._key()` both need
+this value, and neither is called with a `Context`/request object in hand.
+
+Deliberately dependency-free. `client.py` (reads it on every upstream call)
+and `cache.py` (mixes it into every cache key) both import this module at
+module scope; `site.py` (which resolves the value — Host header, `GET
+/sites/`, `GREGORY_SITE_ID` — and depends on both `client.py` and `cache.py`)
+sets it. If this ContextVar lived in `site.py` instead, `client.py` and
+`cache.py` would have to import `site.py` to read it, and `site.py` already
+imports both of them — a real cycle at module-load time, the same shape
+telemetry.py's own docstring calls out for `query_shape`.
+"""
+
+from __future__ import annotations
+
+import contextvars
+
+_current_site_id: contextvars.ContextVar[int | None] = contextvars.ContextVar(
+	"gregory_mcp_site_id", default=None
+)
+
+
+def get_current_site_id() -> int | None:
+	"""The site_id resolved for the in-flight request.
+
+	`None` means "nothing resolved" — env override unset, Host unresolved,
+	`GET /sites/` unavailable, or simply outside a tracked request (most of
+	this test suite calls client/cache code directly, as
+	`telemetry.test_no_accumulator_active_is_a_silent_no_op` does for the
+	telemetry accumulator). Callers must treat `None` as "omit the
+	parameter" — never as site `0` or as a sentinel for "no site".
+	"""
+	return _current_site_id.get()

--- a/mcp-server/tests/conftest.py
+++ b/mcp-server/tests/conftest.py
@@ -9,6 +9,7 @@ from gregory_mcp.cache import reset_catalog_cache
 from gregory_mcp.client import GregoryClient
 from gregory_mcp.config import Settings
 from gregory_mcp.server import build_server
+from gregory_mcp.site import reset_site_resolution
 
 TEST_SETTINGS = Settings(
 	api_url="https://gregory.test",
@@ -19,6 +20,7 @@ TEST_SETTINGS = Settings(
 	max_retries=0,
 	log_level="ERROR",
 	log_dir=None,
+	site_id_override=None,
 )
 
 
@@ -49,7 +51,9 @@ def mock_gregory(monkeypatch):
 	Resets the process-wide catalog cache (see gregory_mcp/cache.py) before
 	and after each test — it's a module-level singleton, so without this a
 	list_subjects()/list_categories() call in one test could be served a
-	cached result left behind by a completely different test.
+	cached result left behind by a completely different test. Also resets
+	gregory_mcp.site's module-level state (the GREGORY_SITE_ID override and
+	the cached /sites/ directory) for the same reason.
 	"""
 	import gregory_mcp.client as client_module
 
@@ -59,6 +63,7 @@ def mock_gregory(monkeypatch):
 
 	monkeypatch.setattr(client_module, "_client", client)
 	reset_catalog_cache()
+	reset_site_resolution()
 
 	class Handle:
 		def set_handler(self, fn):
@@ -70,6 +75,7 @@ def mock_gregory(monkeypatch):
 
 	yield Handle()
 	reset_catalog_cache()
+	reset_site_resolution()
 
 
 @pytest.fixture

--- a/mcp-server/tests/test_cache.py
+++ b/mcp-server/tests/test_cache.py
@@ -6,6 +6,7 @@ import httpx2
 import pytest
 
 from gregory_mcp.cache import CatalogCache, get_all_pages_cached, get_catalog_cache, reset_catalog_cache
+from gregory_mcp.site_context import _current_site_id
 from gregory_mcp.tools.articles import search_articles
 from gregory_mcp.tools.catalog import list_categories, list_subjects
 
@@ -91,6 +92,70 @@ async def test_different_params_are_different_keys():
 	assert len(calls) == 2
 
 
+async def test_different_current_site_ids_are_different_keys():
+	"""The highest-risk failure mode here: without this, site A's caller
+	could be served site B's cached subjects/categories, because the two
+	calls look identical from CatalogCache's own params — the site_id that
+	distinguishes them is added transport-side by GregoryClient.get(), not
+	passed into `params` by the caller."""
+	cache = CatalogCache()
+	calls = []
+
+	async def fetch():
+		calls.append(1)
+		return [f"row-for-call-{len(calls)}"]
+
+	token_a = _current_site_id.set(1)
+	try:
+		result_a = await cache.get_or_fetch("/subjects/", {"team_id": 1}, fetch)
+	finally:
+		_current_site_id.reset(token_a)
+
+	token_b = _current_site_id.set(2)
+	try:
+		result_b = await cache.get_or_fetch("/subjects/", {"team_id": 1}, fetch)
+	finally:
+		_current_site_id.reset(token_b)
+
+	assert len(calls) == 2
+	assert result_a != result_b
+
+
+async def test_same_current_site_id_still_shares_the_key():
+	cache = CatalogCache()
+	calls = []
+
+	async def fetch():
+		calls.append(1)
+		return ["row"]
+
+	token = _current_site_id.set(1)
+	try:
+		await cache.get_or_fetch("/subjects/", {"team_id": 1}, fetch)
+		await cache.get_or_fetch("/subjects/", {"team_id": 1}, fetch)
+	finally:
+		_current_site_id.reset(token)
+
+	assert len(calls) == 1
+
+
+async def test_no_current_site_id_is_its_own_stable_key():
+	"""Outside a tracked request (site_id unresolved, or most of this test
+	suite calling cache code directly) every caller shares the same
+	`None` bucket — unaffected by this change."""
+	cache = CatalogCache()
+	calls = []
+
+	async def fetch():
+		calls.append(1)
+		return ["row"]
+
+	await cache.get_or_fetch("/subjects/", {"team_id": 1}, fetch)
+	await cache.get_or_fetch("/subjects/", {"team_id": 1}, fetch)
+
+	assert len(calls) == 1
+
+
 async def test_single_flight_concurrent_cold_callers_fetch_once():
 	cache = CatalogCache()
 	calls = []
@@ -170,6 +235,38 @@ async def test_list_categories_uses_the_shared_cache(mock_gregory):
 	await list_categories(team_id=1)
 
 	assert len(calls) == 1
+
+
+async def test_list_subjects_does_not_leak_across_sites(mock_gregory):
+	"""End-to-end version of test_different_current_site_ids_are_different_keys,
+	through the actual tool rather than CatalogCache directly — confirms
+	list_subjects (and by the same code path, list_categories, and the
+	gregory://subjects / gregory://categories resources) never serve one
+	site's catalog to another's caller."""
+	site_a_subject = {"id": 1, "subject_name": "MS (site A)", "team_id": 1}
+	site_b_subject = {"id": 2, "subject_name": "MS (site B)", "team_id": 4}
+
+	def handler(request):
+		site_id = request.url.params.get("site_id")
+		row = site_b_subject if site_id == "2" else site_a_subject
+		return httpx2.Response(200, json={"next": None, "results": [row]})
+
+	mock_gregory.set_handler(handler)
+
+	token_a = _current_site_id.set(1)
+	try:
+		result_a = await list_subjects()
+	finally:
+		_current_site_id.reset(token_a)
+
+	token_b = _current_site_id.set(2)
+	try:
+		result_b = await list_subjects()
+	finally:
+		_current_site_id.reset(token_b)
+
+	assert result_a["subjects"] == [{"id": 1, "subject_name": "MS (site A)", "team_id": 1}]
+	assert result_b["subjects"] == [{"id": 2, "subject_name": "MS (site B)", "team_id": 4}]
 
 
 def test_get_catalog_cache_is_a_singleton():

--- a/mcp-server/tests/test_client.py
+++ b/mcp-server/tests/test_client.py
@@ -12,6 +12,7 @@ from gregory_mcp.client import (
 	GregoryClient,
 	GregoryPaginationTruncatedError,
 )
+from gregory_mcp.site_context import _current_site_id
 from tests.conftest import TEST_SETTINGS
 
 
@@ -210,6 +211,102 @@ async def test_get_all_pages_returns_everything_when_it_fits():
 	results = await client.get_all_pages("/subjects/", max_pages=5)
 
 	assert [r["id"] for r in results] == [1, 2]
+
+
+async def test_get_all_pages_carries_site_id_on_every_page():
+	client = GregoryClient(TEST_SETTINGS)
+	seen_site_ids = []
+
+	def handler(request):
+		seen_site_ids.append(request.url.params.get("site_id"))
+		page = request.url.params.get("page", "1")
+		if page == "1":
+			return httpx2.Response(200, json={"next": "https://x/?page=2", "results": [{"id": 1}]})
+		return httpx2.Response(200, json={"next": None, "results": [{"id": 2}]})
+
+	client._client._transport = httpx2.MockTransport(handler)
+
+	token = _current_site_id.set(3)
+	try:
+		await client.get_all_pages("/subjects/", max_pages=5)
+	finally:
+		_current_site_id.reset(token)
+
+	assert seen_site_ids == ["3", "3"]
+
+
+async def test_no_site_id_in_context_means_no_site_id_param():
+	client = GregoryClient(TEST_SETTINGS)
+	seen = {}
+
+	def handler(request):
+		seen.update(request.url.params)
+		return httpx2.Response(200, json={})
+
+	client._client._transport = httpx2.MockTransport(handler)
+
+	await client.get("/articles/", {"team_id": 1})
+
+	assert "site_id" not in seen
+
+
+async def test_current_site_id_is_added_to_every_call():
+	client = GregoryClient(TEST_SETTINGS)
+	seen = {}
+
+	def handler(request):
+		seen.update(request.url.params)
+		return httpx2.Response(200, json={})
+
+	client._client._transport = httpx2.MockTransport(handler)
+
+	token = _current_site_id.set(3)
+	try:
+		await client.get("/articles/", {"team_id": 1})
+	finally:
+		_current_site_id.reset(token)
+
+	assert seen == {"team_id": "1", "site_id": "3"}
+
+
+async def test_current_site_id_is_added_even_with_no_other_params():
+	"""Detail endpoints (get_article, get_trial, ...) call client.get() with
+	no params dict at all — site_id must still be added transport-side."""
+	client = GregoryClient(TEST_SETTINGS)
+	seen = {}
+
+	def handler(request):
+		seen.update(request.url.params)
+		return httpx2.Response(200, json={})
+
+	client._client._transport = httpx2.MockTransport(handler)
+
+	token = _current_site_id.set(3)
+	try:
+		await client.get("/articles/123/")
+	finally:
+		_current_site_id.reset(token)
+
+	assert seen == {"site_id": "3"}
+
+
+async def test_caller_supplied_site_id_is_not_overridden():
+	client = GregoryClient(TEST_SETTINGS)
+	seen = {}
+
+	def handler(request):
+		seen.update(request.url.params)
+		return httpx2.Response(200, json={})
+
+	client._client._transport = httpx2.MockTransport(handler)
+
+	token = _current_site_id.set(3)
+	try:
+		await client.get("/articles/", {"site_id": 99})
+	finally:
+		_current_site_id.reset(token)
+
+	assert seen == {"site_id": "99"}
 
 
 async def test_get_all_pages_raises_rather_than_silently_truncating():

--- a/mcp-server/tests/test_config.py
+++ b/mcp-server/tests/test_config.py
@@ -45,3 +45,29 @@ def test_log_dir_passes_through(monkeypatch):
 	settings = load_settings()
 
 	assert settings.log_dir == "/var/log/gregory-mcp"
+
+
+def test_site_id_override_defaults_to_none(monkeypatch):
+	monkeypatch.setenv("GREGORY_API_URL", "https://gregory.test")
+	monkeypatch.delenv("GREGORY_SITE_ID", raising=False)
+
+	settings = load_settings()
+
+	assert settings.site_id_override is None
+
+
+def test_site_id_override_parses_int(monkeypatch):
+	monkeypatch.setenv("GREGORY_API_URL", "https://gregory.test")
+	monkeypatch.setenv("GREGORY_SITE_ID", "3")
+
+	settings = load_settings()
+
+	assert settings.site_id_override == 3
+
+
+def test_site_id_override_rejects_non_integer(monkeypatch):
+	monkeypatch.setenv("GREGORY_API_URL", "https://gregory.test")
+	monkeypatch.setenv("GREGORY_SITE_ID", "brain-regeneration")
+
+	with pytest.raises(RuntimeError, match="GREGORY_SITE_ID"):
+		load_settings()

--- a/mcp-server/tests/test_schema_contract.py
+++ b/mcp-server/tests/test_schema_contract.py
@@ -82,7 +82,11 @@ def test_detail_endpoint_exists_in_schema(fn, path, schema_params):
 KNOWN_UNEXPOSED_PARAMS = {
 	"/articles/": {
 		"format",  # CSV — no export tool, see STAGE-2 plan "Risks"
-		"site_id",  # Django Site scoping; MCP client is already scoped to one instance
+		# Not a *tool* parameter — no LLM caller ever chooses it. GregoryClient.get()
+		# adds it transport-side to every upstream call from its own per-request
+		# resolution (env override, else inbound Host via GET /sites/) — see
+		# gregory_mcp/site.py. Absent from every tool's signature by design.
+		"site_id",
 		"source_id",  # niche — callers don't know source IDs
 		"subjects",
 		"subjects_any",  # multi-subject AND/OR; subject_id covers the common case
@@ -91,7 +95,7 @@ KNOWN_UNEXPOSED_PARAMS = {
 	},
 	"/trials/": {
 		"format",
-		"site_id",
+		"site_id",  # see /articles/'s entry above — same transport-level injection
 		"source_id",
 		"subjects",
 		"subjects_any",
@@ -193,6 +197,19 @@ def test_no_new_unreviewed_schema_params(fn, path, non_filter_args, schema_param
 		"account for. Add it to the tool, or to KNOWN_UNEXPOSED_PARAMS with "
 		"a reason if it's deliberately out of scope."
 	)
+
+
+def test_site_id_declared_endpoints_match_what_this_audit_found(schema_params):
+	"""Not a correctness requirement on GregoryClient.get() — it sends
+	`site_id` to every endpoint regardless (see gregory_mcp/site.py's module
+	docstring for why that's deliberate and safe). This is a drift detector:
+	it records which endpoints declare `site_id` as of the audit that
+	justified that design, so a schema regeneration that adds or removes it
+	somewhere is caught and reviewed rather than silently changing which
+	endpoints the parameter actually *does* something on.
+	"""
+	declared = {path for path, params in schema_params.items() if "site_id" in params}
+	assert declared == {"/articles/", "/articles/search/", "/trials/", "/trials/search/", "/trials/sites/"}
 
 
 def test_stats_endpoints_exist_in_schema(schema_params):

--- a/mcp-server/tests/test_server.py
+++ b/mcp-server/tests/test_server.py
@@ -71,10 +71,38 @@ def test_every_cacheable_method_carries_a_hint():
 	):
 		assert method in hints, f"{method} has no cache hint — clients will refetch it every time"
 		assert hints[method].ttl_ms > 0, f"{method} hint is ttl_ms=0, same as no hint at all"
+
+
+def test_hints_for_site_invariant_methods_are_shareable():
+	"""Every cacheable method except resources/read returns content that
+	never depends on which site (Host/GREGORY_SITE_ID — see site.py) made
+	the request: tool/prompt schemas are the same for every caller, and so
+	is the *list* of available resource URIs (resources/list). A shared
+	cache should be allowed to serve those."""
+	from gregory_mcp.server import CACHE_HINTS as hints
+
+	for method in ("tools/list", "prompts/list", "resources/list", "server/discover"):
 		assert hints[method].scope == "public", (
-			f"{method} is identical for every caller (this server has no auth), "
+			f"{method} is identical for every caller regardless of site, "
 			"so a shared cache should be allowed to serve it"
 		)
+
+
+def test_resources_read_hint_is_private_so_a_proxy_cant_leak_across_sites():
+	"""resources/read is the exception: SiteMiddleware makes the actual
+	subjects/categories content it returns depend on the resolved site_id
+	for that call (see CatalogCache._key() in cache.py, which mixes site_id
+	into the server-side cache key for exactly this reason). CacheHint has
+	no per-call scope — it's one static value for the whole method, chosen
+	once here — so it must be "private" (the only other value the SDK's
+	CacheHint accepts, per the 2026-07-28 SEP-2549 caching revision):
+	advertising "public" would tell a client/proxy that any two callers'
+	resources/read responses are interchangeable, letting a shared cache
+	hand site A's catalog to site B's caller and undo the server-side
+	per-site isolation entirely."""
+	from gregory_mcp.server import CACHE_HINTS as hints
+
+	assert hints["resources/read"].scope == "private"
 
 
 def test_client_exposes_no_write_methods():

--- a/mcp-server/tests/test_site.py
+++ b/mcp-server/tests/test_site.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import httpx2
+import pytest
+from mcp.server.context import ServerRequestContext
+
+from gregory_mcp.site import (
+	SiteMiddleware,
+	_extract_host_header,
+	_match_domain,
+	_normalize_host,
+	init_site_resolution,
+	resolve_site_id,
+)
+from gregory_mcp.site_context import get_current_site_id
+from tests.conftest import TEST_SETTINGS
+
+
+# --- host normalisation -----------------------------------------------------
+
+
+def test_normalize_host_lowercases():
+	assert _normalize_host("Gregory-AI.Brain-Regeneration.COM") == "gregory-ai.brain-regeneration.com"
+
+
+def test_normalize_host_strips_port():
+	assert _normalize_host("gregory-ai.brain-regeneration.com:8443") == "gregory-ai.brain-regeneration.com"
+
+
+def test_normalize_host_strips_ipv6_brackets():
+	assert _normalize_host("[::1]:8001") == "::1"
+
+
+def test_normalize_host_none_or_empty_is_none():
+	assert _normalize_host(None) is None
+	assert _normalize_host("") is None
+
+
+# --- domain matching (mirrors django/subscriptions/views.py:_find_site_by_domain) --
+
+
+def test_match_domain_exact():
+	domain_map = {"brain-regeneration.com": 3, "encefalites.pt": 7}
+	assert _match_domain("brain-regeneration.com", domain_map) == 3
+
+
+def test_match_domain_falls_back_one_subdomain_level():
+	domain_map = {"brain-regeneration.com": 3}
+	# The MCP server's own deployed host, per docs/07-mcp-server.md.
+	assert _match_domain("gregory-ai.brain-regeneration.com", domain_map) == 3
+
+
+def test_match_domain_two_levels_stripped_is_not_attempted():
+	# _find_site_by_domain only ever strips ONE subdomain level.
+	domain_map = {"brain-regeneration.com": 3}
+	assert _match_domain("a.b.brain-regeneration.com", domain_map) is None
+
+
+def test_match_domain_no_match_returns_none():
+	domain_map = {"brain-regeneration.com": 3}
+	assert _match_domain("unrelated.example.com", domain_map) is None
+
+
+def test_match_domain_bare_domain_has_no_parent_to_strip():
+	# len(parts) < 3 — a two-label host has no "one subdomain level" to strip.
+	domain_map = {"other.com": 9}
+	assert _match_domain("example.com", domain_map) is None
+
+
+# --- resolve_site_id: env override wins outright ----------------------------
+
+
+async def test_env_override_wins_without_touching_the_network(mock_gregory):
+	calls = []
+	mock_gregory.set_handler(lambda request: (calls.append(1), httpx2.Response(200, json=[]))[1])
+	init_site_resolution(replace(TEST_SETTINGS, site_id_override=3))
+
+	result = await resolve_site_id("gregory-ai.brain-regeneration.com")
+
+	assert result == 3
+	assert calls == []  # GET /sites/ never called — the override short-circuits
+
+
+async def test_env_override_wins_even_with_no_host_header(mock_gregory):
+	init_site_resolution(replace(TEST_SETTINGS, site_id_override=5))
+	assert await resolve_site_id(None) == 5
+
+
+# --- resolve_site_id: Host resolution via GET /sites/ -----------------------
+
+
+def _sites_handler(rows):
+	return lambda request: httpx2.Response(200, json=rows)
+
+
+async def test_host_resolves_via_sites_directory(mock_gregory):
+	mock_gregory.set_handler(
+		_sites_handler([{"site_id": 3, "domain": "brain-regeneration.com", "name": "Brain Regeneration"}])
+	)
+
+	result = await resolve_site_id("gregory-ai.brain-regeneration.com")
+
+	assert result == 3
+
+
+async def test_sites_directory_is_cached_across_resolutions(mock_gregory):
+	mock_gregory.set_handler(
+		_sites_handler([{"site_id": 3, "domain": "brain-regeneration.com", "name": "Brain Regeneration"}])
+	)
+
+	await resolve_site_id("gregory-ai.brain-regeneration.com")
+	await resolve_site_id("gregory-ai.brain-regeneration.com")
+	await resolve_site_id("brain-regeneration.com")
+
+	sites_requests = [r for r in mock_gregory.requests if r.url.path == "/sites/"]
+	assert len(sites_requests) == 1
+
+
+async def test_no_host_header_omits_without_calling_the_api(mock_gregory):
+	calls = []
+	mock_gregory.set_handler(lambda request: (calls.append(1), httpx2.Response(200, json=[]))[1])
+
+	assert await resolve_site_id(None) is None
+	assert calls == []
+
+
+async def test_unresolvable_host_returns_none(mock_gregory):
+	mock_gregory.set_handler(_sites_handler([{"site_id": 3, "domain": "brain-regeneration.com", "name": "BR"}]))
+
+	assert await resolve_site_id("totally-unrelated-domain.example") is None
+
+
+async def test_sites_endpoint_missing_degrades_to_none_rather_than_raising(mock_gregory):
+	"""GET /sites/ is new (PR #859) — an older API build 404s. That must
+	degrade to "no domain map", not break every tool call."""
+	mock_gregory.set_handler(lambda request: httpx2.Response(404, text="not found"))
+
+	assert await resolve_site_id("gregory-ai.brain-regeneration.com") is None
+
+
+async def test_sites_endpoint_unexpected_shape_degrades_to_none(mock_gregory):
+	"""GET /sites/ is documented as a plain JSON array, not the paginated
+	{count, next, results} shape other list endpoints use — guard against a
+	future shape change surfacing as a crash instead of a degraded result."""
+	mock_gregory.set_handler(lambda request: httpx2.Response(200, json={"results": []}))
+
+	assert await resolve_site_id("gregory-ai.brain-regeneration.com") is None
+
+
+async def test_sites_call_itself_carries_no_site_id(mock_gregory):
+	"""GET /sites/ is the discovery entry point and is deliberately unscoped
+	— it "cannot require the thing it exists to provide" (schema.yml). It
+	must never carry a site_id of its own, even transitively through the
+	same client.get() every other call goes through."""
+	mock_gregory.set_handler(_sites_handler([]))
+
+	await resolve_site_id("gregory-ai.brain-regeneration.com")
+
+	sites_requests = [r for r in mock_gregory.requests if r.url.path == "/sites/"]
+	assert len(sites_requests) == 1
+	assert "site_id" not in sites_requests[0].url.params
+
+
+# --- SiteMiddleware ----------------------------------------------------------
+
+
+class _FakeRequest:
+	def __init__(self, headers: dict[str, str]):
+		self.headers = headers
+
+
+def _make_ctx(*, request=None, request_id="req-1", method="tools/call"):
+	return ServerRequestContext(
+		session=None,
+		lifespan_context={},
+		protocol_version="2026-07-28",
+		method=method,
+		params={},
+		request_id=request_id,
+		request=request,
+	)
+
+
+async def test_extract_host_header_reads_the_request_headers():
+	ctx = _make_ctx(request=_FakeRequest({"host": "gregory-ai.brain-regeneration.com"}))
+	assert _extract_host_header(ctx) == "gregory-ai.brain-regeneration.com"
+
+
+def test_extract_host_header_none_on_stdio_shaped_request():
+	ctx = _make_ctx(request=None)
+	assert _extract_host_header(ctx) is None
+
+
+async def test_middleware_sets_site_id_for_the_duration_of_the_call(mock_gregory):
+	mock_gregory.set_handler(_sites_handler([{"site_id": 3, "domain": "brain-regeneration.com", "name": "BR"}]))
+	seen_during_call = {}
+
+	async def call_next(ctx):
+		seen_during_call["site_id"] = get_current_site_id()
+		return {"ok": True}
+
+	ctx = _make_ctx(request=_FakeRequest({"host": "gregory-ai.brain-regeneration.com"}))
+	result = await SiteMiddleware()(ctx, call_next)
+
+	assert result == {"ok": True}
+	assert seen_during_call["site_id"] == 3
+	assert get_current_site_id() is None  # reset once the request finishes
+
+
+async def test_middleware_resets_even_when_call_next_raises(mock_gregory):
+	mock_gregory.set_handler(_sites_handler([{"site_id": 3, "domain": "brain-regeneration.com", "name": "BR"}]))
+
+	async def call_next(ctx):
+		raise RuntimeError("boom")
+
+	ctx = _make_ctx(request=_FakeRequest({"host": "gregory-ai.brain-regeneration.com"}))
+	with pytest.raises(RuntimeError):
+		await SiteMiddleware()(ctx, call_next)
+
+	assert get_current_site_id() is None
+
+
+async def test_middleware_skips_resolution_for_notifications(mock_gregory):
+	calls = []
+	mock_gregory.set_handler(lambda request: (calls.append(1), httpx2.Response(200, json=[]))[1])
+
+	async def call_next(ctx):
+		return None
+
+	ctx = _make_ctx(request=_FakeRequest({"host": "gregory-ai.brain-regeneration.com"}), request_id=None)
+	await SiteMiddleware()(ctx, call_next)
+
+	assert calls == []  # no /sites/ fetch triggered for a notification
+
+
+async def test_middleware_with_no_matching_site_calls_upstream_without_site_id(mock_gregory):
+	def handler(request):
+		if request.url.path == "/sites/":
+			return httpx2.Response(
+				200, json=[{"site_id": 3, "domain": "brain-regeneration.com", "name": "BR"}]
+			)
+		return httpx2.Response(200, json={"next": None, "results": []})
+
+	mock_gregory.set_handler(handler)
+
+	from gregory_mcp.tools.catalog import list_subjects
+
+	async def call_next(ctx):
+		return await list_subjects()
+
+	# A host that resolves to no known site.
+	ctx = _make_ctx(request=_FakeRequest({"host": "unrelated.example.com"}))
+	await SiteMiddleware()(ctx, call_next)
+
+	subjects_requests = [r for r in mock_gregory.requests if r.url.path == "/subjects/"]
+	assert len(subjects_requests) == 1
+	assert "site_id" not in subjects_requests[0].url.params

--- a/mcp-server/tests/test_site.py
+++ b/mcp-server/tests/test_site.py
@@ -257,3 +257,16 @@ async def test_middleware_with_no_matching_site_calls_upstream_without_site_id(m
 	subjects_requests = [r for r in mock_gregory.requests if r.url.path == "/subjects/"]
 	assert len(subjects_requests) == 1
 	assert "site_id" not in subjects_requests[0].url.params
+
+
+async def test_sites_endpoint_non_json_body_degrades_to_none(mock_gregory):
+	"""A 2xx response with a non-JSON body (e.g. an HTML proxy/gateway error
+	page returned with a 200/204) makes response.json() raise
+	json.JSONDecodeError from inside GregoryClient.get() — a different
+	exception than GregoryAPIError, which only covers HTTP error statuses
+	and transport failures. _fetch_site_directory's docstring promises it
+	never raises; this must degrade to "no domain map" like every other
+	failure mode here, not propagate and fail the whole request."""
+	mock_gregory.set_handler(lambda request: httpx2.Response(200, text="<html>Bad Gateway</html>"))
+
+	assert await resolve_site_id("gregory-ai.brain-regeneration.com") is None


### PR DESCRIPTION
## Summary

- Ships the "ordered cutover" trick for the site-scoped API visibility project's next phase: that phase will make the Gregory API fail closed for an anonymous caller that names no site, and the MCP server calls the API anonymously (`Accept` + `User-Agent` only) — so this must land and deploy *before* that phase merges, or every tool call breaks.
- `gregory_mcp/site.py` resolves a `site_id` once per inbound request: `GREGORY_SITE_ID` (env) wins outright; otherwise the inbound `Host` header this server was reached on (nginx sends the real one — see `docs/07-mcp-server.md`) is resolved against the API's `GET /sites/` discovery endpoint, mirroring `django/subscriptions/views.py`'s `_find_site_by_domain()` exactly (exact match, then one subdomain level stripped); otherwise the parameter is omitted, exactly like today's behaviour — never guessed, never an error from this server.
- The resolved value is threaded via a `ContextVar` (`gregory_mcp/site_context.py`) rather than a parameter on every tool, the same pattern `telemetry.py`'s `_accumulator` already uses. `GregoryClient.get()` (and therefore `get_all_pages()`) adds it to every upstream call; `CatalogCache._key()` also reads it, so the shared subjects/categories cache can't serve one site's catalog to another site's caller (the highest-risk failure mode here — covered by `test_list_subjects_does_not_leak_across_sites` and the `CatalogCache` key tests).
- `GET /sites/` itself is cached in-process with the same TTL as the other reference-data catalogs, and is never called at all when `GREGORY_SITE_ID` is set — a single-tenant deployment can pin it without depending on Host resolution or on that endpoint existing/being reachable.
- No Django changes (the API side, `GET /sites/`, merged in #859 just ahead of this PR). No MCP tool signature changes — `site_id` is a transport-level concern, invisible to `test_schema_contract.py`'s per-tool-argument checks.

## How site resolution works (and what's out of scope)

This implements *only* "send `site_id`" — not the unstarted MCP multi-tenancy design (per-tenant `MCPServer` instances, `X-Gregory-Site-Id`, per-tenant prompts/subjects).

**Header reachability, verified against the installed `mcp==2.0.0` SDK rather than assumed:** the streamable-http transport hands `ServerRequestContext.request` a Starlette `Request` (`None` on stdio), whose `.headers` is a case-insensitive mapping. `SiteMiddleware` (registered outermost, ahead of `TelemetryMiddleware`, so a cold-cache `/sites/` fetch's latency never lands in some unrelated tool's own `upstream_ms`) reads `ctx.request.headers.get("host")` directly — no per-request Host reachability problem to fall back from.

**Which endpoints get `site_id`, and why all of them:** `schema.yml` currently declares `site_id` only on `/articles/`, `/articles/search/`, `/trials/`, `/trials/search/`, and `/trials/sites/` (a new `test_site_id_declared_endpoints_match_what_this_audit_found` pins this so a schema regen that changes it gets caught). Every other endpoint the MCP server calls — `/articles/{id}/`, `/trials/{id}/`, `/authors/`, `/authors/{id}/`, `/authors/{id}/coauthors/`, `/subjects/`, `/categories/`, `/sponsors/`, `/stats/`, `/articles/stats/`, `/trials/stats/` — does **not** declare it. It still gets sent there: the future fail-closed phase resolves "who is asking" from the raw `?site_id=` query string for *every* anonymous endpoint (per `SITE-API-VISIBILITY-SPEC.md`'s resolution order), not only the ones whose `FilterSet` happens to declare it as a named filter — so sending it everywhere is what keeps `get_article`/`get_trial`/etc. working once that phase ships, not just the two search tools. `GET /sites/` itself is the one deliberate exception — the discovery endpoint can't require the thing it exists to provide, and `test_sites_call_itself_carries_no_site_id` asserts that call never carries one.

## Test plan

- [x] `cd mcp-server && pytest` — 205 passed (168 pre-existing + 37 new, across `test_site.py`, `test_client.py`, `test_cache.py`, `test_config.py`, `test_schema_contract.py`)
- [x] `uvx ruff@0.16.00 check` over every changed/new file — clean
- [x] Manual end-to-end smoke test: `GREGORY_SITE_ID=3` resolves without ever calling the network; Host-based resolution against a mocked `GET /sites/` resolves `gregory-ai.brain-regeneration.com` → site 3 via the one-subdomain-strip rule
- [x] Confirmed `CatalogCache` correctly varies by resolved site_id (`test_list_subjects_does_not_leak_across_sites`, `test_different_current_site_ids_are_different_keys`) — the explicitly-flagged highest-risk failure mode
- [ ] Deploy and confirm against a live instance before the visibility project's fail-closed phase merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)