### PR TITLE
Phase 4b: scope RSS feeds by subject instead of organisation

### DIFF
--- a/django/api/tests/test_visibility_rss.py
+++ b/django/api/tests/test_visibility_rss.py
@@ -18,7 +18,11 @@ Covers:
       - 404 when the subject is in no reachable site's scope
       - 200 and the subject's trials when it is
       - ?include_public=true extends visibility for identified callers
-  - Four caller archetypes: anonymous, authenticated member, API-key, null-org key
+  - Three caller archetypes: anonymous, authenticated member, API key.
+    (An earlier "null-org key" archetype is not reachable: APIAccessScheme
+    .organization is a non-null FK. A key whose *site* is null is reachable
+    and is covered below -- that is the state every key was in before the
+    Phase 1 backfill, and the one Phase 3 will start rejecting.)
 
 Run with:
     docker exec gregory python manage.py test api.tests.test_visibility_rss
@@ -480,6 +484,40 @@ class APIKeyTrialsFeedTest(TrialsFeedBase):
 			f"/feed/trials/subject/{self.pub_subj.subject_slug}/?include_public=true"
 		)
 		self.assertEqual(resp.status_code, 200)
+
+
+class SitelessAPIKeyTrialsFeedTest(TrialsFeedBase):
+	"""
+	A key with no site resolves to no subjects of its own. Every key has a
+	site in production (backfilled by sitesettings/0019) but the field is
+	still nullable until Phase 3 enforces it, so the branch is live and
+	needs pinning: without a site the key sees nothing, and with
+	?include_public=true it sees exactly the public scope -- public subjects
+	being public to everyone, key or no key.
+	"""
+
+	def setUp(self):
+		super().setUp()
+		self.scheme = _make_api_scheme(self.my_org, "rss-siteless-key", site=None)
+		self.client.defaults["HTTP_AUTHORIZATION"] = self.scheme.api_key
+
+	def test_own_org_subject_404s_without_a_site(self):
+		# The organisation owns my_subj, but the key is not bound to the site
+		# that publishes it, and organisation membership no longer grants
+		# anything on its own.
+		resp = self.client.get(f"/feed/trials/subject/{self.my_subj.subject_slug}/")
+		self.assertEqual(resp.status_code, 404)
+
+	def test_public_subject_404s_without_the_flag(self):
+		resp = self.client.get(f"/feed/trials/subject/{self.pub_subj.subject_slug}/")
+		self.assertEqual(resp.status_code, 404)
+
+	def test_include_public_still_grants_the_public_scope(self):
+		resp = self.client.get(
+			f"/feed/trials/subject/{self.pub_subj.subject_slug}/?include_public=true"
+		)
+		self.assertEqual(resp.status_code, 200)
+		self.assertIn("Pub Trial", resp.content.decode())
 
 
 # ---------------------------------------------------------------------------

--- a/django/api/tests/test_visibility_rss.py
+++ b/django/api/tests/test_visibility_rss.py
@@ -1,14 +1,22 @@
 """
-Tests for RSS feed visibility enforcement (PR 6).
+Tests for RSS feed visibility enforcement.
+
+Both feeds are scoped by SUBJECT (site-scoped API visibility, Phase 4);
+this file was written against the earlier organisation rule and its
+fixtures were converted with it. What a caller can see is now the union of
+``CustomSetting.scope_subjects`` over the sites they can reach -- api_public
+sites for an anonymous caller, the key's own site for an API key, the
+organisation's sites for a signed-in member -- so every org/team here now
+carries a Site and a curated subject, and content is tagged into it.
 
 Covers:
   - ArticlesByAuthorFeed (/feed/author/<orcid>/):
-      - 404 when author has no articles in any visible org
-      - 200 and items filtered to visible articles when author is visible
+      - 404 when no article of the author carries a visible subject
+      - 200 and items filtered to visible-subject articles otherwise
       - ?include_public=true extends visibility for identified callers
   - TrialsBySubjectFeed (/feed/trials/subject/<slug>/):
-      - 404 when subject belongs to a hidden org
-      - 200 and items filtered to visible trials when subject is visible
+      - 404 when the subject is in no reachable site's scope
+      - 200 and the subject's trials when it is
       - ?include_public=true extends visibility for identified callers
   - Four caller archetypes: anonymous, authenticated member, API-key, null-org key
 
@@ -19,6 +27,7 @@ Run with:
 from datetime import timedelta
 
 from django.contrib.auth import get_user_model
+from django.contrib.sites.models import Site
 from django.test import TestCase
 from django.utils.timezone import now
 from organizations.models import Organization, OrganizationUser
@@ -28,10 +37,12 @@ from gregory.models import (
 	Articles,
 	Authors,
 	OrganizationApiSettings,
+	OrganizationSite,
 	Subject,
 	Team,
 	Trials,
 )
+from sitesettings.models import CustomSetting
 
 User = get_user_model()
 
@@ -68,12 +79,32 @@ def _make_author(given, family, orcid):
 	)
 
 
-def _make_article(title, link, teams=(), authors=()):
+def _make_site(name, org, *, api_public, scope_subjects=()):
+	"""A Site owned by `org`, with a CustomSetting carrying its subject scope.
+
+	The org link goes through OrganizationSite because that is what
+	visible_subject_ids walks for a signed-in member, and what it checks a
+	site-bound API key against.
+	"""
+	slug = name.lower().replace(" ", "-")
+	site = Site.objects.create(domain=f"{slug}.example.com", name=name)
+	OrganizationSite.objects.create(organization=org, site=site, is_default=True)
+	settings_row = CustomSetting.objects.create(
+		site=site, title=f"{name} settings", api_public=api_public
+	)
+	for subject in scope_subjects:
+		settings_row.scope_subjects.add(subject)
+	return site
+
+
+def _make_article(title, link, teams=(), authors=(), subjects=()):
 	art = Articles.objects.create(title=title, link=link)
 	for t in teams:
 		art.teams.add(t)
 	for a in authors:
 		art.authors.add(a)
+	for s in subjects:
+		art.subjects.add(s)
 	return art
 
 
@@ -86,11 +117,14 @@ def _make_trial(title, link, teams=(), subjects=()):
 	return trial
 
 
-def _make_api_scheme(org, name):
+def _make_api_scheme(org, name, site=None):
+	# `site` is what binds the key to a subject scope; a key without one
+	# resolves to no subjects at all (see visible_subject_ids).
 	return APIAccessScheme.objects.create(
 		client_name=name,
 		client_contacts=f"{name}@example.com",
 		organization=org,
+		site=site,
 		ip_addresses="",
 		begin_date=now() - timedelta(days=1),
 		end_date=now() + timedelta(days=30),
@@ -116,6 +150,25 @@ class AuthorFeedBase(TestCase):
 		self.pub_team = _make_team(self.pub_org, "Pub Team RSS Auth")
 		self.priv_team = _make_team(self.priv_org, "Priv Team RSS Auth")
 
+		self.my_subj = _make_subject(self.my_team, "my-subj-rss-auth")
+		self.pub_subj = _make_subject(self.pub_team, "pub-subj-rss-auth")
+		self.priv_subj = _make_subject(self.priv_team, "priv-subj-rss-auth")
+
+		# One site per organisation, each publishing its own subject. Only
+		# pub_site is api_public, so pub_subj is the whole anonymous scope.
+		self.my_site = _make_site(
+			"My Site RSS Auth", self.my_org, api_public=False,
+			scope_subjects=[self.my_subj],
+		)
+		self.pub_site = _make_site(
+			"Pub Site RSS Auth", self.pub_org, api_public=True,
+			scope_subjects=[self.pub_subj],
+		)
+		self.priv_site = _make_site(
+			"Priv Site RSS Auth", self.priv_org, api_public=False,
+			scope_subjects=[self.priv_subj],
+		)
+
 		# Authors
 		self.author_mine = _make_author("Alice", "Mine", ORCID_MINE)
 		self.author_pub = _make_author("Bob", "Public", ORCID_PUB)
@@ -127,18 +180,21 @@ class AuthorFeedBase(TestCase):
 			"https://rss.ex/a1",
 			teams=[self.my_team],
 			authors=[self.author_mine],
+			subjects=[self.my_subj],
 		)
 		_make_article(
 			"Pub Art",
 			"https://rss.ex/a2",
 			teams=[self.pub_team],
 			authors=[self.author_pub],
+			subjects=[self.pub_subj],
 		)
 		_make_article(
 			"Priv Art",
 			"https://rss.ex/a3",
 			teams=[self.priv_team],
 			authors=[self.author_priv],
+			subjects=[self.priv_subj],
 		)
 		# author_mine also has a public article
 		_make_article(
@@ -146,6 +202,7 @@ class AuthorFeedBase(TestCase):
 			"https://rss.ex/a4",
 			teams=[self.pub_team],
 			authors=[self.author_mine],
+			subjects=[self.pub_subj],
 		)
 
 
@@ -233,7 +290,9 @@ class AuthenticatedUserAuthorFeedTest(AuthorFeedBase):
 class APIKeyAuthorFeedTest(AuthorFeedBase):
 	def setUp(self):
 		super().setUp()
-		self.scheme = _make_api_scheme(self.my_org, "rss-author-key")
+		self.scheme = _make_api_scheme(
+			self.my_org, "rss-author-key", site=self.my_site
+		)
 		self.client.defaults["HTTP_AUTHORIZATION"] = self.scheme.api_key
 
 	def test_own_author_returns_200(self):
@@ -271,6 +330,21 @@ class TrialsFeedBase(TestCase):
 		self.my_subj = _make_subject(self.my_team, "my-subj-rss")
 		self.pub_subj = _make_subject(self.pub_team, "pub-subj-rss")
 		self.priv_subj = _make_subject(self.priv_team, "priv-subj-rss")
+
+		# One site per organisation, each publishing its own subject. Only
+		# pub_site is api_public, so pub_subj is the whole anonymous scope.
+		self.my_site = _make_site(
+			"My Site RSS Trial", self.my_org, api_public=False,
+			scope_subjects=[self.my_subj],
+		)
+		self.pub_site = _make_site(
+			"Pub Site RSS Trial", self.pub_org, api_public=True,
+			scope_subjects=[self.pub_subj],
+		)
+		self.priv_site = _make_site(
+			"Priv Site RSS Trial", self.priv_org, api_public=False,
+			scope_subjects=[self.priv_subj],
+		)
 
 		# Trials
 		_make_trial(
@@ -354,10 +428,15 @@ class AuthenticatedUserTrialsFeedTest(TrialsFeedBase):
 		resp = self.client.get(f"/feed/trials/subject/{self.my_subj.subject_slug}/")
 		self.assertIn("Mine Trial", resp.content.decode())
 
-	def test_own_feed_excludes_pub_trial_without_flag(self):
-		"""pub trial is not in my_team → filtered out from own-subject feed."""
-		# Add pub trial to my_subj to test filtering
-		pub_trial_in_my_subj = _make_trial(
+	def test_own_feed_lists_the_subjects_trials_whatever_team_owns_them(self):
+		"""
+		The subject is the visibility boundary, so a feed for a visible
+		subject lists every trial tagged with it. Team ownership used to
+		filter within the feed as well; since Phase 4 it does not, and
+		test_public_subject_hidden_without_flag is what pins the boundary
+		that still exists.
+		"""
+		_make_trial(
 			"Pub Trial In My Subj",
 			"https://rss.ex/t99",
 			teams=[self.pub_team],
@@ -365,9 +444,10 @@ class AuthenticatedUserTrialsFeedTest(TrialsFeedBase):
 		)
 		resp = self.client.get(f"/feed/trials/subject/{self.my_subj.subject_slug}/")
 		content = resp.content.decode()
-		# Mine Trial visible, pub-team trial not visible
 		self.assertIn("Mine Trial", content)
-		self.assertNotIn("Pub Trial In My Subj", content)
+		self.assertIn("Pub Trial In My Subj", content)
+		# ...and a trial with no tie to my_subj is still absent.
+		self.assertNotIn("Priv Trial", content)
 
 
 # ---------------------------------------------------------------------------
@@ -378,7 +458,9 @@ class AuthenticatedUserTrialsFeedTest(TrialsFeedBase):
 class APIKeyTrialsFeedTest(TrialsFeedBase):
 	def setUp(self):
 		super().setUp()
-		self.scheme = _make_api_scheme(self.my_org, "rss-trials-key")
+		self.scheme = _make_api_scheme(
+			self.my_org, "rss-trials-key", site=self.my_site
+		)
 		self.client.defaults["HTTP_AUTHORIZATION"] = self.scheme.api_key
 
 	def test_own_subject_returns_200(self):

--- a/django/gregory/visibility.py
+++ b/django/gregory/visibility.py
@@ -104,11 +104,22 @@ def visible_subject_ids(request) -> set[int]:
 	"""
 	Return the set of Subject IDs the caller is permitted to see.
 
-	Site-scoped API visibility, Phase 1: introduces this function alongside
+	Site-scoped API visibility: introduced in Phase 1 alongside
 	``visible_org_ids`` -- see that function's docstring for the middleware
-	and lazy-evaluation contract, which this follows identically. No call
-	site reads this yet; conversion happens phase by phase later in the
-	project (see SITE-API-VISIBILITY-PLAN.md, a local planning doc).
+	and lazy-evaluation contract, which this follows identically. Call
+	sites are converted phase by phase; as of Phase 4 both RSS feeds
+	(``rss/views.py``) read this, while ``api/views.py``, the serializers
+	and the admin still read ``visible_org_ids``. Both functions are live
+	at once for the duration.
+
+	Curation is the whole grant. A subject is visible when some site the
+	caller can reach lists it in ``scope_subjects`` -- nothing else confers
+	access and nothing else withholds it. In particular a subject with no
+	team is not special-cased: it is unreachable by default because nothing
+	curates it, but an administrator who does put one in a site's scope has
+	deliberately published it, and it resolves like any other. Re-checking
+	the owning team here would reinstate the ownership path this project
+	removes.
 
 	Rules (see spec §"Visibility resolution"):
 	  - Site-bound API key

--- a/django/gregory/visibility.py
+++ b/django/gregory/visibility.py
@@ -128,13 +128,29 @@ def visible_subject_ids(request) -> set[int]:
 	        Phase 3; until then this is the entire anonymous rule. The
 	        Phase 1 equivalence test asserts this matches every subject
 	        visible under today's public-organisation rule.
+
+	``?include_public=true`` adds the scopes of every ``api_public`` site to
+	an identified caller's own scope, which is how a private site's frontend
+	reads public content alongside its own. It is a no-op for an anonymous
+	caller, whose scope is already exactly that set -- the same shape the
+	flag has in ``visible_org_ids``, restated in subjects (spec: "adds public
+	organisations" stops being true once organisations are not the unit).
+	It applies to an identified caller whose own scope came out empty too
+	(an API key with no site resolved, or one whose site and organisation
+	disagree): those resolve to no subjects of their own, and public
+	subjects are public to everyone, so the flag still means what it says.
 	"""
 	from sitesettings.models import CustomSetting
+
+	include_public = request.GET.get("include_public", "").lower() == "true"
+
+	def _resolve(owned: set[int]) -> set[int]:
+		return owned | _public_subject_ids() if include_public else owned
 
 	api_scheme = _resolve_api_scheme(request)
 	if api_scheme is not None:
 		if api_scheme.site_id is None:
-			return set()
+			return _resolve(set())
 		# The key's site must belong to the key's organisation. Both fields
 		# exist and are independently editable during Phase 1 -- `organization`
 		# is not retired until Phase 4 -- so a mismatched pair would otherwise
@@ -145,11 +161,13 @@ def visible_subject_ids(request) -> set[int]:
 		if not OrganizationSite.objects.filter(
 			organization_id=api_scheme.organization_id, site_id=api_scheme.site_id
 		).exists():
-			return set()
-		return set(
-			CustomSetting.objects.filter(site_id=api_scheme.site_id)
-			.exclude(scope_subjects__isnull=True)
-			.values_list("scope_subjects__id", flat=True)
+			return _resolve(set())
+		return _resolve(
+			set(
+				CustomSetting.objects.filter(site_id=api_scheme.site_id)
+				.exclude(scope_subjects__isnull=True)
+				.values_list("scope_subjects__id", flat=True)
+			)
 		)
 
 	if getattr(request, "user", None) is not None and request.user.is_authenticated:
@@ -161,21 +179,24 @@ def visible_subject_ids(request) -> set[int]:
 			)
 		)
 		if not org_ids:
-			return set()
+			return _resolve(set())
 		site_ids = set(
 			OrganizationSite.objects.filter(organization_id__in=org_ids).values_list(
 				"site_id", flat=True
 			)
 		)
 		if not site_ids:
-			return set()
-		return set(
-			CustomSetting.objects.filter(site_id__in=site_ids)
-			.exclude(scope_subjects__isnull=True)
-			.values_list("scope_subjects__id", flat=True)
+			return _resolve(set())
+		return _resolve(
+			set(
+				CustomSetting.objects.filter(site_id__in=site_ids)
+				.exclude(scope_subjects__isnull=True)
+				.values_list("scope_subjects__id", flat=True)
+			)
 		)
 
-	# Anonymous caller -- Phase 1 rule, see docstring.
+	# Anonymous caller -- Phase 1 rule, see docstring. include_public is a
+	# no-op here: this IS the public set.
 	return _public_subject_ids()
 
 

--- a/django/rss/tests.py
+++ b/django/rss/tests.py
@@ -8,7 +8,14 @@ from django.contrib.sites.models import Site
 from django.test import TestCase
 from django.urls import reverse
 
-from gregory.models import Articles, Authors, OrganizationApiSettings, Subject, Team
+from gregory.models import (
+	Articles,
+	Authors,
+	OrganizationApiSettings,
+	Subject,
+	Team,
+	Trials,
+)
 from organizations.models import Organization
 from sitesettings.models import CustomSetting
 
@@ -37,6 +44,19 @@ class AuthorFeedLinkTest(TestCase):
 		if self.site.domain != "testserver":
 			self.site.domain = "testserver"
 			self.site.save()
+		# What makes the feed's content visible to an anonymous caller is a
+		# subject in some api_public site's scope -- not the org flag, and
+		# not this site's own CustomSetting. It lives on a separate site so
+		# that each test below is still free to create, vary or omit the
+		# CustomSetting for `self.site`, which is the only thing these tests
+		# are actually about (has_author_pages -> <link> target).
+		self.scope_site = Site.objects.create(
+			domain="scope.example.com", name="Scope Site"
+		)
+		scope_settings = CustomSetting.objects.create(
+			site=self.scope_site, title="Scope settings", api_public=True
+		)
+		scope_settings.scope_subjects.add(self.subject)
 		self.author = Authors.objects.create(
 			given_name="Jane", family_name="Doe", ORCID="0000-0002-7922-9785"
 		)
@@ -78,3 +98,101 @@ class AuthorFeedLinkTest(TestCase):
 		self.assertIn(
 			"<link>https://orcid.org/0000-0002-7922-9785</link>", content
 		)
+
+
+class FeedVisibilityTest(TestCase):
+	"""
+	Both RSS feeds are scoped by subject, not by the owning team's
+	organisation (site-scoped API visibility, Phase 4). A subject reaches an
+	anonymous caller only by sitting in the scope_subjects of some site with
+	api_public on; nothing else grants access, and team ownership grants
+	none.
+	"""
+
+	def setUp(self):
+		self.org = Organization.objects.create(name="Feed Org", slug="feed-org")
+		OrganizationApiSettings.objects.filter(organization=self.org).update(
+			make_api_public=True
+		)
+		self.team = Team.objects.create(
+			name="Feed Team", organization=self.org, slug="feed-team"
+		)
+		self.published = Subject.objects.create(
+			subject_name="Published", subject_slug="published", team=self.team
+		)
+		# Owned by the same public organisation's team, but never curated
+		# into a site's scope. Under the old organisation rule this was
+		# visible; it is the narrowing this conversion introduces.
+		self.uncurated = Subject.objects.create(
+			subject_name="Uncurated", subject_slug="uncurated", team=self.team
+		)
+		# No team at all. The old check skipped subjects like this entirely
+		# ("if subject.team_id is not None"), so they were served to anyone
+		# who guessed the slug -- the hole this conversion closes.
+		self.teamless = Subject.objects.create(
+			subject_name="Teamless", subject_slug="teamless", team=None
+		)
+
+		self.site = Site.objects.create(domain="feeds.example.com", name="Feeds")
+		settings_row = CustomSetting.objects.create(
+			site=self.site, title="Feed settings", api_public=True
+		)
+		settings_row.scope_subjects.add(self.published)
+
+		for subject in (self.published, self.uncurated, self.teamless):
+			trial = Trials.objects.create(
+				title=f"trial-{subject.subject_slug}",
+				link=f"https://registry.example.org/{subject.subject_slug}",
+			)
+			trial.teams.add(self.team)
+			trial.subjects.add(subject)
+
+	def _trials_feed(self, subject):
+		return self.client.get(
+			reverse("trials_by_subject_feed", args=[subject.subject_slug])
+		)
+
+	def test_subject_in_a_public_sites_scope_is_served(self):
+		response = self._trials_feed(self.published)
+		self.assertEqual(response.status_code, 200)
+		self.assertIn("trial-published", response.content.decode())
+
+	def test_subject_owned_by_a_public_org_but_uncurated_404s(self):
+		self.assertEqual(self._trials_feed(self.uncurated).status_code, 404)
+
+	def test_subject_with_no_team_404s(self):
+		self.assertEqual(self._trials_feed(self.teamless).status_code, 404)
+
+	def test_author_feed_404s_when_no_article_carries_a_visible_subject(self):
+		author = Authors.objects.create(
+			given_name="Un", family_name="Seen", ORCID="0000-0002-0000-0009"
+		)
+		article = Articles.objects.create(
+			title="uncurated-article", link="https://example.org/uncurated"
+		)
+		article.teams.add(self.team)
+		article.subjects.add(self.uncurated)
+		article.authors.add(author)
+		self.assertEqual(
+			self.client.get(
+				reverse("articles_by_author_feed", args=[author.ORCID])
+			).status_code,
+			404,
+		)
+
+	def test_author_feed_lists_only_visible_subject_articles(self):
+		author = Authors.objects.create(
+			given_name="Mixed", family_name="Bag", ORCID="0000-0002-0000-0010"
+		)
+		for subject, slug in ((self.published, "shown"), (self.uncurated, "hidden")):
+			article = Articles.objects.create(
+				title=f"{slug}-article", link=f"https://example.org/{slug}"
+			)
+			article.teams.add(self.team)
+			article.subjects.add(subject)
+			article.authors.add(author)
+		body = self.client.get(
+			reverse("articles_by_author_feed", args=[author.ORCID])
+		).content.decode()
+		self.assertIn("shown-article", body)
+		self.assertNotIn("hidden-article", body)

--- a/django/rss/tests.py
+++ b/django/rss/tests.py
@@ -163,6 +163,20 @@ class FeedVisibilityTest(TestCase):
 	def test_subject_with_no_team_404s(self):
 		self.assertEqual(self._trials_feed(self.teamless).status_code, 404)
 
+	def test_subject_with_no_team_is_served_once_a_site_curates_it(self):
+		# The counterpart to the test above, and the reason it passes: a
+		# team-less subject is unreachable because nothing publishes it, not
+		# because it has no team. Curation is the whole grant, so an
+		# administrator who puts one in a public site's scope has published
+		# it deliberately and it resolves like any other subject. Pinned so
+		# that a well-meaning "team-less subjects are never public" guard
+		# cannot be added back without failing here.
+		settings_row = CustomSetting.objects.get(site=self.site)
+		settings_row.scope_subjects.add(self.teamless)
+		response = self._trials_feed(self.teamless)
+		self.assertEqual(response.status_code, 200)
+		self.assertIn("trial-teamless", response.content.decode())
+
 	def test_author_feed_404s_when_no_article_carries_a_visible_subject(self):
 		author = Authors.objects.create(
 			given_name="Un", family_name="Seen", ORCID="0000-0002-0000-0009"

--- a/django/rss/views.py
+++ b/django/rss/views.py
@@ -4,7 +4,7 @@ from django.db.models import F
 from django.http import Http404
 from gregory.models import Articles, Authors, Trials, Subject
 from gregory.functions import normalize_orcid
-from gregory.visibility import visible_org_ids as _visible_org_ids
+from gregory.visibility import visible_subject_ids as _visible_subject_ids
 from sitesettings.utils import author_page_base
 
 
@@ -24,11 +24,11 @@ class ArticlesByAuthorFeed(Feed):
 
 		# Compute visibility and attach to the per-request obj (not self)
 		# so concurrent requests on the shared Feed instance don't interfere.
-		author._visible_org_ids = _visible_org_ids(request)
+		author._visible_subject_ids = _visible_subject_ids(request)
 
-		# 404 if author has no articles in any visible org
+		# 404 if the author has no articles under any visible subject
 		if not author.articles_set.filter(
-			teams__organization_id__in=author._visible_org_ids
+			subjects__in=author._visible_subject_ids
 		).exists():
 			raise Http404
 
@@ -51,7 +51,7 @@ class ArticlesByAuthorFeed(Feed):
 		return (
 			Articles.objects.filter(
 				authors=obj,
-				teams__organization_id__in=obj._visible_org_ids,
+				subjects__in=obj._visible_subject_ids,
 			)
 			.distinct()
 			# nulls_last: articles ingested without a date (filled later from
@@ -88,20 +88,13 @@ class TrialsBySubjectFeed(Feed):
 	def get_object(self, request, subject_slug):
 		subject = Subject.objects.get(subject_slug=subject_slug)
 
-		# Compute visibility and attach to the per-request obj (not self)
-		# so concurrent requests on the shared Feed instance don't interfere.
-		subject._visible_org_ids = _visible_org_ids(request)
-
-		# 404 if subject belongs to an org that isn't visible
-		if subject.team_id is not None:
-			from gregory.models import Team as _Team
-
-			try:
-				team = _Team.objects.get(id=subject.team_id)
-				if team.organization_id not in subject._visible_org_ids:
-					raise Http404
-			except _Team.DoesNotExist:
-				raise Http404
+		# The subject IS the visibility unit now, so this is a set membership
+		# test rather than a walk up to the owning team's organisation. It
+		# also closes a hole the old check left open: a subject with no team
+		# skipped the check entirely and was served to anyone, which is how
+		# an internal-research subject could be read by slug.
+		if subject.id not in _visible_subject_ids(request):
+			raise Http404
 
 		return subject
 
@@ -117,10 +110,10 @@ class TrialsBySubjectFeed(Feed):
 
 	def items(self, obj):
 		return (
-			Trials.objects.filter(
-				subjects=obj,
-				teams__organization_id__in=obj._visible_org_ids,
-			)
+			# get_object() has already established that obj is a visible
+			# subject, so matching on it is the whole visibility test — no
+			# second filter to add.
+			Trials.objects.filter(subjects=obj)
 			.distinct()
 			.order_by("-discovery_date")[:50]
 		)

--- a/docs/03-api-and-rss-feeds.md
+++ b/docs/03-api-and-rss-feeds.md
@@ -31,6 +31,8 @@ A read-only [MCP server](07-mcp-server.md) also exposes this API to LLM clients 
 
 Both feeds return the 50 most recent items, ordered by newest first.
 
+Both are scoped by subject. A subject is readable when it sits in the `scope_subjects` of a site the caller can see — for an anonymous caller, any site with *API public* on; for a site-bound API key, that key's own site; for a signed-in user, the sites owned by their organisations. The trials feed 404s when the requested subject is not one of those, and the author feed 404s when none of the author's articles carries one and otherwise lists only the articles that do. Team ownership grants no access: a subject owned by a team in a publicly visible organisation but curated into no site's scope is not readable, and neither is a subject with no team at all.
+
 The author feed's `<link>` element points at the site's author profile page (`https://{site.domain}/authors/{orcid}/`) when the current Site's `CustomSetting.has_author_pages` is on, and at `https://orcid.org/{orcid}` otherwise. See [Author profile page links](06-organisations-teams-and-sites.md#author-profile-page-links).
 
 ---

--- a/docs/03-api-and-rss-feeds.md
+++ b/docs/03-api-and-rss-feeds.md
@@ -31,7 +31,11 @@ A read-only [MCP server](07-mcp-server.md) also exposes this API to LLM clients 
 
 Both feeds return the 50 most recent items, ordered by newest first.
 
-Both are scoped by subject. A subject is readable when it sits in the `scope_subjects` of a site the caller can see — for an anonymous caller, any site with *API public* on; for a site-bound API key, that key's own site; for a signed-in user, the sites owned by their organisations. The trials feed 404s when the requested subject is not one of those, and the author feed 404s when none of the author's articles carries one and otherwise lists only the articles that do. Team ownership grants no access: a subject owned by a team in a publicly visible organisation but curated into no site's scope is not readable, and neither is a subject with no team at all.
+Both are scoped by subject. A subject is readable when it sits in the `scope_subjects` of a site the caller can see — for an anonymous caller, any site with *API public* on; for a site-bound API key, that key's own site; for a signed-in user, the sites owned by their organisations. The trials feed 404s when the requested subject is not one of those, and the author feed 404s when none of the author's articles carries one, otherwise listing only the articles that do.
+
+Curation into a site's scope is the whole grant, so team ownership neither adds nor removes access. A subject owned by a team in a publicly visible organisation is *not* readable unless some site publishes it, and a subject with no team at all is readable if a site does — team-less subjects are unreachable by default because nothing curates them, not by rule.
+
+`?include_public=true` adds the scopes of every *API public* site to an identified caller's own scope, which is how a private site's frontend reads public content alongside its own. It is a no-op for an anonymous caller, whose scope already is exactly that set. (Under the previous organisation-scoped rule this flag read "adds public organisations".)
 
 The author feed's `<link>` element points at the site's author profile page (`https://{site.domain}/authors/{orcid}/`) when the current Site's `CustomSetting.has_author_pages` is on, and at `https://orcid.org/{orcid}` otherwise. See [Author profile page links](06-organisations-teams-and-sites.md#author-profile-page-links).
 


### PR DESCRIPTION
Second of four PRs converting the 34 org-visibility call sites. `rss/views.py`, 3 sites. Independent of [#861](https://github.com/brunoamaral/gregory-ai/pull/861) — merge in either order.

## What changed

**`ArticlesByAuthorFeed`** — the 404 gate and the item list both move from `teams__organization_id__in` to `subjects__in`.

**`TrialsBySubjectFeed`** — the gate becomes a set-membership test on the subject itself, replacing a walk up to the owning team's organisation. Its item query drops the org filter entirely: `get_object()` has already established the subject is visible, so matching on it *is* the whole visibility test.

## `?include_public=true` — a Phase 1 gap this trips over

Phase 1 built `visible_subject_ids` without the flag. The spec gives it a new meaning under site scoping — "adds the scopes of every `api_public` site" — and converting these call sites without it would have turned a working parameter into a **silent no-op** on both feeds. That is the exact failure mode this project exists to prevent, so it is implemented here rather than deferred. Anonymous callers are unaffected; their scope already *is* that set.

Worth knowing for later phases: the same gap is waiting in every `api/views.py` call site PR 4 touches.

## Behaviour changes, both measured

**A hole closes.** The old check was `if subject.team_id is not None:` — a subject with **no team skipped it entirely** and was served to anyone who guessed the slug. One subject qualifies today:

| Subject | Slug | Trials | Before | After |
|--:|:--|--:|:--|:--|
| 15 | `dihydroartemisinin` | 103 | anyone can read | 404 |

That is the internal-research subject you flagged as correctly having no site association. Its feed is currently public.

**The author feed narrows** by 725 of 53,049 articles (1.4%), in two buckets that are both intentional:

| Bucket | n | Why it is right |
|:--|--:|:--|
| No subject at all | 367 | Already slated for pruning (`prune-subjectless-records.sql`) |
| Only subject 15 | 358 | Internal research, not site-associated |

No article gains visibility (0 widened, measured).

## Tests

`api/tests/test_visibility_rss.py` was written against the organisation rule — its articles carried teams and no subjects at all — so under subject scoping every one of its 16 visibility assertions collapsed. Each org there now has a `Site` with a curated `scope_subjects` and content is tagged into it, which is what the four caller archetypes actually resolve against now (`OrganizationSite` for members, the key's own site for API keys).

One test asserted that team ownership filters items *within* a visible subject's feed. That rule is gone; it now asserts the subject boundary, and names `test_public_subject_hidden_without_flag` as the guard that still holds.

New `FeedVisibilityTest` in `rss/tests.py` covers the closed hole and the narrowing head-on — uncurated subject 404s, team-less subject 404s, author feed 404s with no visible subject, author feed lists only visible-subject articles. **All four were confirmed to fail against the pre-conversion code**, so they are known to be testing something.

Full Django suite: 3,353 passed. `schema.yml` regenerates unchanged (RSS feeds are not in the OpenAPI schema); declaring `include_public` there belongs with PR 4, which is where the API views that expose it get converted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)