### PR TITLE
Phase 4d: scope the API surface by subject

### DIFF
--- a/django/api/direct_streaming.py
+++ b/django/api/direct_streaming.py
@@ -319,7 +319,7 @@ def order_columns(keys):
 def csv_header_fields(serializer, request):
 	"""Static CSV header for a serializer, matching per-row behavior.
 
-	OrgScopedSerializerMixin pops _per_org_fields from every row when the
+	ScopedSerializerMixin pops _per_org_fields from every row when the
 	request has no org context, so the header must drop them under the same
 	condition or rows and header would misalign.
 	"""

--- a/django/api/pagination.py
+++ b/django/api/pagination.py
@@ -126,18 +126,26 @@ class CachedCountMixin:
 	)
 
 	def _count_cache_key(self, request):
-		"""Tenant-safe cache key: path + visible org ids + normalised params.
+		"""Tenant-safe cache key: path + visible scope + normalised params.
 
 		Mirrors CachedStatsActionMixin._stats_cache_key's security shape
-		(org ids and query params are both load-bearing — dropping either
+		(the scope and query params are both load-bearing — dropping either
 		would serve one tenant's count to another caller) but keys on
 		``request.path`` instead of a per-view prefix string, since this
 		pagination class is shared across several viewsets (Articles,
 		Trials, Sponsors, ...) and the path is what actually distinguishes
 		their counts from one another.
 		"""
-		visible_org_ids = getattr(request, "visible_org_ids", None)
-		orgs = None if visible_org_ids is None else sorted(visible_org_ids)
+		# The subject scope, not the org scope: every endpoint that uses this
+		# paginator (articles, trials, sponsors, authors and the three search
+		# views) selects its rows by subject since Phase 4 of site-scoped API
+		# visibility, so the subject set is what a cached count is a count OF.
+		# Hashing visible_org_ids as well would only fragment the cache --
+		# there is no paginated org-keyed endpoint for it to protect.
+		visible_subject_ids = getattr(request, "visible_subject_ids", None)
+		subjects = (
+			None if visible_subject_ids is None else sorted(visible_subject_ids)
+		)
 		params = sorted(
 			(key, value)
 			for key in request.query_params.keys()
@@ -145,7 +153,13 @@ class CachedCountMixin:
 			for value in request.query_params.getlist(key)
 		)
 		digest = hashlib.sha256(
-			json.dumps({"path": request.path, "orgs": orgs, "params": params}).encode()
+			json.dumps(
+				{
+					"path": request.path,
+					"subjects": subjects,
+					"params": params,
+				}
+			).encode()
 		).hexdigest()
 		return f"paginator_count:{digest}"
 

--- a/django/api/serializers/__init__.py
+++ b/django/api/serializers/__init__.py
@@ -25,7 +25,7 @@ from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import Count, Q
 
-from api.serializers.mixins import OrgScopedSerializerMixin, _resolve_per_org_fields_org
+from api.serializers.mixins import ScopedSerializerMixin, _resolve_per_org_fields_org
 
 
 def get_custom_settings():
@@ -410,7 +410,7 @@ class ArticleAuthorSerializer(serializers.ModelSerializer):
 
 
 class ArticleSerializer(
-	OrgScopedSerializerMixin, serializers.HyperlinkedModelSerializer
+	ScopedSerializerMixin, serializers.HyperlinkedModelSerializer
 ):
 	sources = serializers.SlugRelatedField(many=True, read_only=True, slug_field="name")
 	team_categories = TeamCategorySerializer(many=True, read_only=True)
@@ -552,7 +552,7 @@ class SponsorSerializer(serializers.ModelSerializer):
 		fields = ["id", "slug", "name", "sponsor_type", "trials_count"]
 
 
-class TrialSerializer(OrgScopedSerializerMixin, serializers.HyperlinkedModelSerializer):
+class TrialSerializer(ScopedSerializerMixin, serializers.HyperlinkedModelSerializer):
 	subjects = SubjectsSerializer(many=True, read_only=True)
 	sources = serializers.SlugRelatedField(many=True, read_only=True, slug_field="name")
 	team_categories = TeamCategorySerializer(many=True, read_only=True)
@@ -803,7 +803,7 @@ class AuthorSerializer(serializers.ModelSerializer):
 		]
 
 	def get_articles_count(self, obj) -> int:
-		# The queryset always annotates a (correctly org-scoped) article_count,
+		# The queryset always annotates a (correctly subject-scoped) article_count,
 		# so prefer it and avoid a per-row COUNT query. Only fall back to a
 		# live query if a caller passes in an un-annotated instance directly.
 		annotated = getattr(obj, "article_count", None)
@@ -811,8 +811,12 @@ class AuthorSerializer(serializers.ModelSerializer):
 			return annotated
 		qs = obj.articles_set.all()
 		request = self.context.get("request")
-		if request is not None and hasattr(request, "visible_org_ids"):
-			return qs.filter(teams__organization_id__in=request.visible_org_ids).distinct().count()
+		if request is not None and hasattr(request, "visible_subject_ids"):
+			return (
+				qs.filter(subjects__in=request.visible_subject_ids)
+				.distinct()
+				.count()
+			)
 		return qs.count()
 
 	def get_relevant_articles_count(self, obj) -> int:
@@ -821,8 +825,8 @@ class AuthorSerializer(serializers.ModelSerializer):
 			return annotated
 		qs = obj.articles_set.filter(relevant=True)
 		request = self.context.get("request")
-		if request is not None and hasattr(request, "visible_org_ids"):
-			qs = qs.filter(teams__organization_id__in=request.visible_org_ids)
+		if request is not None and hasattr(request, "visible_subject_ids"):
+			qs = qs.filter(subjects__in=request.visible_subject_ids)
 		return qs.distinct().count()
 
 	def get_country(self, obj) -> Optional[str]:

--- a/django/api/serializers/mixins.py
+++ b/django/api/serializers/mixins.py
@@ -11,12 +11,18 @@ Stripping here is what keeps the row's fields consistent with the rule that
 selected the row.
 
 Applied fields (when present on the serialised object):
-  - ``subjects``        → Subject entries outside ``request.visible_subject_ids``
-  - ``ml_predictions``  → MLPredictions entries whose subject is outside it
-  - ``team_categories`` → TeamCategory entries whose ``subjects`` M2M does not
-                           intersect it
-  - ``teams``           → Team entries that are neither ``api_listed`` nor
-                           owners of a subject in the caller's scope
+  - ``subjects``                  → Subject entries outside
+                                     ``request.visible_subject_ids``
+  - ``ml_predictions``            → MLPredictions entries whose subject is
+                                     outside it
+  - ``article_subject_relevances``→ ArticleSubjectRelevance entries whose
+                                     nested subject is outside it (same
+                                     shape/reasoning as ml_predictions)
+  - ``team_categories``           → TeamCategory entries whose ``subjects``
+                                     M2M does not intersect it
+  - ``teams``                     → Team entries that are neither
+                                     ``api_listed`` nor owners of a subject in
+                                     the caller's scope
 
 Teams are the odd one out, and deliberately so. A Team carries no subject of
 its own, so it is gated by exactly the rule ``/teams/`` applies: listed by the
@@ -231,6 +237,24 @@ class ScopedSerializerMixin:
 
 			ret["ml_predictions"] = [
 				p for p in ret["ml_predictions"] if _subject_id(p) in visible
+			]
+
+		# --- article_subject_relevances: same shape/reasoning as ml_predictions ---
+		# ArticleSubjectRelevanceSerializer nests a full subject (id, name, ...)
+		# plus is_relevant. An article tagged with one visible and one hidden
+		# subject would otherwise still disclose the hidden subject's identity
+		# and relevance verdict through this relation (PR #863 review finding 3).
+		if "article_subject_relevances" in ret:
+			def _relevance_subject_id(r):
+				s = r.get("subject")
+				if isinstance(s, dict):
+					return s.get("id")
+				return s if isinstance(s, int) else None
+
+			ret["article_subject_relevances"] = [
+				r
+				for r in ret["article_subject_relevances"]
+				if _relevance_subject_id(r) in visible
 			]
 
 		return ret

--- a/django/api/serializers/mixins.py
+++ b/django/api/serializers/mixins.py
@@ -15,14 +15,17 @@ Applied fields (when present on the serialised object):
   - ``ml_predictions``  → MLPredictions entries whose subject is outside it
   - ``team_categories`` → TeamCategory entries whose ``subjects`` M2M does not
                            intersect it
-  - ``teams``           → Team entries with ``api_listed=False``
+  - ``teams``           → Team entries that are neither ``api_listed`` nor
+                           owners of a subject in the caller's scope
 
-Teams are the odd one out, and deliberately so. A Team carries no subject, so
-subject scope cannot speak to it; it is gated by the same explicit
-``Team.api_listed`` flag that governs ``/teams/``, so a team's name appears
-nested inside an article exactly when it would appear in the team directory.
-Using two different answers for "may I see this team's name" depending on
-which endpoint asked would be a leak in whichever direction was laxer.
+Teams are the odd one out, and deliberately so. A Team carries no subject of
+its own, so it is gated by exactly the rule ``/teams/`` applies: listed by the
+explicit ``Team.api_listed`` flag, OR owning a subject already in the caller's
+scope. A team's name therefore appears nested inside an article exactly when it
+would appear in the team directory. Using two different answers for "may I see
+this team's name" depending on which endpoint asked would be a leak in
+whichever direction was laxer, so these two must move together -- if you change
+one, change the other.
 
 The mixin is intentionally a no-op when:
   - There is no ``request`` in the serializer context, OR
@@ -37,8 +40,10 @@ Query strategy (avoiding N+1 on list endpoints)
 - ``team_categories``:  a category's ``subjects`` M2M has to be consulted, so
   the qualifying category IDs are resolved once per request and cached on
   ``request._scoped_mixin_category_ids``.
-- ``teams``:  ``team.api_listed`` is a direct column; iterating ``.all()`` in
-  Python respects ``prefetch_related('teams')`` with zero extra queries.
+- ``teams``:  ``team.api_listed`` is a direct column, so the first half costs
+  nothing and respects ``prefetch_related('teams')``. The second half needs the
+  team ids owning an in-scope subject, resolved once per request and cached on
+  ``request._scoped_mixin_listed_team_ids``.
 
 Per-org fields (``_per_org_fields``)
 -------------------------------------
@@ -105,6 +110,30 @@ def _resolve_per_org_fields_org(request):
 	return org
 
 
+def _request_scope_owning_team_ids(request, visible_subject_ids: set) -> set:
+	"""Team IDs that own at least one subject in the caller's scope.
+
+	The second half of the team-listing rule (see module docstring and
+	TeamsViewSet, which must agree). Cached once per request so a list
+	endpoint does not repeat it per serialised row.
+	"""
+	cache_attr = "_scoped_mixin_listed_team_ids"
+	if not hasattr(request, cache_attr):
+		from gregory.models import Subject
+
+		setattr(
+			request,
+			cache_attr,
+			set(
+				Subject.objects.filter(id__in=visible_subject_ids)
+				.exclude(team_id__isnull=True)
+				.values_list("team_id", flat=True)
+				.distinct()
+			),
+		)
+	return getattr(request, cache_attr)
+
+
 def _request_visible_category_ids(request, visible_subject_ids: set) -> set:
 	"""TeamCategory IDs whose subjects intersect the caller's scope.
 
@@ -166,9 +195,14 @@ class ScopedSerializerMixin:
 
 		visible = request.visible_subject_ids
 
-		# --- teams: api_listed is a direct column; uses prefetch cache ---
+		# --- teams: the same rule /teams/ applies, kept in step with it ---
 		if "teams" in ret and hasattr(instance, "teams"):
-			listed_team_ids = {t.id for t in instance.teams.all() if t.api_listed}
+			scope_owning = _request_scope_owning_team_ids(request, visible)
+			listed_team_ids = {
+				t.id
+				for t in instance.teams.all()
+				if t.api_listed or t.id in scope_owning
+			}
 			ret["teams"] = [t for t in ret["teams"] if t.get("id") in listed_team_ids]
 
 		# --- subjects: a set-membership test, no query ---

--- a/django/api/serializers/mixins.py
+++ b/django/api/serializers/mixins.py
@@ -1,38 +1,44 @@
 """
 api/serializers/mixins.py
 
-OrgScopedSerializerMixin — strips nested associations that belong to
-organisations outside ``request.visible_org_ids``.
+ScopedSerializerMixin — strips nested associations the caller cannot see.
+
+A row reaching the serializer has already passed the viewset's scope filter,
+which means *the row* is visible. That says nothing about the associations
+hanging off it: an article carrying two subjects, one of them out of scope,
+is visible on the strength of the first and must not disclose the second.
+Stripping here is what keeps the row's fields consistent with the rule that
+selected the row.
 
 Applied fields (when present on the serialised object):
-  - ``teams``           → Team entries whose org is not visible
-  - ``subjects``        → Subject entries whose team's org is not visible
-  - ``team_categories`` → TeamCategory entries whose team's org is not visible
-  - ``ml_predictions``  → MLPredictions entries whose subject's team's org
-                           is not visible
+  - ``subjects``        → Subject entries outside ``request.visible_subject_ids``
+  - ``ml_predictions``  → MLPredictions entries whose subject is outside it
+  - ``team_categories`` → TeamCategory entries whose ``subjects`` M2M does not
+                           intersect it
+  - ``teams``           → Team entries with ``api_listed=False``
+
+Teams are the odd one out, and deliberately so. A Team carries no subject, so
+subject scope cannot speak to it; it is gated by the same explicit
+``Team.api_listed`` flag that governs ``/teams/``, so a team's name appears
+nested inside an article exactly when it would appear in the team directory.
+Using two different answers for "may I see this team's name" depending on
+which endpoint asked would be a leak in whichever direction was laxer.
 
 The mixin is intentionally a no-op when:
   - There is no ``request`` in the serializer context, OR
-  - ``request.visible_org_ids`` has not been set (middleware not active).
-
-This guarantees zero behaviour change until the viewsets are explicitly
-opted in (PR 4 onwards).
+  - ``request.visible_subject_ids`` has not been set (middleware not active).
 
 Query strategy (avoiding N+1 on list endpoints)
 ------------------------------------------------
-- ``teams``:  ``team.organization_id`` is a direct FK column; iterating
-  ``.all()`` in Python respects ``prefetch_related('teams')`` with zero
-  extra DB queries.
-- ``subjects`` / ``team_categories``:  ``subject.team_id`` is a direct FK
-  column.  Visible team IDs are resolved once per request and cached on
-  ``request._org_scoped_mixin_team_ids`` so the query runs at most once per
-  request regardless of list length.
-- ``ml_predictions``:  Each serialised item already contains a ``subject``
-  key (the FK integer) from ``MLPredictionsSerializer``.  Visible subject IDs
-  are resolved once per request and cached on
-  ``request._org_scoped_mixin_subject_ids``.  Filtering is done entirely on
-  ``ret['ml_predictions']`` — no extra DB query, no dependency on whether
-  ``ml_predictions_detail`` was prefetched.
+- ``subjects`` / ``ml_predictions``:  no query at all. ``visible_subject_ids``
+  IS the answer, so these are set-membership tests on data already loaded.
+  The org version had to resolve orgs → teams → subjects and cache the result
+  per request; that machinery is gone.
+- ``team_categories``:  a category's ``subjects`` M2M has to be consulted, so
+  the qualifying category IDs are resolved once per request and cached on
+  ``request._scoped_mixin_category_ids``.
+- ``teams``:  ``team.api_listed`` is a direct column; iterating ``.all()`` in
+  Python respects ``prefetch_related('teams')`` with zero extra queries.
 
 Per-org fields (``_per_org_fields``)
 -------------------------------------
@@ -99,55 +105,40 @@ def _resolve_per_org_fields_org(request):
 	return org
 
 
-def _request_visible_team_ids(request, visible_org_ids: set) -> set:
-	"""Return all team IDs belonging to visible orgs, cached once per request.
+def _request_visible_category_ids(request, visible_subject_ids: set) -> set:
+	"""TeamCategory IDs whose subjects intersect the caller's scope.
 
-	Caching avoids issuing a team-lookup query for every object in a list
-	endpoint response.
+	Cached once per request: without it a list endpoint would issue this
+	query per serialised row. Unlike subjects and ml_predictions, a category
+	reaches subjects through its own M2M, so there is no way to answer it
+	from data already in hand.
 	"""
-	cache_attr = "_org_scoped_mixin_team_ids"
+	cache_attr = "_scoped_mixin_category_ids"
 	if not hasattr(request, cache_attr):
-		from gregory.models import Team
+		from gregory.models import TeamCategory
 
 		setattr(
 			request,
 			cache_attr,
 			set(
-				Team.objects.filter(organization_id__in=visible_org_ids).values_list(
-					"id", flat=True
+				TeamCategory.objects.filter(
+					subjects__id__in=visible_subject_ids
 				)
+				.values_list("id", flat=True)
+				.distinct()
 			),
 		)
 	return getattr(request, cache_attr)
 
 
-def _request_visible_subject_ids(request, visible_org_ids: set) -> set:
-	"""Return all subject IDs belonging to visible orgs, cached once per request.
-
-	Caching avoids issuing a subject-lookup query for every object in a list
-	endpoint response (used when filtering ml_predictions in Python).
+class ScopedSerializerMixin:
 	"""
-	cache_attr = "_org_scoped_mixin_subject_ids"
-	if not hasattr(request, cache_attr):
-		from gregory.models import Subject
-
-		vt = _request_visible_team_ids(request, visible_org_ids)
-		setattr(
-			request,
-			cache_attr,
-			set(Subject.objects.filter(team_id__in=vt).values_list("id", flat=True)),
-		)
-	return getattr(request, cache_attr)
-
-
-class OrgScopedSerializerMixin:
-	"""
-	Mixin for DRF serializers that strips nested associations belonging to
-	organisations the caller cannot see.
+	Mixin for DRF serializers that strips nested associations the caller
+	cannot see.
 
 	Usage::
 
-	    class ArticleSerializer(OrgScopedSerializerMixin,
+	    class ArticleSerializer(ScopedSerializerMixin,
 	                            serializers.HyperlinkedModelSerializer):
 	        ...
 
@@ -170,34 +161,23 @@ class OrgScopedSerializerMixin:
 				for field in self._per_org_fields:
 					ret.pop(field, None)
 
-		if request is None or not hasattr(request, "visible_org_ids"):
+		if request is None or not hasattr(request, "visible_subject_ids"):
 			return ret
 
-		visible = request.visible_org_ids
+		visible = request.visible_subject_ids
 
-		# --- teams: iterate Python, uses prefetch_related cache ---
+		# --- teams: api_listed is a direct column; uses prefetch cache ---
 		if "teams" in ret and hasattr(instance, "teams"):
-			visible_team_ids = {
-				t.id for t in instance.teams.all() if t.organization_id in visible
-			}
-			ret["teams"] = [t for t in ret["teams"] if t.get("id") in visible_team_ids]
+			listed_team_ids = {t.id for t in instance.teams.all() if t.api_listed}
+			ret["teams"] = [t for t in ret["teams"] if t.get("id") in listed_team_ids]
 
-		# --- subjects: team_id is a direct FK attribute; team IDs cached per request ---
-		if "subjects" in ret and hasattr(instance, "subjects"):
-			vt = _request_visible_team_ids(request, visible)
-			visible_subject_ids = {
-				s.id for s in instance.subjects.all() if s.team_id in vt
-			}
-			ret["subjects"] = [
-				s for s in ret["subjects"] if s.get("id") in visible_subject_ids
-			]
+		# --- subjects: a set-membership test, no query ---
+		if "subjects" in ret:
+			ret["subjects"] = [s for s in ret["subjects"] if s.get("id") in visible]
 
-		# --- team_categories: same approach as subjects ---
+		# --- team_categories: reached through the category's own subjects M2M ---
 		if "team_categories" in ret and hasattr(instance, "team_categories"):
-			vt = _request_visible_team_ids(request, visible)
-			visible_cat_ids = {
-				c.id for c in instance.team_categories.all() if c.team_id in vt
-			}
+			visible_cat_ids = _request_visible_category_ids(request, visible)
 			ret["team_categories"] = [
 				c for c in ret["team_categories"] if c.get("id") in visible_cat_ids
 			]
@@ -209,8 +189,6 @@ class OrgScopedSerializerMixin:
 		# hitting instance.ml_predictions_detail.all() a second time, which would
 		# cause an extra per-object query when the relation is not prefetched.
 		if "ml_predictions" in ret:
-			vs = _request_visible_subject_ids(request, visible)
-
 			def _subject_id(p):
 				s = p.get("subject")
 				if isinstance(s, dict):
@@ -218,7 +196,7 @@ class OrgScopedSerializerMixin:
 				return s if isinstance(s, int) else None
 
 			ret["ml_predictions"] = [
-				p for p in ret["ml_predictions"] if _subject_id(p) in vs
+				p for p in ret["ml_predictions"] if _subject_id(p) in visible
 			]
 
 		return ret

--- a/django/api/tests/test_article_author_filter.py
+++ b/django/api/tests/test_article_author_filter.py
@@ -11,6 +11,8 @@ from gregory.models import (
 )
 from django.utils import timezone
 
+from api.tests.visibility_helpers import publish_subjects
+
 
 class ArticleAuthorFilterTests(TestCase):
 	"""Test cases for filtering articles by author_id parameter"""
@@ -31,6 +33,7 @@ class ArticleAuthorFilterTests(TestCase):
 		self.subject = Subject.objects.create(
 			subject_name="Test Subject", subject_slug="test-subject", team=self.team
 		)
+		publish_subjects(self.subject, organization=self.organization)
 
 		# Create test authors
 		self.author1 = Authors.objects.create(

--- a/django/api/tests/test_article_query_efficiency.py
+++ b/django/api/tests/test_article_query_efficiency.py
@@ -31,6 +31,8 @@ from gregory.models import (
 	Trials,
 )
 
+from api.tests.visibility_helpers import publish_subjects
+
 
 def _build_articles(n, suffix):
 	"""Create *n* articles, each wired to one of every related field the
@@ -49,6 +51,7 @@ def _build_articles(n, suffix):
 	subject = Subject.objects.create(
 		team=team, subject_name=f"Subject {suffix}", subject_slug=f"subject-{suffix}"
 	)
+	publish_subjects(subject, organization=org)
 	source = Sources.objects.create(
 		name=f"Source {suffix}", source_for="science paper"
 	)

--- a/django/api/tests/test_article_search.py
+++ b/django/api/tests/test_article_search.py
@@ -3,6 +3,7 @@ from django.test import TestCase
 from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
 from rest_framework.test import APIClient
+from api.tests.visibility_helpers import publish_subjects
 from gregory.models import Authors
 from gregory.models import (
 	Articles,
@@ -31,6 +32,9 @@ class ArticleSearchViewTests(TestCase):
 		self.subject = Subject.objects.create(
 			subject_name="Test Subject", subject_slug="test-subject", team=self.team
 		)
+		# /articles/search/ validates subject_id against the caller's subject
+		# scope, so the subject must be published or every search 404s.
+		publish_subjects(self.subject, organization=self.organization)
 
 		# Create test data
 		self.article1 = Articles.objects.create(
@@ -230,6 +234,9 @@ class ArticleSearchViewQueryCountTests(TestCase):
 			subject_name="Other Subject",
 			subject_slug="other-subject",
 			team=self.team,
+		)
+		publish_subjects(
+			self.subject, other_subject, organization=self.organization
 		)
 
 		for i in range(3):

--- a/django/api/tests/test_articles_stats.py
+++ b/django/api/tests/test_articles_stats.py
@@ -35,6 +35,7 @@ from organizations.models import Organization
 from rest_framework.test import APIClient
 
 from api.models import APIAccessScheme
+from api.tests.visibility_helpers import private_site_publishing, publish_subjects
 from gregory.models import (
 	Articles,
 	ArticleSubjectRelevance,
@@ -44,14 +45,32 @@ from gregory.models import (
 	Team,
 )
 
+# Mirrors test_trials_stats.py: under subject-scoped visibility a row with no
+# subject is invisible to everyone, but nearly every `_make_article(...)`
+# call in this file was written against the old organisation rule and passes
+# no `subjects=`. Each team created via `_make_org_team` gets one default
+# subject, published (or kept private) to match that team's organisation,
+# and registered here so `_make_article` can fall back to it. `_ORG_SITES`
+# gives `_make_api_scheme` the matching site to bind a key to.
+_TEAM_DEFAULT_SUBJECTS = {}
+_ORG_SITES = {}
 
-def _make_org_team(name, slug, public=True):
+
+def _make_org_team(name, slug, public=True, subject_name=None, subject_slug=None):
 	org = Organization.objects.create(name=name, slug=slug)
 	OrganizationApiSettings.objects.filter(organization=org).update(
 		make_api_public=public
 	)
 	team = Team.objects.create(organization=org, name=name, slug=slug)
-	return org, team
+	subject = Subject.objects.create(
+		team=team,
+		subject_name=subject_name or f"{name} Subject",
+		subject_slug=subject_slug or f"{slug}-subject",
+	)
+	_TEAM_DEFAULT_SUBJECTS[team.pk] = subject
+	publisher = publish_subjects if public else private_site_publishing
+	_ORG_SITES[org.pk] = publisher(subject, organization=org)
+	return org, team, subject
 
 
 def _make_subject(team, name, slug):
@@ -79,16 +98,26 @@ def _make_article(
 	)
 	for team in teams:
 		article.teams.add(team)
-	for subject in subjects:
+	# Explicit subjects win; otherwise fall back to each team's default so
+	# the many pre-existing calls that never mention a subject stay visible.
+	tagged_subjects = list(subjects) or [
+		_TEAM_DEFAULT_SUBJECTS[team.pk]
+		for team in teams
+		if team.pk in _TEAM_DEFAULT_SUBJECTS
+	]
+	for subject in tagged_subjects:
 		article.subjects.add(subject)
 	return article
 
 
-def _make_api_scheme(org, name):
+def _make_api_scheme(org, name, site=None):
 	return APIAccessScheme.objects.create(
 		client_name=name,
 		client_contacts=f"{name}@example.com",
 		organization=org,
+		# A key without a site resolves to no subjects at all; fall back to
+		# the site _make_org_team already created for this org.
+		site=site or _ORG_SITES.get(org.pk),
 		ip_addresses="",
 		begin_date=now() - timedelta(days=1),
 		end_date=now() + timedelta(days=30),
@@ -109,11 +138,13 @@ class ArticleStatsBase(TestCase):
 		# cached stats from a previous test can't leak into this one.
 		cache.clear()
 
-		self.org, self.team = _make_org_team("A-Stats Org", "a-stats-org")
-		self.other_org, self.other_team = _make_org_team(
+		self.org, self.team, self.subject = _make_org_team(
+			"A-Stats Org", "a-stats-org",
+			subject_name="A-Stats Subject", subject_slug="a-stats-subject",
+		)
+		self.other_org, self.other_team, self.other_subject = _make_org_team(
 			"A-Other Stats Org", "a-other-stats-org"
 		)
-		self.subject = _make_subject(self.team, "A-Stats Subject", "a-stats-subject")
 
 		# a1: open access, relevant (manually reviewed for the subject), has
 		# DOI. The stats `relevant` count uses the live per-subject logic —
@@ -229,6 +260,11 @@ class ArticleStatsBySubjectTest(ArticleStatsBase):
 		other_subject = _make_subject(
 			self.other_team, "A-Other Subject", "a-other-subject"
 		)
+		# No organization= here: other_org already has a default site from
+		# _make_org_team, and OrganizationSite allows only one default per
+		# org. Anonymous visibility only needs an api_public site scoping
+		# the subject, so this stands alone.
+		publish_subjects(other_subject)
 		self.a3.subjects.add(self.subject)
 		self.a4.subjects.add(other_subject)
 
@@ -245,6 +281,7 @@ class ArticleStatsBySubjectTest(ArticleStatsBase):
 		other_subject = _make_subject(
 			self.other_team, "A-Other Subject", "a-other-subject"
 		)
+		publish_subjects(other_subject)
 		self.a4.subjects.add(other_subject)
 
 		resp = self.client.get("/articles/stats/", {"team_id": self.team.id})
@@ -257,7 +294,7 @@ class ArticleStatsBySubjectTest(ArticleStatsBase):
 		# A visible (public-org) article tagged with a subject belonging to
 		# a NON-visible org: the subject must not leak into by_subject, even
 		# though the article itself is counted.
-		hidden_org, hidden_team = _make_org_team(
+		hidden_org, hidden_team, _hidden_default_subject = _make_org_team(
 			"A-Hidden Org", "a-hidden-org", public=False
 		)
 		hidden_subject = _make_subject(
@@ -311,11 +348,11 @@ class ArticleStatsCachingTest(ArticleStatsBase):
 		# it, an API key bound to the org can. If the cache key ignored the
 		# caller's visible orgs, whichever request ran first would leak its
 		# stats to the other.
-		priv_org, priv_team = _make_org_team(
+		# Use the org's own default subject (returned by _make_org_team)
+		# rather than a fresh one: the API key below resolves through
+		# _ORG_SITES, which is keyed to that default subject's site.
+		priv_org, priv_team, priv_subject = _make_org_team(
 			"A-Private Stats Org", "a-private-stats-org", public=False
-		)
-		priv_subject = _make_subject(
-			priv_team, "A-Private Subject", "a-private-subject"
 		)
 		priv_article = _make_article(
 			"Private A",
@@ -363,11 +400,15 @@ class ArticleStatsSubjectScopedRelevantTest(TestCase):
 
 	def setUp(self):
 		cache.clear()
-		self.org, self.team = _make_org_team(
+		self.org, self.team, _default_subject = _make_org_team(
 			"A-Scoped Org", "a-scoped-stats-org"
 		)
 		self.subject_n = _make_subject(self.team, "Subject N", "a-scoped-subject-n")
 		self.subject_m = _make_subject(self.team, "Subject M", "a-scoped-subject-m")
+		# Anonymous only; the org already has a default site from
+		# _make_org_team, and a second organization= link would collide with
+		# OrganizationSite's one-default-per-org constraint.
+		publish_subjects(self.subject_n, self.subject_m)
 
 		# In both subjects, manually relevant ONLY for M.
 		self.article = _make_article(

--- a/django/api/tests/test_author_api.py
+++ b/django/api/tests/test_author_api.py
@@ -13,6 +13,8 @@ from gregory.models import (
 from organizations.models import Organization
 from django_countries.fields import Country
 
+from api.tests.visibility_helpers import publish_subjects
+
 
 class AuthorAPITest(TestCase):
 	"""Test cases for Authors API endpoints"""
@@ -32,6 +34,7 @@ class AuthorAPITest(TestCase):
 		self.subject = Subject.objects.create(
 			subject_name="Test Subject", subject_slug="test-subject", team=self.team
 		)
+		publish_subjects(self.subject, organization=self.organization)
 
 		# Create test category
 		self.category = TeamCategory.objects.create(
@@ -199,6 +202,7 @@ class AuthorAPITest(TestCase):
 		other_subject = Subject.objects.create(
 			subject_name="Other Subject", subject_slug="other-subject", team=self.team
 		)
+		publish_subjects(other_subject)
 		other_author = Authors.objects.create(
 			given_name="Extra", family_name="Author"
 		)
@@ -573,6 +577,7 @@ class AuthorRelevantArticlesCountTest(TestCase):
 			subject_slug="relevant-count-subject",
 			team=self.team,
 		)
+		publish_subjects(self.subject, organization=self.organization)
 
 		self.author = Authors.objects.create(given_name="Alice", family_name="Relevant")
 

--- a/django/api/tests/test_author_coauthors.py
+++ b/django/api/tests/test_author_coauthors.py
@@ -13,6 +13,8 @@ from gregory.models import (
 )
 from organizations.models import Organization
 
+from api.tests.visibility_helpers import publish_subjects
+
 
 def _count_cache_hit_is_a_db_query():
 	"""True when a warm CachedCountMixin cache hit costs one extra DB query.
@@ -43,6 +45,7 @@ class AuthorCoauthorsTest(TestCase):
 			subject_slug="coauthors-subject",
 			team=self.team,
 		)
+		publish_subjects(self.subject, organization=self.organization)
 
 		self.target = Authors.objects.create(given_name="Target", family_name="Author")
 		self.coauthor_a = Authors.objects.create(given_name="Alpha", family_name="Coauthor")
@@ -199,6 +202,7 @@ class AuthorCoauthorsQueryCountTest(TestCase):
 			subject_slug="coauthors-query-subject",
 			team=self.team,
 		)
+		publish_subjects(self.subject, organization=self.organization)
 
 		self.target = Authors.objects.create(given_name="Query", family_name="Target")
 

--- a/django/api/tests/test_author_filter.py
+++ b/django/api/tests/test_author_filter.py
@@ -1,8 +1,10 @@
 from django.test import TestCase
 from rest_framework.test import APIClient
 from rest_framework import status
-from gregory.models import Authors, Articles, Team, OrganizationApiSettings
+from gregory.models import Authors, Articles, Team, Subject, OrganizationApiSettings
 from organizations.models import Organization
+
+from api.tests.visibility_helpers import publish_subjects
 
 
 class AuthorFilterTests(TestCase):
@@ -19,6 +21,12 @@ class AuthorFilterTests(TestCase):
 		team = Team.objects.create(
 			name="Author Filter Team", slug="aut-filter-team", organization=org
 		)
+		subject = Subject.objects.create(
+			subject_name="Author Filter Subject",
+			subject_slug="aut-filter-subject",
+			team=team,
+		)
+		publish_subjects(subject, organization=org)
 
 		# Create test authors
 		self.author1 = Authors.objects.create(
@@ -38,6 +46,7 @@ class AuthorFilterTests(TestCase):
 				link=f"https://example.com/aut-filter/{author.author_id}",
 			)
 			a.teams.add(team)
+			a.subjects.add(subject)
 			a.authors.add(author)
 
 		self.client = APIClient()

--- a/django/api/tests/test_author_pagination_cap.py
+++ b/django/api/tests/test_author_pagination_cap.py
@@ -1,11 +1,12 @@
 from unittest import mock
 
 from rest_framework.test import APITestCase, APIClient
-from gregory.models import Articles, Authors, OrganizationApiSettings, Team
+from gregory.models import Articles, Authors, OrganizationApiSettings, Subject, Team
 from django.contrib.auth.models import User
 from organizations.models import Organization
 
 from api.pagination import CappedPageNumberPagination
+from api.tests.visibility_helpers import publish_subjects
 
 
 class TestAuthorsPaginationCap(APITestCase):
@@ -78,12 +79,17 @@ class TestAuthorsPageLastOffsetCap(APITestCase):
 		team = Team.objects.create(
 			organization=org, name="Page Last Team", slug="page-last-team"
 		)
+		subject = Subject.objects.create(
+			subject_name="Page Last Subject", subject_slug="page-last-subject", team=team
+		)
+		publish_subjects(subject, organization=org)
 		for i in range(15):
 			author = Authors.objects.create(given_name=f"A{i}", family_name="Last")
 			article = Articles.objects.create(
 				title=f"Page Last Article {i}", link=f"https://ex.com/page-last-{i}"
 			)
 			article.teams.add(team)
+			article.subjects.add(subject)
 			article.authors.add(author)
 
 		self.client = APIClient()

--- a/django/api/tests/test_author_search.py
+++ b/django/api/tests/test_author_search.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
 from django.urls import reverse
 from rest_framework.test import APIClient
+from api.tests.visibility_helpers import publish_subjects
 from gregory.models import (
 	Authors,
 	Articles,
@@ -28,6 +29,9 @@ class AuthorSearchViewTests(TestCase):
 		self.subject = Subject.objects.create(
 			subject_name="Test Subject", subject_slug="test-subject", team=self.team
 		)
+		# /authors/search/ validates subject_id against the caller's subject
+		# scope, so the subject must be published or every search 404s.
+		publish_subjects(self.subject, organization=self.organization)
 
 		self.author1 = Authors.objects.create(given_name="Jane", family_name="Doe")
 		self.author2 = Authors.objects.create(given_name="John", family_name="Smith")

--- a/django/api/tests/test_author_url_format.py
+++ b/django/api/tests/test_author_url_format.py
@@ -1,8 +1,9 @@
 from django.test import TestCase, override_settings
 from rest_framework.test import APIClient
 from rest_framework import status
-from gregory.models import Authors, Articles, Team, OrganizationApiSettings
+from gregory.models import Authors, Articles, Team, Subject, OrganizationApiSettings
 from api.serializers import AuthorSerializer
+from api.tests.visibility_helpers import publish_subjects
 from django.contrib.sites.models import Site
 from organizations.models import Organization
 
@@ -19,6 +20,10 @@ class AuthorURLFormatTests(TestCase):
 		team = Team.objects.create(
 			name="URL Format Team", slug="url-fmt-team", organization=org
 		)
+		subject = Subject.objects.create(
+			subject_name="URL Format Subject", subject_slug="url-fmt-subject", team=team
+		)
+		publish_subjects(subject, organization=org)
 
 		# Create test author
 		self.author = Authors.objects.create(
@@ -31,6 +36,7 @@ class AuthorURLFormatTests(TestCase):
 			link="https://example.com/url-fmt",
 		)
 		article.teams.add(team)
+		article.subjects.add(subject)
 		article.authors.add(self.author)
 
 		# Set up site for URL generation

--- a/django/api/tests/test_boolean_search.py
+++ b/django/api/tests/test_boolean_search.py
@@ -10,6 +10,7 @@ from rest_framework import status
 from rest_framework.test import APIClient
 
 from api.filters import ArticleFilter, TrialFilter
+from api.tests.visibility_helpers import publish_subjects
 from api.utils.search import build_search_q, _tokenize
 from gregory.models import (
 	Articles,
@@ -315,6 +316,7 @@ class ArticleViewSetBooleanSearchE2ETests(TestCase):
 		self.subject = Subject.objects.create(
 			subject_name="Bool Subject", subject_slug="bool-subject", team=self.team
 		)
+		publish_subjects(self.subject, organization=self.org)
 
 		# No single article contains every term — mirrors the production category
 		# query (artemisinin OR dihydroartemisinin OR …) that returned nothing.
@@ -381,6 +383,7 @@ class TrialViewSetBooleanSearchE2ETests(TestCase):
 			subject_slug="bool-trial-subject",
 			team=self.team,
 		)
+		publish_subjects(self.subject, organization=self.org)
 		self.t_myelin = Trials.objects.create(
 			title="Myelin restoration trial",
 			link="https://example.com/te1",

--- a/django/api/tests/test_category_count_annotations.py
+++ b/django/api/tests/test_category_count_annotations.py
@@ -22,6 +22,7 @@ from django.utils.text import slugify
 from rest_framework.test import APIClient
 
 from api.serializers import CategorySerializer
+from api.tests.visibility_helpers import publish_subjects
 from api.views import CategoryViewSet, _category_through_count_subquery
 from gregory.models import (
 	ArticleCategoryAssignment,
@@ -63,6 +64,7 @@ class CategoryCountAnnotationTests(TestCase):
 			subject_slug="category-count-subject",
 			team=self.team,
 		)
+		publish_subjects(self.subject, organization=self.organization)
 		self.category = _make_category(self.team, self.subject, "Count Test Category")
 
 		for i in range(5):
@@ -210,6 +212,7 @@ class CategoryAuthorsCountOrderingTests(TestCase):
 			subject_slug="authors-ordering-subject",
 			team=self.team,
 		)
+		publish_subjects(self.subject, organization=self.organization)
 
 		# Two categories with a known, different number of distinct authors.
 		# The 3-author category shares one author across two articles, so a

--- a/django/api/tests/test_category_count_annotations.py
+++ b/django/api/tests/test_category_count_annotations.py
@@ -74,6 +74,7 @@ class CategoryCountAnnotationTests(TestCase):
 				published_date=timezone.now(),
 			)
 			article.team_categories.add(self.category)
+			article.subjects.add(self.subject)
 
 		for i in range(3):
 			trial = Trials.objects.create(
@@ -82,6 +83,7 @@ class CategoryCountAnnotationTests(TestCase):
 				published_date=timezone.now(),
 			)
 			trial.team_categories.add(self.category)
+			trial.subjects.add(self.subject)
 
 		self.client = APIClient()
 
@@ -108,10 +110,10 @@ class CategoryCountAnnotationTests(TestCase):
 		annotated_obj = (
 			TeamCategory.objects.annotate(
 				article_count_annotated=_category_through_count_subquery(
-					ArticleCategoryAssignment
+					ArticleCategoryAssignment, "articles"
 				),
 				trials_count_annotated=_category_through_count_subquery(
-					TrialCategoryAssignment
+					TrialCategoryAssignment, "trials"
 				),
 			)
 			.get(pk=self.category.pk)
@@ -147,6 +149,7 @@ class CategoryCountAnnotationTests(TestCase):
 				published_date=timezone.now(),
 			)
 			article.team_categories.add(self.category)
+			article.subjects.add(self.subject)
 		for i in range(12):
 			trial = Trials.objects.create(
 				title=f"Fanout Guard Trial {i}",
@@ -154,6 +157,7 @@ class CategoryCountAnnotationTests(TestCase):
 				published_date=timezone.now(),
 			)
 			trial.team_categories.add(self.category)
+			trial.subjects.add(self.subject)
 
 		url = reverse("categories-list")
 		with CaptureQueriesContext(connection) as ctx:
@@ -235,6 +239,7 @@ class CategoryAuthorsCountOrderingTests(TestCase):
 				published_date=timezone.now(),
 			)
 			article.team_categories.add(self.many_authors)
+			article.subjects.add(self.subject)
 			article.authors.add(shared, extra)
 
 		article = Articles.objects.create(
@@ -243,6 +248,7 @@ class CategoryAuthorsCountOrderingTests(TestCase):
 			published_date=timezone.now(),
 		)
 		article.team_categories.add(self.few_authors)
+		article.subjects.add(self.subject)
 		article.authors.add(authors[3])
 
 		self.client = APIClient()
@@ -338,11 +344,13 @@ class CategoryAuthorsCountOrderingTests(TestCase):
 	def test_ordering_by_trials_count_uses_the_free_annotation(self):
 		"""trials_count_annotated is always on the queryset, so sorting by it
 		must not add the expensive authors count."""
-		Trials.objects.create(
+		ordering_trial = Trials.objects.create(
 			title="Ordering Trial",
 			link="https://example.com/ordering-trial",
 			published_date=timezone.now(),
-		).team_categories.add(self.many_authors)
+		)
+		ordering_trial.team_categories.add(self.many_authors)
+		ordering_trial.subjects.add(self.subject)
 
 		url = reverse("categories-list")
 		with CaptureQueriesContext(connection) as ctx:

--- a/django/api/tests/test_category_modality_api.py
+++ b/django/api/tests/test_category_modality_api.py
@@ -25,6 +25,8 @@ from gregory.models import (
 	Trials,
 )
 
+from api.tests.visibility_helpers import publish_subjects
+
 
 class CategoryModalityAPITestCase(TestCase):
 	def setUp(self):
@@ -41,6 +43,7 @@ class CategoryModalityAPITestCase(TestCase):
 		self.subject = Subject.objects.create(
 			subject_name="Modality Subject", subject_slug="modality-subject", team=self.team
 		)
+		publish_subjects(self.subject, organization=org)
 
 	def _make_category(self, name, slug, modality=None):
 		category = TeamCategory.objects.create(
@@ -54,7 +57,10 @@ class CategoryModalityAPITestCase(TestCase):
 		trial.teams.add(self.team)
 		for category in categories:
 			trial.team_categories.add(category)
-		for subject in subjects:
+		# Every other call site in this file predates subject-scoped
+		# visibility and doesn't pass subjects=; default to the fixture's
+		# one subject (already published) so those trials stay visible.
+		for subject in (subjects or (self.subject,)):
 			trial.subjects.add(subject)
 		return trial
 
@@ -93,6 +99,7 @@ class CategorySerializerModalityTests(CategoryModalityAPITestCase):
 			title="Modality Article", link="https://example.com/modality-article-1"
 		)
 		article.teams.add(self.team)
+		article.subjects.add(self.subject)
 		article.team_categories.add(category)
 		resp = self.client.get(f"/articles/{article.article_id}/")
 		self.assertEqual(resp.status_code, 200)
@@ -176,12 +183,14 @@ class CategoryModalityFilterTests(CategoryModalityAPITestCase):
 			title="Antibody Article", link="https://example.com/modality-article-filter-1"
 		)
 		matching.teams.add(self.team)
+		matching.subjects.add(self.subject)
 		matching.team_categories.add(self.antibody_category)
 		non_matching = Articles.objects.create(
 			title="Small Molecule Article",
 			link="https://example.com/modality-article-filter-2",
 		)
 		non_matching.teams.add(self.team)
+		non_matching.subjects.add(self.subject)
 		non_matching.team_categories.add(self.small_molecule_category)
 
 		resp = self.client.get("/articles/", {"category_modality": "biologic_antibody"})

--- a/django/api/tests/test_csv_pagination.py
+++ b/django/api/tests/test_csv_pagination.py
@@ -1,9 +1,11 @@
 import unittest
 from django.http import StreamingHttpResponse
 from rest_framework.test import APITestCase, APIClient
-from gregory.models import Articles, Team, Sources
+from gregory.models import Articles, Subject, Team, Sources
 from organizations.models import Organization
 from django.contrib.auth.models import User
+
+from api.tests.visibility_helpers import publish_subjects
 
 
 class TestCSVRenderer(APITestCase):
@@ -29,6 +31,13 @@ class TestCSVRenderer(APITestCase):
 			name="Test Source", source_for="science paper"
 		)
 
+		self.subject = Subject.objects.create(
+			subject_name="CSV Pagination Subject",
+			subject_slug="csv-pagination-subject",
+			team=self.team,
+		)
+		publish_subjects(self.subject, organization=self.organization)
+
 		# Create test articles
 		for i in range(1, 21):  # Create 20 articles for pagination testing
 			article = Articles.objects.create(
@@ -39,6 +48,7 @@ class TestCSVRenderer(APITestCase):
 			)
 			article.sources.add(self.source)
 			article.teams.add(self.team)
+			article.subjects.add(self.subject)
 
 		# Set up API client
 		self.client = APIClient()

--- a/django/api/tests/test_enhanced_filters.py
+++ b/django/api/tests/test_enhanced_filters.py
@@ -13,6 +13,8 @@ from gregory.models import (
 )
 from django.utils import timezone
 
+from api.tests.visibility_helpers import publish_subjects
+
 
 class TrialFilterTests(TestCase):
 	"""Test cases for enhanced trial filtering"""
@@ -32,6 +34,7 @@ class TrialFilterTests(TestCase):
 		cls.subject = Subject.objects.create(
 			subject_name="Test Subject", subject_slug="test-subject", team=cls.team
 		)
+		publish_subjects(cls.subject, organization=cls.organization)
 
 		# Create test trials with various fields
 		cls.trial1 = Trials.objects.create(
@@ -294,6 +297,12 @@ class AuthorFilterTests(TestCase):
 		cls.team = Team.objects.create(
 			name="Author Filter Team", slug="author-filter-team", organization=cls.org
 		)
+		cls.subject = Subject.objects.create(
+			subject_name="Author Filter Subject",
+			subject_slug="author-filter-subject",
+			team=cls.team,
+		)
+		publish_subjects(cls.subject, organization=cls.org)
 
 		# Create test authors
 		cls.author1 = Authors.objects.create(
@@ -318,6 +327,7 @@ class AuthorFilterTests(TestCase):
 				link=f"https://example.com/{author.ORCID}",
 			)
 			a.teams.add(cls.team)
+			a.subjects.add(cls.subject)
 			a.authors.add(author)
 
 	def setUp(self):
@@ -416,6 +426,7 @@ class CategoryFilterTests(TestCase):
 			category_terms=["test", "category", "example"],
 		)
 		self.category.subjects.add(self.subject)
+		publish_subjects(self.subject, organization=self.organization)
 
 		self.client = APIClient()
 

--- a/django/api/tests/test_has_clinical_trials_filter.py
+++ b/django/api/tests/test_has_clinical_trials_filter.py
@@ -2,10 +2,12 @@ from django.test import TestCase
 from rest_framework.test import APIClient
 from rest_framework import status
 
+from api.tests.visibility_helpers import publish_subjects
 from gregory.models import (
 	Articles,
 	Trials,
 	ArticleTrialReference,
+	Subject,
 	Team,
 	OrganizationApiSettings,
 )
@@ -28,6 +30,13 @@ class HasClinicalTrialsFilterTests(TestCase):
 		self.team = Team.objects.create(
 			name="Clin Filter Team", slug="clin-filter-team", organization=org
 		)
+		# Subject scope, not the org flag, is what makes content readable.
+		self.subject = Subject.objects.create(
+			subject_name="Clin Filter Subject",
+			subject_slug="clin-filter-subject",
+			team=self.team,
+		)
+		publish_subjects(self.subject, organization=org)
 
 		# Article linked to a trial
 		self.article_with_trial = Articles.objects.create(
@@ -35,6 +44,7 @@ class HasClinicalTrialsFilterTests(TestCase):
 			link="https://example.com/article-with-trial",
 		)
 		self.article_with_trial.teams.add(self.team)
+		self.article_with_trial.subjects.add(self.subject)
 
 		# Article with no trial link
 		self.article_without_trial = Articles.objects.create(
@@ -42,6 +52,7 @@ class HasClinicalTrialsFilterTests(TestCase):
 			link="https://example.com/article-without-trial",
 		)
 		self.article_without_trial.teams.add(self.team)
+		self.article_without_trial.subjects.add(self.subject)
 
 		# Trial to link
 		self.trial = Trials.objects.create(

--- a/django/api/tests/test_ml_predictions_payload.py
+++ b/django/api/tests/test_ml_predictions_payload.py
@@ -14,6 +14,7 @@ from django.urls import reverse
 from django.utils import timezone
 from rest_framework.test import APIClient
 
+from api.tests.visibility_helpers import publish_subjects
 from gregory.models import (
 	Articles,
 	MLPredictions,
@@ -53,6 +54,7 @@ class ArticleMlPredictionsPayloadTests(TestCase):
 			subject_slug="ml-payload-subject",
 			team=self.team,
 		)
+		publish_subjects(self.subject, organization=self.organization)
 		self.article = Articles.objects.create(
 			title="ML Payload Article",
 			summary="Article used to test ml_predictions payload filtering.",

--- a/django/api/tests/test_ml_score_ordering.py
+++ b/django/api/tests/test_ml_score_ordering.py
@@ -6,6 +6,7 @@ from organizations.models import Organization
 from rest_framework import status
 from rest_framework.test import APIClient
 
+from api.tests.visibility_helpers import publish_subjects
 from gregory.models import Articles, MLPredictions, OrganizationApiSettings, Sources, Subject, Team
 
 
@@ -21,6 +22,7 @@ class MlScoreOrderingTestCase(TestCase):
 		self.subject = Subject.objects.create(
 			subject_name="ML Subject", subject_slug="ml-subject", team=self.team
 		)
+		publish_subjects(self.subject, organization=org)
 		source = Sources.objects.create(name="ML Source", link="http://mlsource.com")
 
 		def make_article(title, link, score):
@@ -104,6 +106,7 @@ class MlScoreSignalIntegrationTestCase(TestCase):
 		self.subject = Subject.objects.create(
 			subject_name="Sig Subject", subject_slug="sig-subject", team=self.team
 		)
+		publish_subjects(self.subject, organization=org)
 		self.article = Articles.objects.create(
 			title="Signal integration article",
 			link="https://ex.com/siginteg",

--- a/django/api/tests/test_monthly_relevant_counts.py
+++ b/django/api/tests/test_monthly_relevant_counts.py
@@ -19,6 +19,7 @@ from django.utils.timezone import now
 from organizations.models import Organization
 from rest_framework.test import APIClient
 
+from api.tests.visibility_helpers import publish_subjects
 from gregory.models import (
 	Articles,
 	MLPredictions,
@@ -54,6 +55,7 @@ class MonthlyRelevantCountsTest(TestCase):
 			category_slug="relevant-category",
 		)
 		cls.category.subjects.add(cls.subject)
+		publish_subjects(cls.subject, organization=org)
 
 		# April: three relevant articles flagged by overlapping models plus one
 		# without predictions. The naive per-model sum is 5 (lstm 2 + pubmed_bert 2
@@ -265,6 +267,7 @@ class MonthlyCountsPerModelLatestPredictionTest(TestCase):
 			category_slug="latest-pred-category",
 		)
 		self.category.subjects.add(self.subject)
+		publish_subjects(self.subject, organization=org)
 
 		# Superseded DOWN: an old lstm prediction cleared the threshold, but the
 		# newest lstm prediction for the same article dropped below it. Must NOT
@@ -369,6 +372,7 @@ class MonthlyCountsAvailableModelsTest(TestCase):
 			category_slug="avail-models-category",
 		)
 		self.category.subjects.add(self.subject)
+		publish_subjects(self.subject, organization=org)
 
 		article = Articles.objects.create(
 			title="Below threshold algo",

--- a/django/api/tests/test_multi_subject_filter.py
+++ b/django/api/tests/test_multi_subject_filter.py
@@ -14,6 +14,8 @@ from gregory.models import (
 	MLPredictions,
 )
 
+from api.tests.visibility_helpers import publish_subjects
+
 
 class ArticleMultiSubjectFilterTests(TestCase):
 	"""Tests for the ?subjects= AND-filter on /articles/"""
@@ -43,6 +45,7 @@ class ArticleMultiSubjectFilterTests(TestCase):
 			subject_slug="subject-c",
 			team=cls.team,
 		)
+		publish_subjects(cls.subject_a, cls.subject_b, cls.subject_c, organization=cls.org)
 
 		# article_ab  → subjects A + B
 		cls.article_ab = Articles.objects.create(
@@ -248,6 +251,7 @@ class ArticleSubjectAnyFilterTests(TestCase):
 			subject_slug="any-subject-c",
 			team=cls.team,
 		)
+		publish_subjects(cls.subject_a, cls.subject_b, cls.subject_c, organization=cls.org)
 
 		# article_a  → subject A only
 		cls.article_a = Articles.objects.create(
@@ -356,6 +360,7 @@ class TrialMultiSubjectFilterTests(TestCase):
 			subject_slug="trial-subject-b",
 			team=cls.team,
 		)
+		publish_subjects(cls.subject_a, cls.subject_b, organization=cls.org)
 
 		cls.trial_ab = Trials.objects.create(
 			title="Trial AB",
@@ -455,6 +460,7 @@ class TrialSubjectAnyFilterTests(TestCase):
 			subject_slug="trial-any-subject-c",
 			team=cls.team,
 		)
+		publish_subjects(cls.subject_a, cls.subject_b, cls.subject_c, organization=cls.org)
 
 		cls.trial_a = Trials.objects.create(
 			title="Trial Any A",
@@ -574,6 +580,7 @@ class RelevantFilterSubjectScopingTests(TestCase):
 			auto_predict=True,
 			ml_consensus_type="any",
 		)
+		publish_subjects(cls.subject_x, cls.subject_y, organization=cls.org)
 
 		# Tagged with BOTH subjects, but only ML-consensus-relevant for X.
 		cls.article = Articles.objects.create(

--- a/django/api/tests/test_org_scoped_serializer_mixin.py
+++ b/django/api/tests/test_org_scoped_serializer_mixin.py
@@ -54,12 +54,18 @@ def _make_team_category(team, name):
 	)
 
 
-def _request_with_visible(visible_ids):
-	"""Build a fake request with a pre-set visible_org_ids attribute."""
+def _request_with_visible_subjects(visible_subject_ids):
+	"""Build a fake request with a pre-set visible_subject_ids attribute.
+
+	ScopedSerializerMixin reads request.visible_subject_ids now (Phase 4 of
+	site-scoped API visibility), not visible_org_ids -- see the mixin's
+	docstring. A request carrying only visible_org_ids is indistinguishable
+	from one with no middleware at all, as far as the mixin is concerned.
+	"""
 	factory = RequestFactory()
 	req = factory.get("/")
 	req.user = AnonymousUser()
-	req.visible_org_ids = visible_ids
+	req.visible_subject_ids = visible_subject_ids
 	return req
 
 
@@ -152,36 +158,53 @@ class _TestArticleSerializer(ScopedSerializerMixin, serializers.ModelSerializer)
 
 
 class ScopedSerializerMixinTeamsTest(TestCase):
+	"""Team stripping no longer depends on the caller's scope at all.
+
+	Before Phase 4, a team's visibility here followed request.visible_org_ids
+	-- the same rule that governed article/subject visibility. Now a Team
+	carries no subject, so subject scope has nothing to say about it: the
+	mixin strips a nested team by its own Team.api_listed flag, which is
+	identical for every caller. Re-deriving it from visible_org_ids (or
+	visible_subject_ids) would resurrect the ownership-based rule this
+	project removes -- see ScopedSerializerMixin's docstring and
+	test_visibility_teams.py.
+	"""
+
 	def setUp(self):
 		self.org_a = _make_org("Org A", "org-a-m", public=False)
 		self.org_b = _make_org("Org B", "org-b-m", public=False)
 		self.team_a = _make_team(self.org_a, "Team A")
 		self.team_b = _make_team(self.org_b, "Team B")
+		Team.objects.filter(pk=self.team_a.pk).update(api_listed=True)
+		Team.objects.filter(pk=self.team_b.pk).update(api_listed=False)
 
 		self.article = _make_article()
 		self.article.teams.add(self.team_a, self.team_b)
 
-	def test_teams_stripped_for_hidden_org(self):
-		"""Only team_a should appear when org_b is not visible."""
-		req = _request_with_visible({self.org_a.id})
+	def test_unlisted_team_stripped_regardless_of_subject_scope(self):
+		"""team_b is unlisted, so it's stripped even though the caller's
+		subject scope has nothing to do with either team."""
+		req = _request_with_visible_subjects({1, 2, 3})
 		data = _TestArticleSerializer(self.article, context={"request": req}).data
 		team_ids = [t["id"] for t in data["teams"]]
 		self.assertIn(self.team_a.id, team_ids)
 		self.assertNotIn(self.team_b.id, team_ids)
 
-	def test_both_teams_visible_when_both_orgs_visible(self):
-		req = _request_with_visible({self.org_a.id, self.org_b.id})
+	def test_listed_team_shown_even_with_empty_subject_scope(self):
+		"""A listed team's name survives a caller with no visible subjects at
+		all -- proof that this is not a subject-scope check in disguise."""
+		req = _request_with_visible_subjects(set())
 		data = _TestArticleSerializer(self.article, context={"request": req}).data
 		team_ids = [t["id"] for t in data["teams"]]
 		self.assertIn(self.team_a.id, team_ids)
-		self.assertIn(self.team_b.id, team_ids)
+		self.assertNotIn(self.team_b.id, team_ids)
 
 	def test_no_middleware_returns_all_teams(self):
-		"""When request has no visible_org_ids, the mixin is a no-op."""
+		"""When request has no visible_subject_ids, the mixin is a no-op."""
 		factory = RequestFactory()
 		req = factory.get("/")
 		req.user = AnonymousUser()
-		# No visible_org_ids attribute set
+		# No visible_subject_ids attribute set
 		data = _TestArticleSerializer(self.article, context={"request": req}).data
 		team_ids = [t["id"] for t in data["teams"]]
 		self.assertIn(self.team_a.id, team_ids)
@@ -208,7 +231,7 @@ class ScopedSerializerMixinSubjectsTest(TestCase):
 		self.article.subjects.add(self.subject_a, self.subject_b)
 
 	def test_hidden_subjects_stripped(self):
-		req = _request_with_visible({self.org_a.id})
+		req = _request_with_visible_subjects({self.subject_a.id})
 		data = _TestArticleSerializer(self.article, context={"request": req}).data
 		subject_ids = [s["id"] for s in data["subjects"]]
 		self.assertIn(self.subject_a.id, subject_ids)
@@ -244,7 +267,7 @@ class ScopedSerializerMixinMLPredictionsTest(TestCase):
 		)
 
 	def test_hidden_ml_predictions_stripped(self):
-		req = _request_with_visible({self.org_a.id})
+		req = _request_with_visible_subjects({self.subject_a.id})
 		data = _TestArticleSerializer(self.article, context={"request": req}).data
 		pred_ids = [p["id"] for p in data["ml_predictions"]]
 		self.assertIn(self.pred_a.id, pred_ids)
@@ -282,14 +305,14 @@ class ScopedSerializerMixinMLPredictionsNestedSubjectTest(TestCase):
 		)
 
 	def test_hidden_ml_predictions_stripped_nested_subject(self):
-		req = _request_with_visible({self.org_a.id})
+		req = _request_with_visible_subjects({self.subject_a.id})
 		data = _TestArticleNestedSubjectSerializer(self.article, context={"request": req}).data
 		pred_ids = [p["id"] for p in data["ml_predictions"]]
 		self.assertIn(self.pred_a.id, pred_ids)
 		self.assertNotIn(self.pred_b.id, pred_ids)
 
 	def test_nested_subject_shape(self):
-		req = _request_with_visible({self.org_a.id})
+		req = _request_with_visible_subjects({self.subject_a.id})
 		data = _TestArticleNestedSubjectSerializer(self.article, context={"request": req}).data
 		self.assertEqual(len(data["ml_predictions"]), 1)
 		subject = data["ml_predictions"][0]["subject"]

--- a/django/api/tests/test_org_scoped_serializer_mixin.py
+++ b/django/api/tests/test_org_scoped_serializer_mixin.py
@@ -1,5 +1,5 @@
 """
-Tests for api.serializers.mixins.OrgScopedSerializerMixin.
+Tests for api.serializers.mixins.ScopedSerializerMixin.
 
 Run with:
     docker exec gregory python manage.py test api.tests.test_org_scoped_serializer_mixin
@@ -17,7 +17,7 @@ from gregory.models import (
 	MLPredictions,
 	OrganizationApiSettings,
 )
-from api.serializers.mixins import OrgScopedSerializerMixin
+from api.serializers.mixins import ScopedSerializerMixin
 
 
 def _make_org(name, slug, public=False):
@@ -106,7 +106,7 @@ class _MLPredictionsNestedSerializer(serializers.ModelSerializer):
 		fields = ["id", "subject", "algorithm", "probability_score"]
 
 
-class _TestArticleNestedSubjectSerializer(OrgScopedSerializerMixin, serializers.ModelSerializer):
+class _TestArticleNestedSubjectSerializer(ScopedSerializerMixin, serializers.ModelSerializer):
 	teams = _TeamSerializer(many=True, read_only=True)
 	subjects = _SubjectSerializer(many=True, read_only=True)
 	team_categories = _TeamCategorySerializer(many=True, read_only=True)
@@ -126,7 +126,7 @@ class _TestArticleNestedSubjectSerializer(OrgScopedSerializerMixin, serializers.
 		]
 
 
-class _TestArticleSerializer(OrgScopedSerializerMixin, serializers.ModelSerializer):
+class _TestArticleSerializer(ScopedSerializerMixin, serializers.ModelSerializer):
 	teams = _TeamSerializer(many=True, read_only=True)
 	subjects = _SubjectSerializer(many=True, read_only=True)
 	team_categories = _TeamCategorySerializer(many=True, read_only=True)
@@ -151,7 +151,7 @@ class _TestArticleSerializer(OrgScopedSerializerMixin, serializers.ModelSerializ
 # ---------------------------------------------------------------------------
 
 
-class OrgScopedSerializerMixinTeamsTest(TestCase):
+class ScopedSerializerMixinTeamsTest(TestCase):
 	def setUp(self):
 		self.org_a = _make_org("Org A", "org-a-m", public=False)
 		self.org_b = _make_org("Org B", "org-b-m", public=False)
@@ -193,7 +193,7 @@ class OrgScopedSerializerMixinTeamsTest(TestCase):
 		self.assertIn("teams", data)
 
 
-class OrgScopedSerializerMixinSubjectsTest(TestCase):
+class ScopedSerializerMixinSubjectsTest(TestCase):
 	def setUp(self):
 		self.org_a = _make_org("Org A", "org-a-s", public=False)
 		self.org_b = _make_org("Org B", "org-b-s", public=False)
@@ -215,7 +215,7 @@ class OrgScopedSerializerMixinSubjectsTest(TestCase):
 		self.assertNotIn(self.subject_b.id, subject_ids)
 
 
-class OrgScopedSerializerMixinMLPredictionsTest(TestCase):
+class ScopedSerializerMixinMLPredictionsTest(TestCase):
 	def setUp(self):
 		self.org_a = _make_org("Org A", "org-a-ml", public=False)
 		self.org_b = _make_org("Org B", "org-b-ml", public=False)
@@ -251,7 +251,7 @@ class OrgScopedSerializerMixinMLPredictionsTest(TestCase):
 		self.assertNotIn(self.pred_b.id, pred_ids)
 
 
-class OrgScopedSerializerMixinMLPredictionsNestedSubjectTest(TestCase):
+class ScopedSerializerMixinMLPredictionsNestedSubjectTest(TestCase):
 	"""Verify visibility filtering works when subject is a nested dict (new shape)."""
 
 	def setUp(self):

--- a/django/api/tests/test_paginator_count_cache.py
+++ b/django/api/tests/test_paginator_count_cache.py
@@ -15,8 +15,10 @@ from rest_framework.test import APIClient
 
 from api.pagination import CappedPageNumberPagination
 
-from gregory.models import Articles, OrganizationApiSettings, Team, Trials
+from gregory.models import Articles, OrganizationApiSettings, Subject, Team, Trials
 from organizations.models import Organization
+
+from api.tests.visibility_helpers import publish_subjects
 
 
 class CountCacheSmokeTest(TestCase):
@@ -28,16 +30,22 @@ class CountCacheSmokeTest(TestCase):
 		self.team = Team.objects.create(
 			organization=self.org, name="Smoke Team", slug="smoke-team"
 		)
+		self.subject = Subject.objects.create(
+			subject_name="Smoke Subject", subject_slug="smoke-subject", team=self.team
+		)
+		publish_subjects(self.subject, organization=self.org)
 		for i in range(3):
 			a = Articles.objects.create(
 				title=f"Smoke {i}", link=f"https://ex.com/smoke-{i}"
 			)
 			a.teams.add(self.team)
+			a.subjects.add(self.subject)
 		for i in range(2):
 			t = Trials.objects.create(
 				title=f"Smoke Trial {i}", link=f"https://ex.com/smoke-trial-{i}"
 			)
 			t.teams.add(self.team)
+			t.subjects.add(self.subject)
 
 		self.client = APIClient()
 
@@ -132,14 +140,15 @@ class CountCacheSmokeTest(TestCase):
 
 
 class CountCacheSubjectScopeTests(TestCase):
-	"""Site-scoped API visibility, Phase 4: the subject scope is part of the
-	cache key.
+	"""Site-scoped API visibility, Phase 4: the subject scope is the cache
+	key's scope component -- visible_org_ids is no longer part of it at all.
 
-	The key hashes the org scope AND the subject scope during the transition.
-	Call sites convert file by file, so some responses are still org-scoped
-	while others are subject-scoped; keying on only one of them could serve a
-	count computed under one rule to a caller scoped by the other. The org
-	half retires in Phase 6 along with visible_org_ids.
+	Every endpoint sharing CappedPageNumberPagination (articles, trials,
+	sponsors, authors, the three search views) selects its rows by subject
+	now, so a cached count IS a count over a subject scope; there is no
+	longer a paginated org-keyed endpoint for visible_org_ids to protect,
+	and hashing it too would only fragment the cache for no isolation
+	benefit. See CappedPageNumberPagination._count_cache_key's comment.
 	"""
 
 	def setUp(self):
@@ -162,10 +171,15 @@ class CountCacheSubjectScopeTests(TestCase):
 			self._key(same_orgs, {3, 4}),
 		)
 
-	def test_different_org_scopes_still_do_not_share_a_cache_entry(self):
-		"""The pre-existing property, unchanged by adding subjects."""
+	def test_org_scope_no_longer_affects_the_cache_key(self):
+		"""Superseded rule: this used to assert isolation on visible_org_ids
+		too (the pre-Phase-4 cache key's whole scope component). Now that
+		every endpoint sharing this paginator selects rows by subject,
+		visible_org_ids plays no part in what a cached count means -- two
+		callers who differ only in org scope but share a subject scope
+		legitimately hit the same cache entry."""
 		same_subjects = {1}
-		self.assertNotEqual(
+		self.assertEqual(
 			self._key({1}, same_subjects),
 			self._key({2}, same_subjects),
 		)

--- a/django/api/tests/test_paginator_count_cache.py
+++ b/django/api/tests/test_paginator_count_cache.py
@@ -9,9 +9,11 @@ Run with:
 """
 
 from django.db import connection
-from django.test import TestCase
+from django.test import RequestFactory, TestCase
 from django.test.utils import CaptureQueriesContext
 from rest_framework.test import APIClient
+
+from api.pagination import CappedPageNumberPagination
 
 from gregory.models import Articles, OrganizationApiSettings, Team, Trials
 from organizations.models import Organization
@@ -126,4 +128,62 @@ class CountCacheSmokeTest(TestCase):
 			self._real_count_queries(ctx.captured_queries),
 			[],
 			"different sort_by/order should reuse the same count cache entry",
+		)
+
+
+class CountCacheSubjectScopeTests(TestCase):
+	"""Site-scoped API visibility, Phase 4: the subject scope is part of the
+	cache key.
+
+	The key hashes the org scope AND the subject scope during the transition.
+	Call sites convert file by file, so some responses are still org-scoped
+	while others are subject-scoped; keying on only one of them could serve a
+	count computed under one rule to a caller scoped by the other. The org
+	half retires in Phase 6 along with visible_org_ids.
+	"""
+
+	def setUp(self):
+		self.factory = RequestFactory()
+
+	def _key(self, org_ids, subject_ids):
+		request = self.factory.get("/articles/")
+		request.visible_org_ids = org_ids
+		request.visible_subject_ids = subject_ids
+		# DRF's query_params is a thin wrapper over GET on a plain request.
+		request.query_params = request.GET
+		return CappedPageNumberPagination()._count_cache_key(request)
+
+	def test_different_subject_scopes_do_not_share_a_cache_entry(self):
+		"""The property the whole key exists for. Two callers whose org scope
+		happens to match but whose subject scope differs must not collide."""
+		same_orgs = {1}
+		self.assertNotEqual(
+			self._key(same_orgs, {1, 2}),
+			self._key(same_orgs, {3, 4}),
+		)
+
+	def test_different_org_scopes_still_do_not_share_a_cache_entry(self):
+		"""The pre-existing property, unchanged by adding subjects."""
+		same_subjects = {1}
+		self.assertNotEqual(
+			self._key({1}, same_subjects),
+			self._key({2}, same_subjects),
+		)
+
+	def test_identical_scopes_share_a_cache_entry(self):
+		"""Otherwise the cache never hits and the whole mechanism is dead
+		weight -- worth pinning alongside the isolation cases."""
+		self.assertEqual(
+			self._key({1, 2}, {3, 4}),
+			self._key({2, 1}, {4, 3}),
+		)
+
+	def test_a_missing_subject_scope_is_distinct_from_an_empty_one(self):
+		"""None means the middleware never ran (management command, test
+		bypassing middleware); set() means it ran and the caller can see
+		nothing. Collapsing them would let an unscoped internal caller share
+		a cache entry with a caller scoped to nothing."""
+		self.assertNotEqual(
+			self._key({1}, None),
+			self._key({1}, set()),
 		)

--- a/django/api/tests/test_read_serialization.py
+++ b/django/api/tests/test_read_serialization.py
@@ -2,7 +2,7 @@
 Tests for org-scoped takeaways read serialization.
 
 Verify ``ArticleSerializer.get_takeaways`` / ``get_summary_plain_english``
-and the omission behaviour added by ``OrgScopedSerializerMixin``.
+and the omission behaviour added by ``ScopedSerializerMixin``.
 
 Covers spec §10.3:
   - With API key for Org A: takeaways resolves to Org A's ArticleOrgContent

--- a/django/api/tests/test_read_serialization.py
+++ b/django/api/tests/test_read_serialization.py
@@ -23,6 +23,7 @@ from organizations.models import Organization
 from rest_framework.test import APIClient
 
 from api.models import APIAccessScheme
+from api.tests.visibility_helpers import private_site_publishing, publish_subjects
 from gregory.models import (
 	Articles,
 	ArticleOrgContent,
@@ -60,20 +61,25 @@ def _make_subject(team, name):
 	)
 
 
-def _make_scheme(org, name):
+def _make_scheme(org, name, site=None):
+	"""``site`` is what binds the key to a subject scope; a key without one
+	resolves to no subjects at all."""
 	return APIAccessScheme.objects.create(
 		client_name=name,
 		client_contacts=f"{name}@example.com",
 		organization=org,
+		site=site,
 		ip_addresses="",
 		begin_date=now() - timedelta(days=1),
 		end_date=now() + timedelta(days=30),
 	)
 
 
-def _make_article(team, title="Test Article", link="https://example.com/art1"):
+def _make_article(team, title="Test Article", link="https://example.com/art1", subjects=()):
 	article = Articles.objects.create(title=title, link=link)
 	article.teams.add(team)
+	for subject in subjects:
+		article.subjects.add(subject)
 	return article
 
 
@@ -98,8 +104,10 @@ class TakeawaysReadWithApiKeyTest(TestCase):
 		self.client = APIClient()
 		self.org = _make_org("Read Org A")
 		self.team = _make_team(self.org, "Read Team A")
-		self.scheme = _make_scheme(self.org, "read-key-a")
-		self.article = _make_article(self.team)
+		self.subject = _make_subject(self.team, "Read Subject A")
+		self.site = private_site_publishing(self.subject, organization=self.org)
+		self.scheme = _make_scheme(self.org, "read-key-a", site=self.site)
+		self.article = _make_article(self.team, subjects=[self.subject])
 
 	def test_takeaways_from_org_content_when_key_present(self):
 		"""API key for Org A → takeaways resolves to ArticleOrgContent for Org A."""
@@ -147,8 +155,13 @@ class TakeawaysReadAnonymousTest(TestCase):
 		self.client = APIClient()
 		self.org = _make_org("Anon Org", public=True)
 		self.team = _make_team(self.org, "Anon Team")
+		self.subject = _make_subject(self.team, "Anon Subject")
+		publish_subjects(self.subject, organization=self.org)
 		self.article = _make_article(
-			self.team, title="Anon Article", link="https://example.com/anon"
+			self.team,
+			title="Anon Article",
+			link="https://example.com/anon",
+			subjects=[self.subject],
 		)
 		ArticleOrgContent.objects.create(
 			article=self.article,
@@ -180,8 +193,13 @@ class TakeawaysPublicOrgTeamIdTest(TestCase):
 		self.client = APIClient()
 		self.org = _make_org("Public Org TK", public=True)
 		self.team = _make_team(self.org, "Public Team TK")
+		self.subject = _make_subject(self.team, "Public Subject TK")
+		publish_subjects(self.subject, organization=self.org)
 		self.article = _make_article(
-			self.team, title="Public TK Article", link="https://example.com/pbtk"
+			self.team,
+			title="Public TK Article",
+			link="https://example.com/pbtk",
+			subjects=[self.subject],
 		)
 		ArticleOrgContent.objects.create(
 			article=self.article,
@@ -212,14 +230,20 @@ class TakeawaysTwoOrgsTest(TestCase):
 		self.org_b = _make_org("Dual Org B", "dual-org-b")
 		self.team_a = _make_team(self.org_a, "Dual Team A")
 		self.team_b = _make_team(self.org_b, "Dual Team B")
-		self.scheme_a = _make_scheme(self.org_a, "dual-key-a")
-		self.scheme_b = _make_scheme(self.org_b, "dual-key-b")
-		# Article shared across both orgs
+		self.subject_a = _make_subject(self.team_a, "Dual Subject A")
+		self.subject_b = _make_subject(self.team_b, "Dual Subject B")
+		self.site_a = private_site_publishing(self.subject_a, organization=self.org_a)
+		self.site_b = private_site_publishing(self.subject_b, organization=self.org_b)
+		self.scheme_a = _make_scheme(self.org_a, "dual-key-a", site=self.site_a)
+		self.scheme_b = _make_scheme(self.org_b, "dual-key-b", site=self.site_b)
+		# Article shared across both orgs -- each org's key must resolve it
+		# via its own subject, so it carries both.
 		self.article = Articles.objects.create(
 			title="Shared Article",
 			link="https://example.com/shared",
 		)
 		self.article.teams.add(self.team_a, self.team_b)
+		self.article.subjects.add(self.subject_a, self.subject_b)
 		ArticleOrgContent.objects.create(
 			article=self.article, organization=self.org_a, takeaways="Org A takeaway"
 		)

--- a/django/api/tests/test_relevant_filter_latest_prediction.py
+++ b/django/api/tests/test_relevant_filter_latest_prediction.py
@@ -15,6 +15,7 @@ from django.utils import timezone
 from organizations.models import Organization
 from rest_framework.test import APIClient
 
+from api.tests.visibility_helpers import publish_subjects
 from gregory.models import (
 	Articles,
 	ArticleSubjectRelevance,
@@ -50,6 +51,7 @@ class RelevantFilterLatestPredictionTestCase(TestCase):
 			auto_predict=True,
 			ml_consensus_type="majority",
 		)
+		publish_subjects(self.subject_any, self.subject_majority, organization=org)
 
 	def _article(self, title, subject):
 		article = Articles.objects.create(

--- a/django/api/tests/test_search_ordering.py
+++ b/django/api/tests/test_search_ordering.py
@@ -19,6 +19,8 @@ from organizations.models import Organization
 from rest_framework.test import APIClient
 from rest_framework import status
 
+from api.tests.visibility_helpers import publish_subjects
+
 
 class SearchOrderingTestCase(TestCase):
 	"""Test case for search endpoint ordering functionality"""
@@ -38,6 +40,7 @@ class SearchOrderingTestCase(TestCase):
 		self.subject = Subject.objects.create(
 			subject_name="Test Subject", subject_slug="test-subject", team=self.team
 		)
+		publish_subjects(self.subject, organization=self.organization)
 
 		# Create test source
 		self.source = Sources.objects.create(name="Test Source", link="http://test.com")

--- a/django/api/tests/test_search_post_filters.py
+++ b/django/api/tests/test_search_post_filters.py
@@ -16,6 +16,7 @@ from django.utils import timezone
 from rest_framework import status
 from rest_framework.test import APIClient
 
+from api.tests.visibility_helpers import publish_subjects
 from gregory.models import (
 	ArticleSubjectRelevance,
 	Articles,
@@ -52,6 +53,9 @@ class ArticleSearchPostFilterTests(TestCase):
 			subject_slug="search-post-filter-other-subject",
 			team=self.team,
 		)
+		# The search views validate subject_id against the caller's subject
+		# scope, so both must be published or every search 404s.
+		publish_subjects(self.subject, self.other_subject, organization=self.org)
 
 		def make_article(title, link, pub_date, subjects=(self.subject,)):
 			a = Articles.objects.create(title=title, link=link)
@@ -233,6 +237,7 @@ class TrialSearchPostFilterTests(TestCase):
 			subject_slug="trial-search-post-filter-subject",
 			team=self.team,
 		)
+		publish_subjects(self.subject, organization=self.org)
 
 		def make_trial(title, link, date_registration, phase=None, has_results=False):
 			t = Trials.objects.create(
@@ -324,6 +329,11 @@ class TrialSearchPostFilterTests(TestCase):
 		identity_params forcing them from the body, a disagreeing query-string
 		subject_id would leak into the filterset and silently intersect against
 		the body's subject_id, emptying the results — not just being ignored."""
+		# Deliberately NOT published: the search view 404s on a subject_id
+		# outside the caller's scope, so a 200 here is only possible if the
+		# query-string value was discarded before that check ever ran. Do not
+		# "fix" this by publishing it — that would weaken the assertion to
+		# one a leaking query-string subject_id could also satisfy.
 		other_subject = Subject.objects.create(
 			subject_name="Other Trial POST Filter Subject",
 			subject_slug="other-trial-post-filter-subject",
@@ -385,6 +395,7 @@ class AuthorSearchPostFilterTests(TestCase):
 			subject_slug="author-search-post-filter-subject",
 			team=self.team,
 		)
+		publish_subjects(self.subject, organization=self.org)
 
 		self.author_pt = Authors.objects.create(
 			given_name="Ines", family_name="Silva", country="PT"

--- a/django/api/tests/test_site_filter.py
+++ b/django/api/tests/test_site_filter.py
@@ -11,10 +11,13 @@ from gregory.models import (
 	Articles,
 	OrganizationApiSettings,
 	Sources,
+	Subject,
 	Team,
 	Trials,
 )
 from organizations.models import Organization
+
+from api.tests.visibility_helpers import private_site_publishing, publish_subjects
 
 
 class SiteFilterTest(TestCase):
@@ -65,6 +68,23 @@ class SiteFilterTest(TestCase):
 			site=self.site_b,
 		)
 
+		# Subject-scoped visibility (unrelated to Team.site / ?site_id= above,
+		# despite both being django.contrib.sites.models.Site rows): content
+		# needs a subject in the caller's scope to be visible at all now.
+		# public_subject is published for public_org, so self.user (a member
+		# of public_org) and the anonymous client both see it; priv_subject
+		# stays private to private_org, which self.user does not belong to.
+		self.public_subject = Subject.objects.create(
+			team=self.team1, subject_name="Site Filter Public Subject",
+			subject_slug="site-filter-public-subject",
+		)
+		publish_subjects(self.public_subject, organization=self.public_org)
+		self.priv_subject = Subject.objects.create(
+			team=self.private_team, subject_name="Site Filter Private Subject",
+			subject_slug="site-filter-private-subject",
+		)
+		private_site_publishing(self.priv_subject, organization=self.private_org)
+
 		# Article belonging to both team1 and team2 (same site) -- must not duplicate.
 		self.shared_article = Articles.objects.create(
 			title="Shared Article",
@@ -74,6 +94,7 @@ class SiteFilterTest(TestCase):
 		)
 		self.shared_article.sources.add(self.source)
 		self.shared_article.teams.add(self.team1, self.team2)
+		self.shared_article.subjects.add(self.public_subject)
 
 		# Article only on the private team's site_a team.
 		self.private_article = Articles.objects.create(
@@ -84,10 +105,12 @@ class SiteFilterTest(TestCase):
 		)
 		self.private_article.sources.add(self.source)
 		self.private_article.teams.add(self.private_team)
+		self.private_article.subjects.add(self.priv_subject)
 
 		# Trial mirrors the same shape.
 		self.shared_trial = Trials.objects.create(title="Shared Trial")
 		self.shared_trial.teams.add(self.team1, self.team2)
+		self.shared_trial.subjects.add(self.public_subject)
 
 		self.client = APIClient()
 		self.client.force_authenticate(user=self.user)

--- a/django/api/tests/test_sponsor_api_surface.py
+++ b/django/api/tests/test_sponsor_api_surface.py
@@ -193,6 +193,24 @@ class SponsorFacetsTests(SponsorAPITestCase):
 class SponsorViewSetTests(TestCase):
 	def setUp(self):
 		self.client = APIClient()
+		# A sponsor reaches the caller only through its trials, and a trial
+		# only through its subjects, so both links are load-bearing here:
+		# without them these sponsors are invisible, which is the rule, not a
+		# fixture accident. A sponsor with no trials at all is unreachable by
+		# anyone — that is the population the 2026-09-10 prune removed.
+		org = Organization.objects.create(
+			name="Sponsor VS Org", slug="sponsor-vs-org"
+		)
+		team = Team.objects.create(
+			organization=org, name="Sponsor VS Team", slug="sponsor-vs-team"
+		)
+		self.subject = Subject.objects.create(
+			subject_name="Sponsor VS Subject",
+			subject_slug="sponsor-vs-subject",
+			team=team,
+		)
+		publish_subjects(self.subject, organization=org)
+
 		self.industry = Sponsor.objects.create(
 			name="Industry Sponsor Co", slug="industry-sponsor-co", sponsor_type="industry"
 		)
@@ -200,16 +218,29 @@ class SponsorViewSetTests(TestCase):
 			name="Nonprofit Sponsor Org", slug="nonprofit-sponsor-org", sponsor_type="nonprofit"
 		)
 		for i in range(3):
-			Trials.objects.create(
+			trial = Trials.objects.create(
 				title=f"Industry Trial {i}",
 				link=f"https://example.com/sponsor-viewset-{i}",
 				primary_sponsor=None,
 			)
-		# Attach trials to self.industry without going through resolution, to
+			trial.subjects.add(self.subject)
+		# One trial for the nonprofit too, so it is reachable at all.
+		nonprofit_trial = Trials.objects.create(
+			title="Nonprofit Trial",
+			link="https://example.com/sponsor-viewset-nonprofit",
+			primary_sponsor=None,
+		)
+		nonprofit_trial.subjects.add(self.subject)
+		# Attach trials to sponsors without going through resolution, to
 		# control the exact trials_count independent of the save() hook.
 		Trials.objects.filter(
 			link__startswith="https://example.com/sponsor-viewset-"
-		).update(primary_sponsor_normalized=self.industry)
+		).exclude(pk=nonprofit_trial.pk).update(
+			primary_sponsor_normalized=self.industry
+		)
+		Trials.objects.filter(pk=nonprofit_trial.pk).update(
+			primary_sponsor_normalized=self.nonprofit
+		)
 
 	def test_list_and_detail_routing(self):
 		resp = self.client.get("/sponsors/")
@@ -241,6 +272,69 @@ class SponsorViewSetTests(TestCase):
 		self.assertEqual(resp.status_code, 200)
 		names = [row["name"] for row in resp.data["results"]]
 		self.assertEqual(names[0], "Industry Sponsor Co")
+
+	def test_sponsor_whose_trials_are_all_out_of_scope_is_hidden(self):
+		"""The scoping rule itself. A Sponsor carries no subject, so its
+		visibility is entirely derived from its trials -- and a sponsor row
+		that survived would disclose that a trial the caller cannot read
+		exists."""
+		hidden_sponsor = Sponsor.objects.create(
+			name="Hidden Sponsor Ltd", slug="hidden-sponsor-ltd",
+			sponsor_type="industry",
+		)
+		other_team = Team.objects.create(
+			organization=Organization.objects.create(
+				name="Other Sponsor Org", slug="other-sponsor-org"
+			),
+			name="Other Sponsor Team", slug="other-sponsor-team",
+		)
+		unpublished_subject = Subject.objects.create(
+			subject_name="Unpublished", subject_slug="unpublished-sponsor-subj",
+			team=other_team,
+		)
+		hidden_trial = Trials.objects.create(
+			title="Hidden Trial", link="https://example.com/sponsor-hidden",
+		)
+		hidden_trial.subjects.add(unpublished_subject)
+		Trials.objects.filter(pk=hidden_trial.pk).update(
+			primary_sponsor_normalized=hidden_sponsor
+		)
+
+		resp = self.client.get("/sponsors/")
+		names = [row["name"] for row in resp.data["results"]]
+		self.assertNotIn("Hidden Sponsor Ltd", names)
+		self.assertIn("Industry Sponsor Co", names)
+		# Hide-existence: detail 404s rather than 403.
+		self.assertEqual(
+			self.client.get(f"/sponsors/{hidden_sponsor.pk}/").status_code, 404
+		)
+
+	def test_trials_count_counts_only_trials_in_scope(self):
+		"""Not cosmetic: trials_count is orderable (?ordering=-trials_count),
+		so an unscoped count would leak the size of what the caller cannot
+		read, and leak it again through the ranking."""
+		out_of_scope_subject = Subject.objects.create(
+			subject_name="Out Of Scope", subject_slug="out-of-scope-sponsor-subj",
+			team=Team.objects.create(
+				organization=Organization.objects.create(
+					name="OOS Org", slug="oos-org"
+				),
+				name="OOS Team", slug="oos-team",
+			),
+		)
+		extra = Trials.objects.create(
+			title="Industry Trial Hidden",
+			link="https://example.com/sponsor-viewset-hidden",
+		)
+		extra.subjects.add(out_of_scope_subject)
+		Trials.objects.filter(pk=extra.pk).update(
+			primary_sponsor_normalized=self.industry
+		)
+
+		detail = self.client.get(f"/sponsors/{self.industry.pk}/")
+		self.assertEqual(detail.status_code, 200)
+		# Still 3 — the fourth trial is out of scope.
+		self.assertEqual(detail.data["trials_count"], 3)
 
 	def test_page_size_capped_at_100(self):
 		resp = self.client.get("/sponsors/", {"page_size": "500"})

--- a/django/api/tests/test_sponsor_api_surface.py
+++ b/django/api/tests/test_sponsor_api_surface.py
@@ -21,8 +21,10 @@ from django.test.utils import CaptureQueriesContext
 from organizations.models import Organization
 from rest_framework.test import APIClient
 
-from gregory.models import OrganizationApiSettings, Sponsor, Team, Trials
+from gregory.models import OrganizationApiSettings, Sponsor, Subject, Team, Trials
 from gregory.utils.trial_field_normalizers import SponsorType
+
+from api.tests.visibility_helpers import publish_subjects
 
 
 class SponsorAPITestCase(TestCase):
@@ -31,10 +33,20 @@ class SponsorAPITestCase(TestCase):
 		org = Organization.objects.create(name="Sponsor API Org", slug="sponsor-api-org")
 		OrganizationApiSettings.objects.filter(organization=org).update(make_api_public=True)
 		self.team = Team.objects.create(organization=org, name="Sponsor API Org", slug="sponsor-api-org")
+		# /trials/ and /trials/stats/ are subject-scoped now: a trial with no
+		# subject is invisible to everyone. /sponsors/ itself carries no such
+		# mixin (deliberately -- sponsors are global, not org/subject-owned,
+		# see SponsorViewSet's docstring), so this is only needed for the
+		# trial-facing assertions below.
+		self.subject = Subject.objects.create(
+			subject_name="Sponsor API Subject", subject_slug="sponsor-api-subject", team=self.team
+		)
+		publish_subjects(self.subject, organization=org)
 
 	def _make_trial(self, title, link, primary_sponsor=None):
 		trial = Trials.objects.create(title=title, link=link, primary_sponsor=primary_sponsor)
 		trial.teams.add(self.team)
+		trial.subjects.add(self.subject)
 		return trial
 
 

--- a/django/api/tests/test_streaming_csv.py
+++ b/django/api/tests/test_streaming_csv.py
@@ -4,11 +4,12 @@ from django.test import TestCase
 from django.urls import reverse
 from rest_framework.request import Request
 from rest_framework.test import APIClient, APIRequestFactory
-from gregory.models import Articles, OrganizationApiSettings, Team, TeamCategory, Sources
+from gregory.models import Articles, OrganizationApiSettings, Subject, Team, TeamCategory, Sources
 from organizations.models import Organization
 from django.contrib.auth.models import User
 from api.direct_streaming import DirectStreamingCSVRenderer
 from api.serializers import ArticleSerializer
+from api.tests.visibility_helpers import publish_subjects
 
 
 class StreamingCSVRendererTest(TestCase):
@@ -34,6 +35,13 @@ class StreamingCSVRendererTest(TestCase):
 			team=self.team, category_name="Test Category", category_slug="test-category"
 		)
 
+		self.subject = Subject.objects.create(
+			subject_name="Streaming CSV Subject",
+			subject_slug="streaming-csv-subject",
+			team=self.team,
+		)
+		publish_subjects(self.subject, organization=self.organization)
+
 		# Create test articles
 		for i in range(10):
 			article = Articles.objects.create(
@@ -45,6 +53,7 @@ class StreamingCSVRendererTest(TestCase):
 			# Add source after creation (ManyToMany relationship)
 			article.sources.add(self.source)
 			article.teams.add(self.team)
+			article.subjects.add(self.subject)
 			article.team_categories.add(self.category)
 
 		# Set up client
@@ -113,7 +122,11 @@ class StreamingCSVRendererTest(TestCase):
 		wsgi_request = factory.get("/articles/?format=csv&all_results=true")
 		wsgi_request.user = self.user
 		drf_request = Request(wsgi_request)
-		drf_request.visible_org_ids = {self.organization.id}
+		# ScopedSerializerMixin reads visible_subject_ids now, not
+		# visible_org_ids (Phase 4) -- match what the real middleware
+		# would compute for this user (a member of self.organization,
+		# which publish_subjects() linked to self.subject in setUp).
+		drf_request.visible_subject_ids = {self.subject.id}
 
 		data = ArticleSerializer(
 			Articles.objects.all().order_by("-discovery_date"),

--- a/django/api/tests/test_team_serializer_fields.py
+++ b/django/api/tests/test_team_serializer_fields.py
@@ -24,8 +24,14 @@ class TeamSerializerFieldWhitelistTests(TestCase):
 		OrganizationApiSettings.objects.filter(organization=self.org).update(
 			make_api_public=True
 		)
+		# /teams/ is gated by the explicit api_listed flag now, independent of
+		# the caller and of the organisation's public/private status -- see
+		# test_visibility_teams.py.
 		self.team = Team.objects.create(
-			organization=self.org, name="Team Fields Team", slug="team-fields-team"
+			organization=self.org,
+			name="Team Fields Team",
+			slug="team-fields-team",
+			api_listed=True,
 		)
 		self.user = User.objects.create_user(
 			username="team-fields-member", password="unused"

--- a/django/api/tests/test_trial_age_eligible_filter.py
+++ b/django/api/tests/test_trial_age_eligible_filter.py
@@ -11,6 +11,8 @@ from gregory.models import (
 	OrganizationApiSettings,
 )
 
+from api.tests.visibility_helpers import publish_subjects
+
 
 class TrialAgeEligibleFilterTests(TestCase):
 	"""Tests for the numeric ?age_eligible= range-containment filter on /trials/"""
@@ -35,6 +37,7 @@ class TrialAgeEligibleFilterTests(TestCase):
 			subject_slug="age-other-subject",
 			team=self.team,
 		)
+		publish_subjects(self.subject, self.other_subject, organization=self.org)
 
 		# min 18 / max 65 -> includes 40
 		self.trial_18_65 = Trials.objects.create(

--- a/django/api/tests/test_trial_contact_fields_hidden.py
+++ b/django/api/tests/test_trial_contact_fields_hidden.py
@@ -15,6 +15,7 @@ from rest_framework import status
 from rest_framework.test import APIClient
 
 from api.serializers import TrialSerializer
+from api.tests.visibility_helpers import publish_subjects
 from gregory.models import Organization, OrganizationApiSettings, Subject, Team, Trials
 
 CONTACT_FIELDS = [
@@ -45,6 +46,7 @@ class TrialContactFieldsHiddenTests(TestCase):
 			subject_slug="contact-fields-subject",
 			team=self.team,
 		)
+		publish_subjects(self.subject, organization=self.organization)
 		self.trial = Trials.objects.create(
 			title="Contact Fields Trial",
 			link="https://example.com/contact-fields",

--- a/django/api/tests/test_trial_country_normalization.py
+++ b/django/api/tests/test_trial_country_normalization.py
@@ -11,6 +11,7 @@ from rest_framework import status
 from rest_framework.test import APIClient
 
 from api.serializers import TrialSerializer
+from api.tests.visibility_helpers import publish_subjects
 from gregory.models import (
 	Organization,
 	OrganizationApiSettings,
@@ -38,6 +39,7 @@ class TrialCountryAndRegionFilterTests(TestCase):
 			subject_slug="country-filter-subject",
 			team=self.team,
 		)
+		publish_subjects(self.subject, organization=self.organization)
 
 		self.germany_trial = Trials.objects.create(
 			title="Germany Trial",

--- a/django/api/tests/test_trial_identifier_filter.py
+++ b/django/api/tests/test_trial_identifier_filter.py
@@ -4,6 +4,7 @@ from rest_framework import status
 from django.utils import timezone
 
 from gregory.models import Trials, Team, Subject, Organization, OrganizationApiSettings
+from api.tests.visibility_helpers import publish_subjects
 
 
 class TrialIdentifierFilterTests(TestCase):
@@ -32,6 +33,7 @@ class TrialIdentifierFilterTests(TestCase):
 			subject_slug="identifier-subject",
 			team=self.team,
 		)
+		publish_subjects(self.subject, organization=self.org)
 
 		self.trial_nct = self._make_trial(
 			"Trial NCT one", identifiers={"nct": "NCT02521311"}, acronym="ReCOVER"

--- a/django/api/tests/test_trial_inclusion_gender_normalization.py
+++ b/django/api/tests/test_trial_inclusion_gender_normalization.py
@@ -17,6 +17,7 @@ from rest_framework import status
 from rest_framework.test import APIClient
 
 from api.serializers import TrialSerializer
+from api.tests.visibility_helpers import publish_subjects
 from gregory.models import (
 	Organization,
 	OrganizationApiSettings,
@@ -44,6 +45,7 @@ class TrialInclusionGenderNormalizedFilterTests(TestCase):
 			subject_slug="inclusion-gender-filter-subject",
 			team=self.team,
 		)
+		publish_subjects(self.subject, organization=self.organization)
 
 		self.female_trial = Trials.objects.create(
 			title="Female Only Trial",

--- a/django/api/tests/test_trial_multiselect_filter.py
+++ b/django/api/tests/test_trial_multiselect_filter.py
@@ -11,6 +11,8 @@ from gregory.models import (
 	OrganizationApiSettings,
 )
 
+from api.tests.visibility_helpers import publish_subjects
+
 
 class TrialPhaseNormalizedMultiSelectFilterTests(TestCase):
 	"""Tests for the comma-separated OR filter on ?phase_normalized= for /trials/"""
@@ -67,6 +69,7 @@ class TrialPhaseNormalizedMultiSelectFilterTests(TestCase):
 			subject_slug="phase-ms-other-subject",
 			team=self.team,
 		)
+		publish_subjects(self.subject, self.other_subject, organization=self.org)
 
 	def test_single_value_still_works(self):
 		"""?phase_normalized=phase_2 behaves exactly as before (regression)."""
@@ -133,6 +136,7 @@ class TrialRecruitmentStatusNormalizedMultiSelectFilterTests(TestCase):
 			subject_slug="status-ms-subject",
 			team=self.team,
 		)
+		publish_subjects(self.subject, organization=self.org)
 
 		self.trial_recruiting = Trials.objects.create(
 			title="Trial Recruiting",

--- a/django/api/tests/test_trial_phase_normalization.py
+++ b/django/api/tests/test_trial_phase_normalization.py
@@ -11,6 +11,7 @@ from rest_framework import status
 from rest_framework.test import APIClient
 
 from api.serializers import TrialSerializer
+from api.tests.visibility_helpers import publish_subjects
 from gregory.models import (
 	Organization,
 	OrganizationApiSettings,
@@ -38,6 +39,7 @@ class TrialPhaseNormalizedFilterTests(TestCase):
 			subject_slug="phase-filter-subject",
 			team=self.team,
 		)
+		publish_subjects(self.subject, organization=self.organization)
 
 		self.phase3_trial = Trials.objects.create(
 			title="Phase III Trial",

--- a/django/api/tests/test_trial_recruiting_first_ordering.py
+++ b/django/api/tests/test_trial_recruiting_first_ordering.py
@@ -17,6 +17,7 @@ from django.test.utils import CaptureQueriesContext
 from rest_framework import status
 from rest_framework.test import APIClient
 
+from api.tests.visibility_helpers import publish_subjects
 from api.views import _RECRUITING_RANK
 from gregory.models import Organization, OrganizationApiSettings, Subject, Team, Trials
 from gregory.utils.trial_field_normalizers import TrialRecruitmentStatus
@@ -74,6 +75,7 @@ class RecruitingFirstOrderingTest(TestCase):
 			subject_slug="recruiting-first-subject",
 			team=self.team,
 		)
+		publish_subjects(self.subject, organization=self.organization)
 
 		base = datetime(2026, 1, 1, tzinfo=dt_timezone.utc)
 		self.recruiting = _make_trial(
@@ -239,6 +241,7 @@ class RecruitingFirstStablePaginationTest(TestCase):
 			subject_slug="recruiting-first-stable-subject",
 			team=self.team,
 		)
+		publish_subjects(self.subject, organization=self.organization)
 
 		# 5 "recruiting" trials (same rank) with distinct discovery_date values so
 		# the tiebreaker gives a single deterministic order.

--- a/django/api/tests/test_trial_recruitment_status_normalization.py
+++ b/django/api/tests/test_trial_recruitment_status_normalization.py
@@ -12,6 +12,7 @@ from rest_framework import status
 from rest_framework.test import APIClient
 
 from api.serializers import TrialSerializer
+from api.tests.visibility_helpers import publish_subjects
 from gregory.models import (
 	Organization,
 	OrganizationApiSettings,
@@ -39,6 +40,7 @@ class TrialRecruitmentStatusNormalizedFilterTests(TestCase):
 			subject_slug="recruitment-status-filter-subject",
 			team=self.team,
 		)
+		publish_subjects(self.subject, organization=self.organization)
 
 		self.recruiting_trial = Trials.objects.create(
 			title="Recruiting Trial",

--- a/django/api/tests/test_trial_search.py
+++ b/django/api/tests/test_trial_search.py
@@ -3,6 +3,7 @@ from django.test import TestCase
 from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
 from rest_framework.test import APIClient
+from api.tests.visibility_helpers import publish_subjects
 from gregory.models import Trials, Team, Subject, Organization, OrganizationApiSettings
 from django.utils import timezone
 
@@ -24,6 +25,9 @@ class TrialSearchViewTests(TestCase):
 		self.subject = Subject.objects.create(
 			subject_name="Test Subject", subject_slug="test-subject", team=self.team
 		)
+		# /trials/search/ validates subject_id against the caller's subject
+		# scope, so the subject must be published or every search 404s.
+		publish_subjects(self.subject, organization=self.organization)
 
 		# Create test data
 		self.trial1 = Trials.objects.create(
@@ -254,6 +258,9 @@ class TrialSearchViewQueryCountTests(TestCase):
 			subject_name="Trial Other Subject",
 			subject_slug="trial-other-subject",
 			team=self.team,
+		)
+		publish_subjects(
+			self.subject, other_subject, organization=self.organization
 		)
 
 		for i in range(3):

--- a/django/api/tests/test_trial_site_api.py
+++ b/django/api/tests/test_trial_site_api.py
@@ -14,6 +14,7 @@ from django.utils import timezone
 from rest_framework import status
 from rest_framework.test import APIClient
 
+from api.tests.visibility_helpers import publish_subjects
 from gregory.models import (
 	Organization,
 	OrganizationApiSettings,
@@ -47,6 +48,7 @@ class TrialSiteAPITests(TestCase):
 			subject_slug="trial-site-api-other-subject",
 			team=self.team,
 		)
+		publish_subjects(self.subject, self.other_subject, organization=self.organization)
 
 		self.trial = Trials.objects.create(
 			title="Site API Test Trial",

--- a/django/api/tests/test_trial_study_type_normalization.py
+++ b/django/api/tests/test_trial_study_type_normalization.py
@@ -12,6 +12,7 @@ from rest_framework import status
 from rest_framework.test import APIClient
 
 from api.serializers import TrialSerializer
+from api.tests.visibility_helpers import publish_subjects
 from gregory.models import (
 	Organization,
 	OrganizationApiSettings,
@@ -39,6 +40,7 @@ class TrialStudyTypeNormalizedFilterTests(TestCase):
 			subject_slug="study-type-filter-subject",
 			team=self.team,
 		)
+		publish_subjects(self.subject, organization=self.organization)
 
 		self.interventional_trial = Trials.objects.create(
 			title="Interventional Trial",

--- a/django/api/tests/test_trials_stats.py
+++ b/django/api/tests/test_trials_stats.py
@@ -74,6 +74,7 @@ from organizations.models import Organization
 from rest_framework.test import APIClient
 
 from api.models import APIAccessScheme
+from api.tests.visibility_helpers import private_site_publishing, publish_subjects
 from gregory.models import OrganizationApiSettings, Subject, Team, Trials
 from gregory.utils.trial_field_normalizers import (
 	TrialPhase,
@@ -83,14 +84,34 @@ from gregory.utils.trial_field_normalizers import (
 	TrialStudyType,
 )
 
+# Under subject-scoped visibility a trial with no subject is invisible to
+# everyone, but the overwhelming majority of `_make_trial(...)` calls in this
+# file (nearly all of them) were written against the old organisation rule
+# and pass no `subjects=` at all. Rather than touch every call site, each
+# team created via `_make_org_team` gets one default subject, published (or
+# kept private) to match that team's organisation, and registered here so
+# `_make_trial` can fall back to it when the caller doesn't pass one
+# explicitly. `_ORG_SITES` gives `_make_api_scheme` the matching site to bind
+# a key to, for the same reason.
+_TEAM_DEFAULT_SUBJECTS = {}
+_ORG_SITES = {}
 
-def _make_org_team(name, slug, public=True):
+
+def _make_org_team(name, slug, public=True, subject_name=None, subject_slug=None):
 	org = Organization.objects.create(name=name, slug=slug)
 	OrganizationApiSettings.objects.filter(organization=org).update(
 		make_api_public=public
 	)
 	team = Team.objects.create(organization=org, name=name, slug=slug)
-	return org, team
+	subject = Subject.objects.create(
+		team=team,
+		subject_name=subject_name or f"{name} Subject",
+		subject_slug=subject_slug or f"{slug}-subject",
+	)
+	_TEAM_DEFAULT_SUBJECTS[team.pk] = subject
+	publisher = publish_subjects if public else private_site_publishing
+	_ORG_SITES[org.pk] = publisher(subject, organization=org)
+	return org, team, subject
 
 
 def _make_subject(team, name, slug):
@@ -112,16 +133,26 @@ def _make_trial(
 	)
 	for team in teams:
 		trial.teams.add(team)
-	for subject in subjects:
+	# Explicit subjects win; otherwise fall back to each team's default so
+	# the many pre-existing calls that never mention a subject stay visible.
+	tagged_subjects = list(subjects) or [
+		_TEAM_DEFAULT_SUBJECTS[team.pk]
+		for team in teams
+		if team.pk in _TEAM_DEFAULT_SUBJECTS
+	]
+	for subject in tagged_subjects:
 		trial.subjects.add(subject)
 	return trial
 
 
-def _make_api_scheme(org, name):
+def _make_api_scheme(org, name, site=None):
 	return APIAccessScheme.objects.create(
 		client_name=name,
 		client_contacts=f"{name}@example.com",
 		organization=org,
+		# A key without a site resolves to no subjects at all; fall back to
+		# the site _make_org_team already created for this org.
+		site=site or _ORG_SITES.get(org.pk),
 		ip_addresses="",
 		begin_date=now() - timedelta(days=1),
 		end_date=now() + timedelta(days=30),
@@ -142,11 +173,13 @@ class TrialStatsBase(TestCase):
 		# cached stats from a previous test can't leak into this one.
 		cache.clear()
 
-		self.org, self.team = _make_org_team("Stats Org", "stats-org")
-		self.other_org, self.other_team = _make_org_team(
+		self.org, self.team, self.subject = _make_org_team(
+			"Stats Org", "stats-org",
+			subject_name="Stats Subject", subject_slug="stats-subject",
+		)
+		self.other_org, self.other_team, self.other_subject = _make_org_team(
 			"Other Stats Org", "other-stats-org"
 		)
-		self.subject = _make_subject(self.team, "Stats Subject", "stats-subject")
 
 		self.t1 = _make_trial(
 			"T1",
@@ -273,6 +306,11 @@ class TrialStatsBySubjectTest(TrialStatsBase):
 		other_subject = _make_subject(
 			self.other_team, "Other Subject", "other-subject"
 		)
+		# No organization= here: other_org already has a default site from
+		# _make_org_team, and OrganizationSite allows only one default per
+		# org. Anonymous visibility only needs an api_public site scoping
+		# the subject, so this stands alone.
+		publish_subjects(other_subject)
 		self.t3.subjects.add(self.subject)
 		self.t4.subjects.add(other_subject)
 
@@ -291,6 +329,11 @@ class TrialStatsBySubjectTest(TrialStatsBase):
 		other_subject = _make_subject(
 			self.other_team, "Other Subject", "other-subject"
 		)
+		# No organization= here: other_org already has a default site from
+		# _make_org_team, and OrganizationSite allows only one default per
+		# org. Anonymous visibility only needs an api_public site scoping
+		# the subject, so this stands alone.
+		publish_subjects(other_subject)
 		self.t4.subjects.add(other_subject)
 
 		resp = self.client.get("/trials/stats/", {"team_id": self.team.id})
@@ -303,7 +346,7 @@ class TrialStatsBySubjectTest(TrialStatsBase):
 		# A visible (public-org) trial tagged with a subject belonging to a
 		# NON-visible org: the subject must not leak into by_subject, even
 		# though the trial itself is counted.
-		hidden_org, hidden_team = _make_org_team(
+		hidden_org, hidden_team, _hidden_default_subject = _make_org_team(
 			"Hidden Org", "hidden-org", public=False
 		)
 		hidden_subject = _make_subject(
@@ -381,7 +424,7 @@ class TrialStatsCachingTest(TrialStatsBase):
 		# an API key bound to the org can. If the cache key ignored the
 		# caller's visible orgs, whichever request ran first would leak its
 		# stats to the other.
-		priv_org, priv_team = _make_org_team(
+		priv_org, priv_team, _priv_subject = _make_org_team(
 			"Private Stats Org", "private-stats-org", public=False
 		)
 		_make_trial(
@@ -653,6 +696,11 @@ class TrialStatsSexFacetTest(TrialStatsBase):
 		)
 		for team in teams:
 			trial.teams.add(team)
+			# Mirrors _make_trial's default-subject fallback -- this helper
+			# bypasses that function, so it has to repeat the lookup.
+			default_subject = _TEAM_DEFAULT_SUBJECTS.get(team.pk)
+			if default_subject is not None:
+				trial.subjects.add(default_subject)
 		return trial
 
 	def test_every_sex_key_present_and_no_stray_keys(self):

--- a/django/api/tests/test_visibility_articles.py
+++ b/django/api/tests/test_visibility_articles.py
@@ -1,14 +1,23 @@
 """
-Tests for article visibility enforcement (PR 4).
+Tests for article visibility enforcement.
 
-Covers the four caller archetypes × the test matrix from the PR plan:
-  - Article in caller's org only
-  - Article in another public org only
-  - Article in another private org only
-  - Article spanning caller's org + a public org (listing + association stripping)
-  - Article spanning caller's org + a private org (listing + association stripping)
-  - Detail endpoint: all-hidden teams → 404
-  - ArticleSearchView: team_id of hidden team → 404
+Visibility is SUBJECT-scoped (site-scoped API visibility, Phase 4): a caller
+sees an article when one of its subjects is in the scope of a site that
+caller can reach. This suite was written against the earlier organisation
+rule -- articles carried teams, and visibility followed team -> organisation
+-- so its whole matrix has been restated in the new unit. Each organisation
+here now owns a Site publishing exactly one subject, which keeps the
+archetypes one-to-one with what they were: "my org's article" becomes "an
+article carrying my site's subject".
+
+Covers the three caller archetypes × the matrix:
+  - Article in the caller's scope only
+  - Article in another public scope only
+  - Article in another private scope only
+  - Article spanning the caller's scope + a public one (listing + stripping)
+  - Article spanning the caller's scope + a private one (listing + stripping)
+  - Detail endpoint: no visible subject → 404
+  - ArticleSearchView: team_id of a hidden team → 404
 
 Run with:
     docker exec gregory python manage.py test api.tests.test_visibility_articles
@@ -23,6 +32,7 @@ from organizations.models import Organization, OrganizationUser
 from rest_framework.test import APIClient
 
 from api.models import APIAccessScheme
+from api.tests.visibility_helpers import private_site_publishing, publish_subjects
 from gregory.models import Articles, OrganizationApiSettings, Subject, Team
 
 User = get_user_model()
@@ -41,9 +51,11 @@ def _make_org(name, slug, public=False):
 	return org
 
 
-def _make_team(org, name):
+def _make_team(org, name, api_listed=True):
 	slug = name.lower().replace(" ", "-")
-	return Team.objects.create(organization=org, name=name, slug=slug)
+	return Team.objects.create(
+		organization=org, name=name, slug=slug, api_listed=api_listed
+	)
 
 
 def _make_subject(team, name):
@@ -63,12 +75,17 @@ def _make_article(title, link, teams=(), subjects=()):
 	return art
 
 
-def _make_api_scheme(org, name):
-	"""Create a valid (not-expired) APIAccessScheme for the given org."""
+def _make_api_scheme(org, name, site=None):
+	"""Create a valid (not-expired) APIAccessScheme for the given org.
+
+	``site`` is what binds the key to a subject scope; a key without one
+	resolves to no subjects at all.
+	"""
 	return APIAccessScheme.objects.create(
 		client_name=name,
 		client_contacts=f"{name}@example.com",
 		organization=org,
+		site=site,
 		ip_addresses="",
 		begin_date=now() - timedelta(days=1),
 		end_date=now() + timedelta(days=30),
@@ -91,30 +108,52 @@ class ArticleVisibilityBase(TestCase):
 
 		self.my_team = _make_team(self.my_org, "My Team")
 		self.pub_team = _make_team(self.pub_org, "Pub Team")
-		self.priv_team = _make_team(self.priv_org, "Priv Team")
+		# Unlisted, so the nested-team assertions below have something to
+		# strip. Listing is caller-independent now -- see the tests.
+		self.priv_team = _make_team(self.priv_org, "Priv Team", api_listed=False)
 
 		self.my_subj = _make_subject(self.my_team, "My Subject")
 		self.pub_subj = _make_subject(self.pub_team, "Pub Subject")
+		self.priv_subj = _make_subject(self.priv_team, "Priv Subject")
 
-		# Article in my org only
+		# One site per organisation, each publishing that organisation's
+		# subject. Only pub_site is api_public, so pub_subj is exactly what
+		# an anonymous caller can see; my_site is reachable by a member of
+		# my_org or a key bound to it, and priv_site by nobody in this suite.
+		self.my_site = private_site_publishing(
+			self.my_subj, organization=self.my_org
+		)
+		self.pub_site = publish_subjects(self.pub_subj, organization=self.pub_org)
+		self.priv_site = private_site_publishing(
+			self.priv_subj, organization=self.priv_org
+		)
+
+		# Article in my scope only
 		self.art_mine = _make_article(
-			"Mine Only", "https://ex.com/1", teams=[self.my_team]
+			"Mine Only", "https://ex.com/1",
+			teams=[self.my_team], subjects=[self.my_subj],
 		)
-		# Article in public org only
+		# Article in the public scope only
 		self.art_pub = _make_article(
-			"Public Only", "https://ex.com/2", teams=[self.pub_team]
+			"Public Only", "https://ex.com/2",
+			teams=[self.pub_team], subjects=[self.pub_subj],
 		)
-		# Article in private (hidden) org only
+		# Article in a private (hidden) scope only
 		self.art_priv = _make_article(
-			"Private Only", "https://ex.com/3", teams=[self.priv_team]
+			"Private Only", "https://ex.com/3",
+			teams=[self.priv_team], subjects=[self.priv_subj],
 		)
-		# Article spanning my org + public org
+		# Article spanning my scope + the public scope
 		self.art_mine_pub = _make_article(
-			"Mine+Pub", "https://ex.com/4", teams=[self.my_team, self.pub_team]
+			"Mine+Pub", "https://ex.com/4",
+			teams=[self.my_team, self.pub_team],
+			subjects=[self.my_subj, self.pub_subj],
 		)
-		# Article spanning my org + hidden org
+		# Article spanning my scope + a hidden scope
 		self.art_mine_priv = _make_article(
-			"Mine+Priv", "https://ex.com/5", teams=[self.my_team, self.priv_team]
+			"Mine+Priv", "https://ex.com/5",
+			teams=[self.my_team, self.priv_team],
+			subjects=[self.my_subj, self.priv_subj],
 		)
 
 		self.client = APIClient()
@@ -147,8 +186,15 @@ class AnonymousArticleVisibilityTest(ArticleVisibilityBase):
 		self.assertIn(self.art_mine_pub.article_id, ids)
 		self.assertNotIn(self.art_mine_priv.article_id, ids)
 
-	def test_cross_org_article_has_hidden_team_stripped(self):
-		"""art_mine_pub: my_team should be stripped (not public), pub_team visible."""
+	def test_cross_scope_article_has_out_of_scope_subject_stripped(self):
+		"""art_mine_pub qualifies on pub_subj; my_subj must not be disclosed.
+
+		This is the assertion that used to be made about teams. It belongs on
+		subjects now: a row is selected by subject, so the subject list is
+		the field that has to agree with the rule that selected it. An
+		anonymous caller sees the article because it carries pub_subj, and
+		must not learn that it also carries my_subj.
+		"""
 		resp = self.client.get("/articles/")
 		self.assertEqual(resp.status_code, 200)
 		art = next(
@@ -156,9 +202,24 @@ class AnonymousArticleVisibilityTest(ArticleVisibilityBase):
 			for a in resp.data["results"]
 			if a["article_id"] == self.art_mine_pub.article_id
 		)
-		team_ids = [t["id"] for t in art["teams"]]
+		subject_ids = [s["id"] for s in art["subjects"]]
+		self.assertIn(self.pub_subj.id, subject_ids)
+		self.assertNotIn(self.my_subj.id, subject_ids)
+
+	def test_unlisted_team_is_stripped_from_nested_teams(self):
+		"""Team nesting follows Team.api_listed, the same flag /teams/ uses.
+
+		Caller-independent by design, unlike subject stripping above: a
+		team's name is either published or it is not, and answering that
+		question differently depending on which endpoint asked would be a
+		leak in whichever direction was laxer.
+		"""
+		resp = self.client.get(f"/articles/{self.art_mine_pub.article_id}/")
+		self.assertEqual(resp.status_code, 200)
+		team_ids = [t["id"] for t in resp.data["teams"]]
 		self.assertIn(self.pub_team.id, team_ids)
-		self.assertNotIn(self.my_team.id, team_ids)
+		self.assertIn(self.my_team.id, team_ids)
+		self.assertNotIn(self.priv_team.id, team_ids)
 
 	def test_detail_of_all_hidden_article_returns_404(self):
 		resp = self.client.get(f"/articles/{self.art_mine.article_id}/")
@@ -243,10 +304,18 @@ class AuthenticatedUserArticleVisibilityTest(ArticleVisibilityBase):
 		resp = self.client.get(f"/articles/{self.art_mine.article_id}/")
 		self.assertEqual(resp.status_code, 200)
 
-	def test_cross_org_article_has_hidden_team_stripped(self):
-		"""art_mine_priv: priv_team should be stripped from teams field."""
+	def test_cross_scope_article_has_out_of_scope_subject_stripped(self):
+		"""art_mine_priv qualifies on my_subj; priv_subj must not be disclosed."""
 		resp = self.client.get(f"/articles/{self.art_mine_priv.article_id}/")
 		self.assertEqual(resp.status_code, 200)
+		subject_ids = [s["id"] for s in resp.data["subjects"]]
+		self.assertIn(self.my_subj.id, subject_ids)
+		self.assertNotIn(self.priv_subj.id, subject_ids)
+
+	def test_unlisted_team_is_stripped_for_a_member_too(self):
+		# The flag is caller-independent: being a member of priv_org's peer
+		# does not reveal an unlisted team's name.
+		resp = self.client.get(f"/articles/{self.art_mine_priv.article_id}/")
 		team_ids = [t["id"] for t in resp.data["teams"]]
 		self.assertIn(self.my_team.id, team_ids)
 		self.assertNotIn(self.priv_team.id, team_ids)
@@ -280,7 +349,7 @@ class AuthenticatedUserArticleVisibilityTest(ArticleVisibilityBase):
 class APIKeyArticleVisibilityTest(ArticleVisibilityBase):
 	def setUp(self):
 		super().setUp()
-		self.scheme = _make_api_scheme(self.my_org, "my-key")
+		self.scheme = _make_api_scheme(self.my_org, "my-key", site=self.my_site)
 		self.client.credentials(HTTP_AUTHORIZATION=self.scheme.api_key)
 
 	def test_list_shows_my_org_article(self):
@@ -366,6 +435,7 @@ class CSVExportArticleVisibilityTest(ArticleVisibilityBase):
 			client_name="csv-key",
 			client_contacts="csv@example.com",
 			organization=self.my_org,
+			site=self.my_site,
 			ip_addresses="",
 			begin_date=now() - timedelta(days=1),
 			end_date=now() + timedelta(days=30),
@@ -384,6 +454,7 @@ class CSVExportArticleVisibilityTest(ArticleVisibilityBase):
 			client_name="csv-key-pub",
 			client_contacts="csvpub@example.com",
 			organization=self.my_org,
+			site=self.my_site,
 			ip_addresses="",
 			begin_date=now() - timedelta(days=1),
 			end_date=now() + timedelta(days=30),

--- a/django/api/tests/test_visibility_articles.py
+++ b/django/api/tests/test_visibility_articles.py
@@ -156,6 +156,20 @@ class ArticleVisibilityBase(TestCase):
 			subjects=[self.my_subj, self.priv_subj],
 		)
 
+		# A second subject owned by pub_team but never curated onto ANY
+		# site's scope_subjects -- pub_team's ORGANISATION is reachable
+		# (pub_org is public), but this particular subject is not. Guards
+		# against ArticleSearchView validating team_id against
+		# visible_org_ids and then trusting subject_id unchecked (PR #863
+		# review finding 1).
+		self.pub_subj_unpublished = _make_subject(
+			self.pub_team, "Pub Unpublished Subject"
+		)
+		self.art_pub_unpublished_subj = _make_article(
+			"Public Team, Unpublished Subject", "https://ex.com/6",
+			teams=[self.pub_team], subjects=[self.pub_subj_unpublished],
+		)
+
 		self.client = APIClient()
 
 
@@ -256,6 +270,29 @@ class AnonymousArticleVisibilityTest(ArticleVisibilityBase):
 			},
 		)
 		self.assertEqual(resp.status_code, 200)
+
+	def test_search_with_reachable_team_but_unpublished_subject_returns_404(self):
+		"""PR #863 review finding 1: the team check alone is not enough.
+
+		pub_team's organisation is public (reachable), but
+		pub_subj_unpublished was never curated onto any site's
+		scope_subjects. Before the fix, ArticleSearchView validated only
+		team_id against visible_org_ids and then filtered
+		subjects__id=subject_id unconditionally, returning
+		art_pub_unpublished_subj in full.
+		"""
+		for method in ("get", "post"):
+			with self.subTest(method=method):
+				params = {
+					"team_id": self.pub_team.id,
+					"subject_id": self.pub_subj_unpublished.id,
+				}
+				resp = (
+					self.client.get("/articles/search/", params)
+					if method == "get"
+					else self.client.post("/articles/search/", params, format="json")
+				)
+				self.assertEqual(resp.status_code, 404)
 
 
 # ---------------------------------------------------------------------------

--- a/django/api/tests/test_visibility_authors.py
+++ b/django/api/tests/test_visibility_authors.py
@@ -162,6 +162,23 @@ class AuthorVisibilityBase(TestCase):
 			authors=[self.author_cross],
 		)
 
+		# A second subject owned by pub_team but never curated onto ANY
+		# site's scope_subjects -- see test_visibility_articles.py's
+		# identical fixture for why (PR #863 review findings 1 and 5:
+		# AuthorSearchView selected author IDs from articles carrying the
+		# requested subject_id before checking that subject was visible).
+		self.pub_subj_unpublished = _make_subject(
+			self.pub_team, "Pub Unpublished Subject Auth"
+		)
+		self.author_pub_unpublished = _make_author("Erin", "Unpublished")
+		_make_article(
+			"Public Team, Unpublished Subject",
+			"https://ex.com/a6",
+			teams=[self.pub_team],
+			subjects=[self.pub_subj_unpublished],
+			authors=[self.author_pub_unpublished],
+		)
+
 		self.client = APIClient()
 
 
@@ -218,6 +235,27 @@ class AnonymousAuthorVisibilityTest(AuthorVisibilityBase):
 			},
 		)
 		self.assertEqual(resp.status_code, 200)
+
+	def test_author_search_reachable_team_but_unpublished_subject_returns_404(self):
+		"""PR #863 review findings 1 and 5 -- see the identical test in
+		test_visibility_articles.py for the full explanation. For
+		AuthorSearchView specifically, the pre-fix leak returned
+		author_pub_unpublished (with zero-count aggregates) rather than
+		404ing, since author IDs were selected from articles carrying the
+		requested subject_id before that subject's visibility was checked.
+		"""
+		for method in ("get", "post"):
+			with self.subTest(method=method):
+				params = {
+					"team_id": self.pub_team.id,
+					"subject_id": self.pub_subj_unpublished.id,
+				}
+				resp = (
+					self.client.get("/authors/search/", params)
+					if method == "get"
+					else self.client.post("/authors/search/", params, format="json")
+				)
+				self.assertEqual(resp.status_code, 404)
 
 
 # ---------------------------------------------------------------------------

--- a/django/api/tests/test_visibility_authors.py
+++ b/django/api/tests/test_visibility_authors.py
@@ -21,6 +21,7 @@ from organizations.models import Organization, OrganizationUser
 from rest_framework.test import APIClient
 
 from api.models import APIAccessScheme
+from api.tests.visibility_helpers import private_site_publishing, publish_subjects
 from gregory.models import Articles, Authors, OrganizationApiSettings, Subject, Team
 
 User = get_user_model()
@@ -72,11 +73,14 @@ def _make_article(title, link, teams=(), subjects=(), authors=()):
 	return art
 
 
-def _make_api_scheme(org, name):
+def _make_api_scheme(org, name, site=None):
+	"""``site`` is what binds the key to a subject scope; a key without one
+	resolves to no subjects at all."""
 	return APIAccessScheme.objects.create(
 		client_name=name,
 		client_contacts=f"{name}@example.com",
 		organization=org,
+		site=site,
 		ip_addresses="",
 		begin_date=now() - timedelta(days=1),
 		end_date=now() + timedelta(days=30),
@@ -100,6 +104,19 @@ class AuthorVisibilityBase(TestCase):
 
 		self.my_subj = _make_subject(self.my_team, "My Subject Auth")
 		self.pub_subj = _make_subject(self.pub_team, "Pub Subject Auth")
+		self.priv_subj = _make_subject(self.priv_team, "Priv Subject Auth")
+
+		# One site per organisation, each publishing that organisation's
+		# subject -- see test_visibility_articles.py for the same shape. An
+		# author is visible only through an article carrying a subject in
+		# the caller's scope, so every article below needs one.
+		self.my_site = private_site_publishing(
+			self.my_subj, organization=self.my_org
+		)
+		self.pub_site = publish_subjects(self.pub_subj, organization=self.pub_org)
+		self.priv_site = private_site_publishing(
+			self.priv_subj, organization=self.priv_org
+		)
 
 		# Authors
 		self.author_mine = _make_author("Alice", "Mine")
@@ -112,18 +129,21 @@ class AuthorVisibilityBase(TestCase):
 			"Mine Art",
 			"https://ex.com/a1",
 			teams=[self.my_team],
+			subjects=[self.my_subj],
 			authors=[self.author_mine],
 		)
 		_make_article(
 			"Pub Art",
 			"https://ex.com/a2",
 			teams=[self.pub_team],
+			subjects=[self.pub_subj],
 			authors=[self.author_pub],
 		)
 		_make_article(
 			"Priv Art",
 			"https://ex.com/a3",
 			teams=[self.priv_team],
+			subjects=[self.priv_subj],
 			authors=[self.author_priv],
 		)
 		# author_cross has articles in both my_team and priv_team
@@ -131,12 +151,14 @@ class AuthorVisibilityBase(TestCase):
 			"Cross Mine Art",
 			"https://ex.com/a4",
 			teams=[self.my_team],
+			subjects=[self.my_subj],
 			authors=[self.author_cross],
 		)
 		_make_article(
 			"Cross Priv Art",
 			"https://ex.com/a5",
 			teams=[self.priv_team],
+			subjects=[self.priv_subj],
 			authors=[self.author_cross],
 		)
 
@@ -282,7 +304,7 @@ class AuthenticatedUserAuthorVisibilityTest(AuthorVisibilityBase):
 class APIKeyAuthorVisibilityTest(AuthorVisibilityBase):
 	def setUp(self):
 		super().setUp()
-		self.scheme = _make_api_scheme(self.my_org, "author-key")
+		self.scheme = _make_api_scheme(self.my_org, "author-key", site=self.my_site)
 		self.client.credentials(HTTP_AUTHORIZATION=self.scheme.api_key)
 
 	def test_list_shows_own_org_author(self):

--- a/django/api/tests/test_visibility_categories.py
+++ b/django/api/tests/test_visibility_categories.py
@@ -20,6 +20,7 @@ from organizations.models import Organization, OrganizationUser
 from rest_framework.test import APIClient
 
 from api.models import APIAccessScheme
+from api.tests.visibility_helpers import private_site_publishing, publish_subjects
 from gregory.models import OrganizationApiSettings, Subject, Team, TeamCategory
 
 User = get_user_model()
@@ -63,11 +64,14 @@ def _make_category(team, subject, name):
 	return cat
 
 
-def _make_api_scheme(org, name):
+def _make_api_scheme(org, name, site=None):
+	"""``site`` is what binds the key to a subject scope; a key without one
+	resolves to no subjects at all."""
 	return APIAccessScheme.objects.create(
 		client_name=name,
 		client_contacts=f"{name}@example.com",
 		organization=org,
+		site=site,
 		ip_addresses="",
 		begin_date=now() - timedelta(days=1),
 		end_date=now() + timedelta(days=30),
@@ -92,6 +96,16 @@ class CategoryVisibilityBase(TestCase):
 		self.my_subj = _make_subject(self.my_team, "My Subj Cat")
 		self.pub_subj = _make_subject(self.pub_team, "Pub Subj Cat")
 		self.priv_subj = _make_subject(self.priv_team, "Priv Subj Cat")
+
+		# One site per organisation, each publishing that organisation's
+		# subject -- see test_visibility_articles.py for the same shape.
+		self.my_site = private_site_publishing(
+			self.my_subj, organization=self.my_org
+		)
+		self.pub_site = publish_subjects(self.pub_subj, organization=self.pub_org)
+		self.priv_site = private_site_publishing(
+			self.priv_subj, organization=self.priv_org
+		)
 
 		self.cat_mine = _make_category(self.my_team, self.my_subj, "Mine Category")
 		self.cat_pub = _make_category(self.pub_team, self.pub_subj, "Public Category")
@@ -204,7 +218,7 @@ class AuthenticatedUserCategoryVisibilityTest(CategoryVisibilityBase):
 class APIKeyCategoryVisibilityTest(CategoryVisibilityBase):
 	def setUp(self):
 		super().setUp()
-		self.scheme = _make_api_scheme(self.my_org, "cat-key")
+		self.scheme = _make_api_scheme(self.my_org, "cat-key", site=self.my_site)
 		self.client.credentials(HTTP_AUTHORIZATION=self.scheme.api_key)
 
 	def test_list_shows_own_category(self):

--- a/django/api/tests/test_visibility_org_filter_edge_cases.py
+++ b/django/api/tests/test_visibility_org_filter_edge_cases.py
@@ -1,17 +1,19 @@
 """
-Regression tests for HOUSE-LOAD-SPIKE-P2-QUERY-COST.md item 2
-(OrgVisibilityMixin's Exists() rewrite from a self-join to a direct
-through-table traversal with team ids resolved in Python).
+Edge cases for SubjectVisibilityMixin's through-table traversal.
 
-These two cases were the ones the plan flagged as untested anywhere in the
-suite before this rewrite:
-  - an article whose *team* is soft-deleted (Team.is_active=False) must stay
-    visible — the mixin resolves organisation ids to team ids via
-    Team.all_objects, not the ActiveTeamManager default, to preserve the
-    pre-rewrite behaviour (the raw SQL it replaced joined gregory_team with
-    no is_active filter at all).
-  - an article with no teams at all must stay invisible (fail-closed), same
-    as before the rewrite.
+Descended from regression tests for HOUSE-LOAD-SPIKE-P2-QUERY-COST.md item 2,
+which pinned OrgVisibilityMixin's Exists() rewrite. Phase 4 of site-scoped
+API visibility replaced that mixin, and the traversal is now over the
+`subjects` M2M rather than `teams`, so what these cases pin has shifted:
+
+  - The team-soft-delete case is no longer about resolving team ids through
+    Team.all_objects (there is nothing to resolve -- subject ids are what the
+    through table holds). It is kept, restated, because it now asserts
+    something stronger and worth keeping: team state cannot affect visibility
+    AT ALL, in either direction.
+  - The fail-closed case survives intact and matters more than before: a row
+    with no subjects is invisible to everyone. That is the whole reason
+    subject-less content is slated for pruning rather than left to sit.
 
 Run with:
     docker exec gregory python manage.py test api.tests.test_visibility_org_filter_edge_cases
@@ -22,7 +24,14 @@ from django.test import TestCase
 from organizations.models import Organization, OrganizationUser
 from rest_framework.test import APIClient
 
-from gregory.models import Articles, OrganizationApiSettings, Team, Trials
+from api.tests.visibility_helpers import publish_subjects
+from gregory.models import (
+	Articles,
+	OrganizationApiSettings,
+	Subject,
+	Team,
+	Trials,
+)
 
 User = get_user_model()
 
@@ -35,11 +44,21 @@ def _make_org(name, slug, public=False):
 	return org
 
 
-class OrgVisibilityThroughTableEdgeCaseTest(TestCase):
+class SubjectVisibilityThroughTableEdgeCaseTest(TestCase):
 	def setUp(self):
 		self.org = _make_org("Edge Org", "edge-org", public=False)
 		self.user = User.objects.create_user(username="member", password="pw")
 		OrganizationUser.objects.create(organization=self.org, user=self.user)
+
+		self.owning_team = Team.objects.create(
+			organization=self.org, name="Edge Team", slug="edge-team"
+		)
+		self.subject = Subject.objects.create(
+			subject_name="Edge Subject",
+			subject_slug="edge-subject",
+			team=self.owning_team,
+		)
+		publish_subjects(self.subject, organization=self.org)
 
 		self.client = APIClient()
 		self.client.force_login(self.user)
@@ -60,6 +79,7 @@ class OrgVisibilityThroughTableEdgeCaseTest(TestCase):
 			title="Inactive Team Article", link="https://ex.com/inactive-team"
 		)
 		article.teams.add(team)
+		article.subjects.add(self.subject)
 
 		resp = self.client.get("/articles/")
 		self.assertEqual(resp.status_code, 200)
@@ -77,25 +97,30 @@ class OrgVisibilityThroughTableEdgeCaseTest(TestCase):
 			title="Inactive Team Trial", link="https://ex.com/inactive-trial"
 		)
 		trial.teams.add(team)
+		trial.subjects.add(self.subject)
 
 		resp = self.client.get("/trials/")
 		self.assertEqual(resp.status_code, 200)
 		ids = [t["trial_id"] for t in resp.data["results"]]
 		self.assertIn(trial.trial_id, ids)
 
-	def test_team_less_article_stays_invisible(self):
+	def test_subject_less_article_stays_invisible(self):
 		article = Articles.objects.create(
-			title="No Team Article", link="https://ex.com/no-team"
+			title="No Subject Article", link="https://ex.com/no-subject"
 		)
+		# Deliberately given a team the caller CAN reach, so the assertion
+		# below can only be explained by the missing subject.
+		article.teams.add(self.owning_team)
 		resp = self.client.get("/articles/")
 		self.assertEqual(resp.status_code, 200)
 		ids = [a["article_id"] for a in resp.data["results"]]
 		self.assertNotIn(article.article_id, ids)
 
-	def test_team_less_trial_stays_invisible(self):
+	def test_subject_less_trial_stays_invisible(self):
 		trial = Trials.objects.create(
-			title="No Team Trial", link="https://ex.com/no-team-trial"
+			title="No Subject Trial", link="https://ex.com/no-subject-trial"
 		)
+		trial.teams.add(self.owning_team)
 		resp = self.client.get("/trials/")
 		self.assertEqual(resp.status_code, 200)
 		ids = [t["trial_id"] for t in resp.data["results"]]

--- a/django/api/tests/test_visibility_sources.py
+++ b/django/api/tests/test_visibility_sources.py
@@ -19,6 +19,7 @@ from organizations.models import Organization, OrganizationUser
 from rest_framework.test import APIClient
 
 from api.models import APIAccessScheme
+from api.tests.visibility_helpers import private_site_publishing, publish_subjects
 from gregory.models import OrganizationApiSettings, Sources, Subject, Team
 
 User = get_user_model()
@@ -60,11 +61,12 @@ def _make_source(team, subject, name):
 	)
 
 
-def _make_api_scheme(org, name):
+def _make_api_scheme(org, name, site=None):
 	return APIAccessScheme.objects.create(
 		client_name=name,
 		client_contacts=f"{name}@example.com",
 		organization=org,
+		site=site,
 		ip_addresses="",
 		begin_date=now() - timedelta(days=1),
 		end_date=now() + timedelta(days=30),
@@ -93,6 +95,15 @@ class SourceVisibilityBase(TestCase):
 		self.src_mine = _make_source(self.my_team, self.my_subj, "Mine Source")
 		self.src_pub = _make_source(self.pub_team, self.pub_subj, "Public Source")
 		self.src_priv = _make_source(self.priv_team, self.priv_subj, "Private Source")
+
+		# Sources reach scope through their subject FK.
+		self.my_site = private_site_publishing(
+			self.my_subj, organization=self.my_org
+		)
+		self.pub_site = publish_subjects(self.pub_subj, organization=self.pub_org)
+		self.priv_site = private_site_publishing(
+			self.priv_subj, organization=self.priv_org
+		)
 
 		self.client = APIClient()
 
@@ -175,7 +186,7 @@ class AuthenticatedUserSourceVisibilityTest(SourceVisibilityBase):
 class APIKeySourceVisibilityTest(SourceVisibilityBase):
 	def setUp(self):
 		super().setUp()
-		self.scheme = _make_api_scheme(self.my_org, "src-key")
+		self.scheme = _make_api_scheme(self.my_org, "src-key", site=self.my_site)
 		self.client.credentials(HTTP_AUTHORIZATION=self.scheme.api_key)
 
 	def test_list_shows_own_source(self):

--- a/django/api/tests/test_visibility_stats.py
+++ b/django/api/tests/test_visibility_stats.py
@@ -19,12 +19,15 @@ Run with:
 from datetime import timedelta
 
 from django.contrib.auth import get_user_model
+from django.contrib.sites.models import Site
 from django.test import TestCase
 from django.utils.timezone import now
 from organizations.models import Organization, OrganizationUser
 from rest_framework.test import APIClient
 
 from api.models import APIAccessScheme
+from sitesettings.models import CustomSetting
+from api.views import stats_payload_cache_key
 from api.tests.visibility_helpers import private_site_publishing, publish_subjects
 from gregory.models import Articles, Authors, OrganizationApiSettings, Sources, Subject, Team
 from subscriptions.models import Lists, Subscribers
@@ -78,11 +81,12 @@ def _make_trial(title, link, teams=(), subjects=()):
 	return trial
 
 
-def _make_api_scheme(org, name):
+def _make_api_scheme(org, name, site=None):
 	return APIAccessScheme.objects.create(
 		client_name=name,
 		client_contacts=f"{name}@example.com",
 		organization=org,
+		site=site,
 		ip_addresses="",
 		begin_date=now() - timedelta(days=1),
 		end_date=now() + timedelta(days=30),
@@ -92,6 +96,32 @@ def _make_api_scheme(org, name):
 # ---------------------------------------------------------------------------
 # Base setUp
 # ---------------------------------------------------------------------------
+
+
+def _key_for(case, team_ids=None, subject_ids=None):
+	"""Build StatsView's layer-1 cache key for the scope `case`'s client has.
+
+	Rebuilding the string by hand is what made these assertions drift the
+	moment the caller-scope component was added, so they go through the same
+	builder the view uses (api.views.stats_payload_cache_key) and resolve the
+	scope through the real visibility function rather than assuming it.
+
+	The caller is taken from the test case: `self.user` when it logged one
+	in, `self.scheme` when it set an API key, anonymous otherwise -- mirroring
+	however that class configured its client.
+	"""
+	from django.contrib.auth.models import AnonymousUser
+	from django.test import RequestFactory
+
+	from gregory.visibility import visible_subject_ids as _resolve
+
+	scheme = getattr(case, "scheme", None)
+	headers = (
+		{"HTTP_AUTHORIZATION": scheme.api_key} if scheme is not None else {}
+	)
+	request = RequestFactory().get("/stats/", **headers)
+	request.user = getattr(case, "user", None) or AnonymousUser()
+	return stats_payload_cache_key(team_ids, _resolve(request), subject_ids)
 
 
 class StatsVisibilityBase(TestCase):
@@ -104,26 +134,48 @@ class StatsVisibilityBase(TestCase):
 		self.pub_team = _make_team(self.pub_org, "Pub Team Stats")
 		self.priv_team = _make_team(self.priv_org, "Priv Team Stats")
 
+		# /stats/ counts are subject-scoped, so content must carry a subject
+		# and a site must publish it. One base subject per organisation, on
+		# that organisation's own site; subclasses add their own on top.
+		self.base_subj_mine = _make_subject(self.my_team, "Base Subj Mine")
+		self.base_subj_pub = _make_subject(self.pub_team, "Base Subj Pub")
+		self.base_subj_priv = _make_subject(self.priv_team, "Base Subj Priv")
+		self.base_site_mine = private_site_publishing(
+			self.base_subj_mine, organization=self.my_org
+		)
+		self.base_site_pub = publish_subjects(
+			self.base_subj_pub, organization=self.pub_org
+		)
+		self.base_site_priv = private_site_publishing(
+			self.base_subj_priv, organization=self.priv_org
+		)
+
 		# Articles
 		self.art_mine = _make_article(
-			"Mine Art", "https://st.ex/a1", teams=[self.my_team]
+			"Mine Art", "https://st.ex/a1", teams=[self.my_team],
+			subjects=[self.base_subj_mine],
 		)
 		self.art_pub = _make_article(
-			"Pub Art", "https://st.ex/a2", teams=[self.pub_team]
+			"Pub Art", "https://st.ex/a2", teams=[self.pub_team],
+			subjects=[self.base_subj_pub],
 		)
 		self.art_priv = _make_article(
-			"Priv Art", "https://st.ex/a3", teams=[self.priv_team]
+			"Priv Art", "https://st.ex/a3", teams=[self.priv_team],
+			subjects=[self.base_subj_priv],
 		)
 
 		# Trials
 		self.trial_mine = _make_trial(
-			"Mine Trial", "https://st.ex/t1", teams=[self.my_team]
+			"Mine Trial", "https://st.ex/t1", teams=[self.my_team],
+			subjects=[self.base_subj_mine],
 		)
 		self.trial_pub = _make_trial(
-			"Pub Trial", "https://st.ex/t2", teams=[self.pub_team]
+			"Pub Trial", "https://st.ex/t2", teams=[self.pub_team],
+			subjects=[self.base_subj_pub],
 		)
 		self.trial_priv = _make_trial(
-			"Priv Trial", "https://st.ex/t3", teams=[self.priv_team]
+			"Priv Trial", "https://st.ex/t3", teams=[self.priv_team],
+			subjects=[self.base_subj_priv],
 		)
 
 		self.client = APIClient()
@@ -226,7 +278,7 @@ class AuthenticatedUserStatsVisibilityTest(StatsVisibilityBase):
 class APIKeyStatsVisibilityTest(StatsVisibilityBase):
 	def setUp(self):
 		super().setUp()
-		self.scheme = _make_api_scheme(self.my_org, "stats-key")
+		self.scheme = _make_api_scheme(self.my_org, "stats-key", site=self.base_site_mine)
 		self.client.credentials(HTTP_AUTHORIZATION=self.scheme.api_key)
 
 	def test_own_team_visible(self):
@@ -414,8 +466,8 @@ class StatsCacheTest(StatsVisibilityBase):
 		self.client.get("/stats/", {"team": self.pub_team2.id})
 
 		# Both requests must produce distinct, non-None cache entries.
-		key1 = f"stats:{self.pub_team.id}:subj:all"
-		key2 = f"stats:{self.pub_team2.id}:subj:all"
+		key1 = _key_for(self, [self.pub_team.id])
+		key2 = _key_for(self, [self.pub_team2.id])
 		self.assertIsNotNone(django_cache.get(key1))
 		self.assertIsNotNone(django_cache.get(key2))
 		self.assertNotEqual(key1, key2)
@@ -424,7 +476,7 @@ class StatsCacheTest(StatsVisibilityBase):
 		"""setUp.cache.clear() isolates test runs."""
 		from django.core.cache import cache as django_cache
 
-		self.assertIsNone(django_cache.get("stats:all:subj:all"))
+		self.assertIsNone(django_cache.get(_key_for(self)))
 
 
 # ---------------------------------------------------------------------------
@@ -659,9 +711,19 @@ class SubjectFilterStatsTest(SubjectStatsBase):
 		self.assertEqual(resp.status_code, 200)
 		self.assertEqual(resp.data["articles"], 1)  # art_mine, not art_teamless
 
-	def test_source_with_null_subject_dropped_when_filtering(self):
+	def test_source_with_null_subject_is_never_counted(self):
+		"""A Source with subject=None is counted in neither case.
+
+		It used to be counted when no ?subject= was given. That was the stats
+		endpoint disagreeing with /sources/, which scopes on
+		subject_id__in=<visible> — a NULL subject_id matches no IN list, so
+		such a source has always been unreachable there. Since the stats
+		content filter defaults to the caller's visible subject set (PR #863
+		review finding 6), the two agree: /stats/ no longer reports rows the
+		list endpoint will not return.
+		"""
 		resp_unfiltered = self.client.get("/stats/", {"team": self.my_team.id})
-		self.assertEqual(resp_unfiltered.data["sources"]["total"], 2)
+		self.assertEqual(resp_unfiltered.data["sources"]["total"], 1)
 
 		resp_filtered = self.client.get(
 			"/stats/", {"team": self.my_team.id, "subject": self.subj_a.id}
@@ -739,8 +801,8 @@ class SubjectStatsCacheTest(SubjectStatsBase):
 		self.client.get(
 			"/stats/", {"team": self.my_team.id, "subject": self.subj_a.id}
 		)
-		key_unfiltered = f"stats:{self.my_team.id}:subj:all"
-		key_filtered = f"stats:{self.my_team.id}:subj:{self.subj_a.id}"
+		key_unfiltered = _key_for(self, [self.my_team.id])
+		key_filtered = _key_for(self, [self.my_team.id], [self.subj_a.id])
 		cached_unfiltered = django_cache.get(key_unfiltered)
 		cached_filtered = django_cache.get(key_filtered)
 		self.assertIsNotNone(cached_unfiltered)
@@ -756,8 +818,8 @@ class SubjectStatsCacheTest(SubjectStatsBase):
 		self.client.get(
 			"/stats/", {"team": self.my_team.id, "subject": self.subj_b.id}
 		)
-		key_a = f"stats:{self.my_team.id}:subj:{self.subj_a.id}"
-		key_b = f"stats:{self.my_team.id}:subj:{self.subj_b.id}"
+		key_a = _key_for(self, [self.my_team.id], [self.subj_a.id])
+		key_b = _key_for(self, [self.my_team.id], [self.subj_b.id])
 		self.assertIsNotNone(django_cache.get(key_a))
 		self.assertIsNotNone(django_cache.get(key_b))
 
@@ -768,10 +830,9 @@ class SubjectStatsCacheTest(SubjectStatsBase):
 			"/stats/",
 			{"team": self.my_team.id, "subject": f"{self.subj_a.id},{self.subj_b.id}"},
 		)
-		sorted_ids = ",".join(
-			str(i) for i in sorted([self.subj_a.id, self.subj_b.id])
+		key_sorted = _key_for(
+			self, [self.my_team.id], [self.subj_b.id, self.subj_a.id]
 		)
-		key_sorted = f"stats:{self.my_team.id}:subj:{sorted_ids}"
 		self.assertIsNotNone(django_cache.get(key_sorted))
 
 		resp2 = self.client.get(
@@ -858,7 +919,11 @@ class BySubjectFacetTest(StatsVisibilityBase):
 			subject=self.subj_beta,
 			source_for="science paper",
 		)
-		# No subject at all → must not appear in any by_subject row.
+		# No subject at all → appears in no by_subject row, and since the
+		# stats content filter defaults to the caller's visible subjects
+		# (PR #863 review finding 6) it is absent from sources.total too,
+		# matching /sources/ where a NULL subject_id has always been
+		# unreachable.
 		Sources.objects.create(
 			name="Null Feed",
 			link="https://null-domain.example.com/feed",
@@ -908,9 +973,9 @@ class BySubjectFacetTest(StatsVisibilityBase):
 		self.assertEqual(rows[self.subj_alpha.id]["sources"], 1)
 		# Domain shared with alpha, different subject → appears here too.
 		self.assertEqual(rows[self.subj_beta.id]["sources"], 1)
-		# Shared domain counted once overall despite feeding two subjects,
-		# plus the null-domain source → 2 total.
-		self.assertEqual(resp.data["sources"]["total"], 2)
+		# Shared domain counted once overall despite feeding two subjects.
+		# The null-subject source is not counted at all — see the fixture.
+		self.assertEqual(resp.data["sources"]["total"], 1)
 
 	def test_no_subscribers_key_in_by_subject_rows(self):
 		resp = self.client.get("/stats/", {"team": self.my_team.id})
@@ -1015,7 +1080,7 @@ class BySubjectRowCacheTest(SubjectStatsBase):
 
 		self.client.get("/stats/", {"team": self.my_team.id})  # warms both layers
 
-		layer1_key = f"stats:{self.my_team.id}:subj:all"
+		layer1_key = _key_for(self, [self.my_team.id])
 		django_cache.delete(layer1_key)
 
 		through_table = Articles.subjects.through._meta.db_table
@@ -1077,7 +1142,7 @@ class BySubjectRowCacheTest(SubjectStatsBase):
 		self.subj_a.subject_name = "Renamed Subject A"
 		self.subj_a.save(update_fields=["subject_name"])
 
-		django_cache.delete(f"stats:{self.my_team.id}:subj:all")  # layer-1 only
+		django_cache.delete(_key_for(self, [self.my_team.id]))  # layer-1 only
 
 		resp = self.client.get("/stats/", {"team": self.my_team.id})
 		row = next(r for r in resp.data["by_subject"] if r["subject_id"] == self.subj_a.id)
@@ -1102,7 +1167,9 @@ class BySubjectRowCacheTest(SubjectStatsBase):
 			subjects=[self.subj_a],
 		)
 
-		django_cache.delete(f"stats:{self.my_team.id}:subj:{self.subj_a.id}")
+		django_cache.delete(
+			_key_for(self, [self.my_team.id], [self.subj_a.id])
+		)
 
 		resp = self.client.get(
 			"/stats/", {"team": self.my_team.id, "subject": self.subj_a.id}
@@ -1160,7 +1227,95 @@ class SiteFilterStatsTest(SubjectStatsBase):
 		resp = self.client.get("/stats/", {"site": "not-an-id"})
 		self.assertEqual(resp.status_code, 400)
 
+	def test_a_reachable_site_plus_an_unknown_one_404s(self):
+		"""Every requested site is validated, not just the union.
+
+		Unioning first and checking only that the result is non-empty would
+		let the reachable half carry the request, silently ignoring the
+		other -- so a caller probing IDs could not tell a real site from a
+		typo, and a request naming something it cannot see would still get
+		an answer.
+		"""
+		resp = self.client.get(
+			"/stats/", {"site": f"{self.my_site.id},999999"}
+		)
+		self.assertEqual(resp.status_code, 404)
+
+	def test_a_reachable_site_plus_an_unreachable_one_404s(self):
+		resp = self.client.get(
+			"/stats/", {"site": f"{self.my_site.id},{self.priv_site.id}"}
+		)
+		self.assertEqual(resp.status_code, 404)
+
+	def test_a_site_with_an_empty_scope_404s(self):
+		# Same answer as "does not exist" and "cannot see it", on purpose:
+		# distinguishing them would leak which site IDs are real.
+		empty_site = Site.objects.create(
+			domain="empty-scope.example.com", name="Empty Scope"
+		)
+		CustomSetting.objects.create(
+			site=empty_site, title="Empty Scope settings", api_public=True
+		)
+		self.assertEqual(
+			self.client.get("/stats/", {"site": empty_site.id}).status_code, 404
+		)
+
 	def test_organization_still_works_unchanged(self):
 		# Deprecated, not removed, and still means what it always meant.
 		resp = self.client.get("/stats/", {"organization": self.my_org.id})
 		self.assertEqual(resp.status_code, 200)
+
+
+class StatsCrossTenantCacheTest(SubjectStatsBase):
+	"""
+	Two site-bound API keys in the SAME organisation must not share a
+	/stats/ payload (PR #863 review finding 7).
+
+	They resolve to the same ?team= narrowing and, with no ?subject=, to the
+	same "subj:all" — so a key built only from the request parameters is
+	identical for both, while their visible subject sets, their counts and
+	their by_subject rosters are not. The caller's own scope is therefore
+	part of the key.
+	"""
+
+	def setUp(self):
+		super().setUp()
+		self.client.logout()
+		# A second site under the same organisation, publishing a different
+		# subject with its own article.
+		self.other_subject = _make_subject(self.my_team, "Other Site Subject")
+		self.other_site = private_site_publishing(
+			self.other_subject, organization=self.my_org
+		)
+		_make_article(
+			"Other Site Art",
+			"https://st.ex/other-site",
+			teams=[self.my_team],
+			subjects=[self.other_subject],
+		)
+
+	def _stats_for(self, site):
+		scheme = _make_api_scheme(
+			self.my_org, f"key-{site.id}-{id(site)}", site=site
+		)
+		client = APIClient()
+		client.credentials(HTTP_AUTHORIZATION=scheme.api_key)
+		resp = client.get("/stats/")
+		self.assertEqual(resp.status_code, 200)
+		return resp.data
+
+	def test_two_site_keys_in_one_org_do_not_share_a_payload(self):
+		first = self._stats_for(self.my_site)
+		second = self._stats_for(self.other_site)
+
+		first_subjects = {row["subject_id"] for row in first["by_subject"]}
+		second_subjects = {row["subject_id"] for row in second["by_subject"]}
+
+		# Each key sees only its own site's scope...
+		self.assertIn(self.subj_a.id, first_subjects)
+		self.assertNotIn(self.other_subject.id, first_subjects)
+		self.assertIn(self.other_subject.id, second_subjects)
+		self.assertNotIn(self.subj_a.id, second_subjects)
+		# ...which is only possible if the second request was not served the
+		# first one's cached payload.
+		self.assertNotEqual(first["by_subject"], second["by_subject"])

--- a/django/api/tests/test_visibility_stats.py
+++ b/django/api/tests/test_visibility_stats.py
@@ -25,6 +25,7 @@ from organizations.models import Organization, OrganizationUser
 from rest_framework.test import APIClient
 
 from api.models import APIAccessScheme
+from api.tests.visibility_helpers import private_site_publishing, publish_subjects
 from gregory.models import Articles, Authors, OrganizationApiSettings, Sources, Subject, Team
 from subscriptions.models import Lists, Subscribers
 
@@ -569,6 +570,18 @@ class SubjectStatsBase(StatsVisibilityBase):
 		self.subj_pub = _make_subject(self.pub_team, "Subject Pub")
 		self.subj_priv = _make_subject(self.priv_team, "Subject Priv")
 
+		# One site per organisation publishing its own subjects. This is what
+		# puts them in scope at all: the stats subject roster is subject-scoped
+		# since Phase 4, so an unpublished subject contributes nothing and the
+		# ?subject= checks below would all 404.
+		self.my_site = private_site_publishing(
+			self.subj_a, self.subj_b, organization=self.my_org
+		)
+		self.pub_site = publish_subjects(self.subj_pub, organization=self.pub_org)
+		self.priv_site = private_site_publishing(
+			self.subj_priv, organization=self.priv_org
+		)
+
 		# art_mine / trial_mine (from the base fixture) get tagged with subj_a.
 		self.art_mine.subjects.add(self.subj_a)
 		self.trial_mine.subjects.add(self.subj_a)
@@ -785,8 +798,20 @@ class BySubjectFacetTest(StatsVisibilityBase):
 		self.subj_zeta = _make_subject(self.my_team, "Zeta Subject")
 		self.subj_alpha = _make_subject(self.my_team, "Alpha Subject")
 		self.subj_beta = _make_subject(self.my_team, "Beta Subject")
-		# Belongs to a private org invisible to this caller.
+		# Published on a site this caller's organisation owns, so the three
+		# above are in scope; subj_hidden deliberately is not published here.
+		self.my_site = private_site_publishing(
+			self.subj_zeta,
+			self.subj_alpha,
+			self.subj_beta,
+			organization=self.my_org,
+		)
+		# In no scope this caller can reach — the roster must drop it even
+		# though an article below carries both it and subj_alpha.
 		self.subj_hidden = _make_subject(self.priv_team, "Hidden Subject")
+		self.priv_site = private_site_publishing(
+			self.subj_hidden, organization=self.priv_org
+		)
 
 		self.author1 = Authors.objects.create(given_name="Ann", family_name="One")
 		self.author2 = Authors.objects.create(given_name="Bob", family_name="Two")
@@ -1088,3 +1113,54 @@ class BySubjectRowCacheTest(SubjectStatsBase):
 		# ...but the by_subject row is served from the still-warm layer-2
 		# cache and has not caught up yet — the documented skew.
 		self.assertEqual(row["articles"], 1)
+
+
+class SiteFilterStatsTest(SubjectStatsBase):
+	"""
+	``?site=`` scopes /stats/ to the subjects a site publishes.
+
+	Added with Phase 4 of site-scoped API visibility, as the replacement for
+	``?organization=``: organisations stopped being the visibility unit, and
+	silently redefining a documented parameter is the failure mode this
+	project exists to prevent. So ``?organization=`` keeps its old meaning and
+	is marked deprecated, while ``?site=`` is the one that matches how
+	visibility now works.
+	"""
+
+	def test_site_scopes_to_that_sites_subjects(self):
+		resp = self.client.get("/stats/", {"site": self.my_site.id})
+		self.assertEqual(resp.status_code, 200)
+		roster = {row["subject_id"] for row in resp.data["by_subject"]}
+		self.assertEqual(roster, {self.subj_a.id, self.subj_b.id})
+
+	def test_site_and_subject_intersect_rather_than_override(self):
+		# A filter may only ever narrow. subj_b is in my_site's scope, so
+		# naming both leaves exactly subj_b.
+		resp = self.client.get(
+			"/stats/", {"site": self.my_site.id, "subject": self.subj_b.id}
+		)
+		self.assertEqual(resp.status_code, 200)
+		roster = {row["subject_id"] for row in resp.data["by_subject"]}
+		self.assertEqual(roster, {self.subj_b.id})
+
+	def test_unreachable_site_404s_rather_than_returning_everything(self):
+		# priv_site belongs to an organisation this caller is not in. Its
+		# scope resolves to nothing the caller may see, and an empty scope
+		# must not read as "no filter" — that would widen the answer to
+		# everything, which is the opposite of what was asked.
+		resp = self.client.get("/stats/", {"site": self.priv_site.id})
+		self.assertEqual(resp.status_code, 404)
+
+	def test_unknown_site_404s(self):
+		self.assertEqual(
+			self.client.get("/stats/", {"site": 999999}).status_code, 404
+		)
+
+	def test_non_numeric_site_is_400_not_500(self):
+		resp = self.client.get("/stats/", {"site": "not-an-id"})
+		self.assertEqual(resp.status_code, 400)
+
+	def test_organization_still_works_unchanged(self):
+		# Deprecated, not removed, and still means what it always meant.
+		resp = self.client.get("/stats/", {"organization": self.my_org.id})
+		self.assertEqual(resp.status_code, 200)

--- a/django/api/tests/test_visibility_subjects.py
+++ b/django/api/tests/test_visibility_subjects.py
@@ -2,9 +2,13 @@
 Tests for subject visibility enforcement (PR 5).
 
 Covers:
-  - SubjectsViewSet list/detail: only subjects whose team.organization is visible
-  - Detail endpoint 404s when subject belongs to a hidden org
-  - Four caller archetypes × the standard test matrix
+  - SubjectsViewSet list/detail: only subjects in a scope the caller can reach
+  - Detail endpoint 404s when no reachable site publishes the subject
+  - Three caller archetypes × the standard test matrix
+
+The subject IS the row here, so scoping is a set-membership test rather than
+a walk to the owning team's organisation (site-scoped API visibility,
+Phase 4). Each organisation owns a Site publishing its own subject.
 
 Run with:
     docker exec gregory python manage.py test api.tests.test_visibility_subjects
@@ -19,6 +23,7 @@ from organizations.models import Organization, OrganizationUser
 from rest_framework.test import APIClient
 
 from api.models import APIAccessScheme
+from api.tests.visibility_helpers import private_site_publishing, publish_subjects
 from gregory.models import OrganizationApiSettings, Subject, Team
 
 User = get_user_model()
@@ -50,11 +55,12 @@ def _make_subject(team, name):
 	)
 
 
-def _make_api_scheme(org, name):
+def _make_api_scheme(org, name, site=None):
 	return APIAccessScheme.objects.create(
 		client_name=name,
 		client_contacts=f"{name}@example.com",
 		organization=org,
+		site=site,
 		ip_addresses="",
 		begin_date=now() - timedelta(days=1),
 		end_date=now() + timedelta(days=30),
@@ -79,6 +85,14 @@ class SubjectVisibilityBase(TestCase):
 		self.subj_mine = _make_subject(self.my_team, "Mine Subj")
 		self.subj_pub = _make_subject(self.pub_team, "Public Subj")
 		self.subj_priv = _make_subject(self.priv_team, "Private Subj")
+
+		self.my_site = private_site_publishing(
+			self.subj_mine, organization=self.my_org
+		)
+		self.pub_site = publish_subjects(self.subj_pub, organization=self.pub_org)
+		self.priv_site = private_site_publishing(
+			self.subj_priv, organization=self.priv_org
+		)
 
 		self.client = APIClient()
 
@@ -161,7 +175,7 @@ class AuthenticatedUserSubjectVisibilityTest(SubjectVisibilityBase):
 class APIKeySubjectVisibilityTest(SubjectVisibilityBase):
 	def setUp(self):
 		super().setUp()
-		self.scheme = _make_api_scheme(self.my_org, "subj-key")
+		self.scheme = _make_api_scheme(self.my_org, "subj-key", site=self.my_site)
 		self.client.credentials(HTTP_AUTHORIZATION=self.scheme.api_key)
 
 	def test_list_shows_own_subject(self):

--- a/django/api/tests/test_visibility_teams.py
+++ b/django/api/tests/test_visibility_teams.py
@@ -1,12 +1,23 @@
 """
-Tests for team visibility enforcement (PR 5).
+Tests for team listing on /teams/.
 
-Covers:
-  - TeamsViewSet list/detail: only teams in visible orgs
-  - Detail endpoint 404s when team belongs to a hidden org
-  - Permission changed from IsAuthenticated → IsAuthenticatedOrReadOnly
-    (anonymous users can now see public orgs' teams without authentication)
-  - Four caller archetypes × the standard test matrix
+A Team is not content: it carries no subject of its own, so subject scope --
+the rule everywhere else since Phase 4 of site-scoped API visibility -- has
+nothing to say about it. `/teams/` is gated by the explicit `Team.api_listed`
+flag instead, seeded by `sitesettings/0019` from the teams that owned a
+subject in a public scope and overridable in either direction after that.
+
+That makes this endpoint **caller-independent**, which is the whole change
+this suite records. The previous rule was "teams in organisations you can
+see", so the same request returned different teams to an anonymous caller, a
+member and an API key, and `?include_public=true` widened it. Now every
+caller gets the same list and the flag is the only input.
+
+The flag gates *listing*, not *access*: `api_listed = False` removes a team
+from this endpoint and does nothing to the visibility of that team's
+articles, trials or subjects, which subject scope governs. Keeping those two
+separate is deliberate -- conflating them is how a metadata switch quietly
+becomes a data-visibility switch.
 
 Run with:
     docker exec gregory python manage.py test api.tests.test_visibility_teams
@@ -39,9 +50,11 @@ def _make_org(name, slug, public=False):
 	return org
 
 
-def _make_team(org, name):
+def _make_team(org, name, api_listed=False):
 	slug = name.lower().replace(" ", "-")
-	return Team.objects.create(organization=org, name=name, slug=slug)
+	return Team.objects.create(
+		organization=org, name=name, slug=slug, api_listed=api_listed
+	)
 
 
 def _make_api_scheme(org, name):
@@ -60,17 +73,31 @@ def _make_api_scheme(org, name):
 # ---------------------------------------------------------------------------
 
 
-class TeamVisibilityBase(TestCase):
+class TeamListingBase(TestCase):
 	def setUp(self):
 		self.my_org = _make_org("My Org", "my-org-team", public=False)
 		self.pub_org = _make_org("Public Org", "pub-org-team", public=True)
 		self.priv_org = _make_org("Private Org", "priv-org-team", public=False)
 
-		self.my_team = _make_team(self.my_org, "My Team Teams")
-		self.pub_team = _make_team(self.pub_org, "Pub Team Teams")
-		self.priv_team = _make_team(self.priv_org, "Priv Team Teams")
+		# api_listed cuts across the public/private organisation split on
+		# purpose: the flag is independent of who owns the team, which is
+		# exactly what the endpoint no longer derives.
+		self.listed_team = _make_team(self.pub_org, "Listed Team", api_listed=True)
+		self.unlisted_public_team = _make_team(
+			self.pub_org, "Unlisted Public Team", api_listed=False
+		)
+		self.my_team = _make_team(self.my_org, "My Team Teams", api_listed=False)
+		self.my_listed_team = _make_team(
+			self.my_org, "My Listed Team", api_listed=True
+		)
+		self.priv_team = _make_team(self.priv_org, "Priv Team Teams", api_listed=False)
 
 		self.client = APIClient()
+
+	def _listed_ids(self):
+		resp = self.client.get("/teams/")
+		self.assertEqual(resp.status_code, 200)
+		return [t["id"] for t in resp.data["results"]]
 
 
 # ---------------------------------------------------------------------------
@@ -78,117 +105,90 @@ class TeamVisibilityBase(TestCase):
 # ---------------------------------------------------------------------------
 
 
-class AnonymousTeamVisibilityTest(TeamVisibilityBase):
+class AnonymousTeamListingTest(TeamListingBase):
 	def test_list_does_not_require_auth(self):
-		"""TeamsViewSet is now IsAuthenticatedOrReadOnly — anonymous read is allowed."""
-		resp = self.client.get("/teams/")
-		self.assertEqual(resp.status_code, 200)
+		self.assertEqual(self.client.get("/teams/").status_code, 200)
 
-	def test_list_includes_public_team(self):
-		resp = self.client.get("/teams/")
-		ids = [t["id"] for t in resp.data["results"]]
-		self.assertIn(self.pub_team.id, ids)
+	def test_list_includes_listed_team(self):
+		self.assertIn(self.listed_team.id, self._listed_ids())
 
-	def test_list_excludes_private_teams(self):
-		resp = self.client.get("/teams/")
-		ids = [t["id"] for t in resp.data["results"]]
+	def test_list_excludes_unlisted_teams(self):
+		ids = self._listed_ids()
+		self.assertNotIn(self.unlisted_public_team.id, ids)
 		self.assertNotIn(self.my_team.id, ids)
 		self.assertNotIn(self.priv_team.id, ids)
 
-	def test_detail_hidden_returns_404(self):
-		resp = self.client.get(f"/teams/{self.my_team.id}/")
+	def test_a_public_organisation_does_not_make_its_team_listed(self):
+		# The old rule listed every team of a public organisation. The flag
+		# is now the only input, so an unlisted team in a public
+		# organisation stays out.
+		self.assertNotIn(self.unlisted_public_team.id, self._listed_ids())
+
+	def test_detail_unlisted_returns_404(self):
+		resp = self.client.get(f"/teams/{self.unlisted_public_team.id}/")
 		self.assertEqual(resp.status_code, 404)
 
-	def test_detail_public_returns_200(self):
-		resp = self.client.get(f"/teams/{self.pub_team.id}/")
+	def test_detail_listed_returns_200(self):
+		resp = self.client.get(f"/teams/{self.listed_team.id}/")
 		self.assertEqual(resp.status_code, 200)
 
 
 # ---------------------------------------------------------------------------
-# Authenticated user (member of my_org)
+# The listing is the same for every caller
 # ---------------------------------------------------------------------------
 
 
-class AuthenticatedUserTeamVisibilityTest(TeamVisibilityBase):
+class AuthenticatedUserTeamListingTest(TeamListingBase):
 	def setUp(self):
 		super().setUp()
 		self.user = User.objects.create_user(username="team-member", password="pw")
 		OrganizationUser.objects.create(organization=self.my_org, user=self.user)
 		self.client.force_login(self.user)
 
-	def test_list_shows_own_team(self):
-		resp = self.client.get("/teams/")
-		ids = [t["id"] for t in resp.data["results"]]
-		self.assertIn(self.my_team.id, ids)
-
-	def test_list_excludes_unrelated_private_team(self):
-		resp = self.client.get("/teams/")
-		ids = [t["id"] for t in resp.data["results"]]
+	def test_member_sees_the_same_listing_as_anonymous(self):
+		ids = self._listed_ids()
+		self.assertIn(self.listed_team.id, ids)
+		self.assertIn(self.my_listed_team.id, ids)
+		self.assertNotIn(self.unlisted_public_team.id, ids)
 		self.assertNotIn(self.priv_team.id, ids)
 
-	def test_list_excludes_public_team_without_flag(self):
-		resp = self.client.get("/teams/")
-		ids = [t["id"] for t in resp.data["results"]]
-		self.assertNotIn(self.pub_team.id, ids)
+	def test_membership_does_not_reveal_an_unlisted_team(self):
+		# Worth stating explicitly: the user belongs to my_org, and my_team
+		# is my_org's, but the flag governs and it is off. Under the old
+		# organisation rule this team WAS visible to this caller.
+		ids = self._listed_ids()
+		self.assertNotIn(self.my_team.id, ids)
+		self.assertEqual(
+			self.client.get(f"/teams/{self.my_team.id}/").status_code, 404
+		)
 
-	def test_include_public_adds_public_teams(self):
+	def test_include_public_is_a_no_op(self):
+		# The flag is caller-independent, so there is no "own scope" for the
+		# flag to widen. The parameter is accepted and changes nothing.
+		plain = self._listed_ids()
 		resp = self.client.get("/teams/?include_public=true")
-		ids = [t["id"] for t in resp.data["results"]]
-		self.assertIn(self.my_team.id, ids)
-		self.assertIn(self.pub_team.id, ids)
-		self.assertNotIn(self.priv_team.id, ids)
+		self.assertEqual(resp.status_code, 200)
+		self.assertEqual([t["id"] for t in resp.data["results"]], plain)
 
-	def test_detail_hidden_returns_404(self):
-		resp = self.client.get(f"/teams/{self.priv_team.id}/")
-		self.assertEqual(resp.status_code, 404)
-
-	def test_detail_own_returns_200(self):
-		resp = self.client.get(f"/teams/{self.my_team.id}/")
+	def test_detail_own_listed_returns_200(self):
+		resp = self.client.get(f"/teams/{self.my_listed_team.id}/")
 		self.assertEqual(resp.status_code, 200)
 
 
-# ---------------------------------------------------------------------------
-# API key caller (bound to my_org)
-# ---------------------------------------------------------------------------
-
-
-class APIKeyTeamVisibilityTest(TeamVisibilityBase):
+class APIKeyTeamListingTest(TeamListingBase):
 	def setUp(self):
 		super().setUp()
 		self.scheme = _make_api_scheme(self.my_org, "team-key")
 		self.client.credentials(HTTP_AUTHORIZATION=self.scheme.api_key)
 
-	def test_list_shows_own_team(self):
-		resp = self.client.get("/teams/")
-		ids = [t["id"] for t in resp.data["results"]]
-		self.assertIn(self.my_team.id, ids)
-
-	def test_list_excludes_other_private_team(self):
-		resp = self.client.get("/teams/")
-		ids = [t["id"] for t in resp.data["results"]]
+	def test_key_sees_the_same_listing_as_anonymous(self):
+		ids = self._listed_ids()
+		self.assertIn(self.listed_team.id, ids)
+		self.assertIn(self.my_listed_team.id, ids)
+		self.assertNotIn(self.unlisted_public_team.id, ids)
+		self.assertNotIn(self.my_team.id, ids)
 		self.assertNotIn(self.priv_team.id, ids)
 
-	def test_list_excludes_public_team_without_flag(self):
-		resp = self.client.get("/teams/")
-		ids = [t["id"] for t in resp.data["results"]]
-		self.assertNotIn(self.pub_team.id, ids)
-
-	def test_include_public_adds_public_teams(self):
-		resp = self.client.get("/teams/?include_public=true")
-		ids = [t["id"] for t in resp.data["results"]]
-		self.assertIn(self.my_team.id, ids)
-		self.assertIn(self.pub_team.id, ids)
-		self.assertNotIn(self.priv_team.id, ids)
-
-	def test_detail_hidden_returns_404(self):
-		resp = self.client.get(f"/teams/{self.priv_team.id}/")
-		self.assertEqual(resp.status_code, 404)
-
-	def test_detail_own_returns_200(self):
+	def test_detail_unlisted_returns_404(self):
 		resp = self.client.get(f"/teams/{self.my_team.id}/")
-		self.assertEqual(resp.status_code, 200)
-
-
-# ---------------------------------------------------------------------------
-# Null-org API key (anonymous-equivalent)
-# ---------------------------------------------------------------------------
+		self.assertEqual(resp.status_code, 404)

--- a/django/api/tests/test_visibility_teams.py
+++ b/django/api/tests/test_visibility_teams.py
@@ -7,11 +7,17 @@ nothing to say about it. `/teams/` is gated by the explicit `Team.api_listed`
 flag instead, seeded by `sitesettings/0019` from the teams that owned a
 subject in a public scope and overridable in either direction after that.
 
-That makes this endpoint **caller-independent**, which is the whole change
-this suite records. The previous rule was "teams in organisations you can
-see", so the same request returned different teams to an anonymous caller, a
-member and an API key, and `?include_public=true` widened it. Now every
-caller gets the same list and the flag is the only input.
+A team is listed when EITHER the flag is on, OR the team owns a subject
+already in the caller's scope. The flag is the primary answer and is
+caller-independent; the second clause only ever adds, and exists so a private
+site's own authenticated frontend can list its own teams -- those are exactly
+the teams an operator marks unlisted. A caller who can already read a team's
+articles learns nothing new from its name.
+
+The previous rule was "teams in organisations you can see", so the same
+request returned different teams to an anonymous caller, a member and an API
+key, and `?include_public=true` widened it. Organisation membership grants
+nothing here now; only the flag and the subject scope do.
 
 The flag gates *listing*, not *access*: `api_listed = False` removes a team
 from this endpoint and does nothing to the visibility of that team's
@@ -32,7 +38,8 @@ from organizations.models import Organization, OrganizationUser
 from rest_framework.test import APIClient
 
 from api.models import APIAccessScheme
-from gregory.models import OrganizationApiSettings, Team
+from api.tests.visibility_helpers import private_site_publishing
+from gregory.models import OrganizationApiSettings, Subject, Team
 
 User = get_user_model()
 
@@ -57,11 +64,12 @@ def _make_team(org, name, api_listed=False):
 	)
 
 
-def _make_api_scheme(org, name):
+def _make_api_scheme(org, name, site=None):
 	return APIAccessScheme.objects.create(
 		client_name=name,
 		client_contacts=f"{name}@example.com",
 		organization=org,
+		site=site,
 		ip_addresses="",
 		begin_date=now() - timedelta(days=1),
 		end_date=now() + timedelta(days=30),
@@ -91,6 +99,24 @@ class TeamListingBase(TestCase):
 			self.my_org, "My Listed Team", api_listed=True
 		)
 		self.priv_team = _make_team(self.priv_org, "Priv Team Teams", api_listed=False)
+
+		# Unlisted, but owns a subject. Whether it appears depends entirely on
+		# whether the caller can reach that subject -- this is the fixture
+		# that exercises the second half of the rule, and the reason the
+		# suite is not purely caller-independent.
+		self.scoped_unlisted_team = _make_team(
+			self.my_org, "Scoped Unlisted Team", api_listed=False
+		)
+		self.scoped_subject = Subject.objects.create(
+			subject_name="Scoped Subj",
+			subject_slug="scoped-subj",
+			team=self.scoped_unlisted_team,
+		)
+		# A private site: in scope for my_org's members and for a key bound to
+		# it, invisible to anonymous callers.
+		self.my_site = private_site_publishing(
+			self.scoped_subject, organization=self.my_org
+		)
 
 		self.client = APIClient()
 
@@ -128,13 +154,24 @@ class AnonymousTeamListingTest(TeamListingBase):
 		resp = self.client.get(f"/teams/{self.unlisted_public_team.id}/")
 		self.assertEqual(resp.status_code, 404)
 
+	def test_unlisted_team_owning_an_out_of_scope_subject_stays_hidden(self):
+		# scoped_unlisted_team owns a subject, but only a private site
+		# publishes it, so an anonymous caller cannot reach it and the second
+		# half of the rule does not fire.
+		self.assertNotIn(self.scoped_unlisted_team.id, self._listed_ids())
+		self.assertEqual(
+			self.client.get(f"/teams/{self.scoped_unlisted_team.id}/").status_code,
+			404,
+		)
+
 	def test_detail_listed_returns_200(self):
 		resp = self.client.get(f"/teams/{self.listed_team.id}/")
 		self.assertEqual(resp.status_code, 200)
 
 
 # ---------------------------------------------------------------------------
-# The listing is the same for every caller
+# Identified callers: the flag's teams, plus any team owning a subject they
+# can already read.
 # ---------------------------------------------------------------------------
 
 
@@ -145,26 +182,39 @@ class AuthenticatedUserTeamListingTest(TeamListingBase):
 		OrganizationUser.objects.create(organization=self.my_org, user=self.user)
 		self.client.force_login(self.user)
 
-	def test_member_sees_the_same_listing_as_anonymous(self):
+	def test_flagged_teams_are_listed_and_unrelated_unlisted_ones_are_not(self):
 		ids = self._listed_ids()
 		self.assertIn(self.listed_team.id, ids)
 		self.assertIn(self.my_listed_team.id, ids)
 		self.assertNotIn(self.unlisted_public_team.id, ids)
 		self.assertNotIn(self.priv_team.id, ids)
 
-	def test_membership_does_not_reveal_an_unlisted_team(self):
-		# Worth stating explicitly: the user belongs to my_org, and my_team
-		# is my_org's, but the flag governs and it is off. Under the old
-		# organisation rule this team WAS visible to this caller.
+	def test_membership_alone_does_not_reveal_an_unlisted_team(self):
+		# my_team is my_org's and the user is a member, but it is unlisted AND
+		# owns nothing the user can read, so neither half of the rule fires.
+		# Under the old organisation rule this team WAS visible to this caller;
+		# organisation membership on its own now grants nothing here.
 		ids = self._listed_ids()
 		self.assertNotIn(self.my_team.id, ids)
 		self.assertEqual(
 			self.client.get(f"/teams/{self.my_team.id}/").status_code, 404
 		)
 
+	def test_unlisted_team_is_listed_when_it_owns_a_subject_in_scope(self):
+		# The second half of the rule. The same team 404s for an anonymous
+		# caller (asserted above), so this is genuinely scope-driven and not
+		# the flag leaking.
+		ids = self._listed_ids()
+		self.assertIn(self.scoped_unlisted_team.id, ids)
+		self.assertEqual(
+			self.client.get(f"/teams/{self.scoped_unlisted_team.id}/").status_code,
+			200,
+		)
+
 	def test_include_public_is_a_no_op(self):
-		# The flag is caller-independent, so there is no "own scope" for the
-		# flag to widen. The parameter is accepted and changes nothing.
+		# include_public widens the *subject* scope, and every subject it adds
+		# belongs to an api_public site whose teams are already listed by the
+		# flag. So it is accepted and changes nothing here.
 		plain = self._listed_ids()
 		resp = self.client.get("/teams/?include_public=true")
 		self.assertEqual(resp.status_code, 200)
@@ -178,13 +228,15 @@ class AuthenticatedUserTeamListingTest(TeamListingBase):
 class APIKeyTeamListingTest(TeamListingBase):
 	def setUp(self):
 		super().setUp()
-		self.scheme = _make_api_scheme(self.my_org, "team-key")
+		self.scheme = _make_api_scheme(self.my_org, "team-key", site=self.my_site)
 		self.client.credentials(HTTP_AUTHORIZATION=self.scheme.api_key)
 
-	def test_key_sees_the_same_listing_as_anonymous(self):
+	def test_key_sees_flagged_teams_plus_its_own_sites_scope(self):
 		ids = self._listed_ids()
 		self.assertIn(self.listed_team.id, ids)
 		self.assertIn(self.my_listed_team.id, ids)
+		# The key is bound to my_site, which publishes scoped_subject.
+		self.assertIn(self.scoped_unlisted_team.id, ids)
 		self.assertNotIn(self.unlisted_public_team.id, ids)
 		self.assertNotIn(self.my_team.id, ids)
 		self.assertNotIn(self.priv_team.id, ids)

--- a/django/api/tests/test_visibility_trials.py
+++ b/django/api/tests/test_visibility_trials.py
@@ -16,6 +16,7 @@ from organizations.models import Organization, OrganizationUser
 from rest_framework.test import APIClient
 
 from api.models import APIAccessScheme
+from api.tests.visibility_helpers import private_site_publishing, publish_subjects
 from gregory.models import OrganizationApiSettings, Subject, Team, Trials
 
 User = get_user_model()
@@ -56,11 +57,12 @@ def _make_trial(title, link, teams=(), subjects=()):
 	return trial
 
 
-def _make_api_scheme(org, name):
+def _make_api_scheme(org, name, site=None):
 	return APIAccessScheme.objects.create(
 		client_name=name,
 		client_contacts=f"{name}@example.com",
 		organization=org,
+		site=site,
 		ip_addresses="",
 		begin_date=now() - timedelta(days=1),
 		end_date=now() + timedelta(days=30),
@@ -84,21 +86,40 @@ class TrialVisibilityBase(TestCase):
 
 		self.my_subj = _make_subject(self.my_team, "My Subject T")
 		self.pub_subj = _make_subject(self.pub_team, "Pub Subject T")
+		self.priv_subj = _make_subject(self.priv_team, "Priv Subject T")
+
+		# One site per organisation publishing that organisation's subject.
+		# Only pub_site is api_public — see test_visibility_articles.py for
+		# the reasoning, which is identical here.
+		self.my_site = private_site_publishing(
+			self.my_subj, organization=self.my_org
+		)
+		self.pub_site = publish_subjects(self.pub_subj, organization=self.pub_org)
+		self.priv_site = private_site_publishing(
+			self.priv_subj, organization=self.priv_org
+		)
 
 		self.trial_mine = _make_trial(
-			"Mine Only", "https://trial.com/1", teams=[self.my_team]
+			"Mine Only", "https://trial.com/1",
+			teams=[self.my_team], subjects=[self.my_subj],
 		)
 		self.trial_pub = _make_trial(
-			"Public Only", "https://trial.com/2", teams=[self.pub_team]
+			"Public Only", "https://trial.com/2",
+			teams=[self.pub_team], subjects=[self.pub_subj],
 		)
 		self.trial_priv = _make_trial(
-			"Private Only", "https://trial.com/3", teams=[self.priv_team]
+			"Private Only", "https://trial.com/3",
+			teams=[self.priv_team], subjects=[self.priv_subj],
 		)
 		self.trial_mine_pub = _make_trial(
-			"Mine+Pub", "https://trial.com/4", teams=[self.my_team, self.pub_team]
+			"Mine+Pub", "https://trial.com/4",
+			teams=[self.my_team, self.pub_team],
+			subjects=[self.my_subj, self.pub_subj],
 		)
 		self.trial_mine_priv = _make_trial(
-			"Mine+Priv", "https://trial.com/5", teams=[self.my_team, self.priv_team]
+			"Mine+Priv", "https://trial.com/5",
+			teams=[self.my_team, self.priv_team],
+			subjects=[self.my_subj, self.priv_subj],
 		)
 
 		self.client = APIClient()
@@ -240,7 +261,7 @@ class AuthenticatedUserTrialVisibilityTest(TrialVisibilityBase):
 class APIKeyTrialVisibilityTest(TrialVisibilityBase):
 	def setUp(self):
 		super().setUp()
-		self.scheme = _make_api_scheme(self.my_org, "my-key-t")
+		self.scheme = _make_api_scheme(self.my_org, "my-key-t", site=self.my_site)
 		self.client.credentials(HTTP_AUTHORIZATION=self.scheme.api_key)
 
 	def test_list_shows_my_org_trial(self):
@@ -318,7 +339,7 @@ class CSVExportTrialVisibilityTest(TrialVisibilityBase):
 		self.assertNotIn("Private Only", titles)
 
 	def test_api_key_csv_shows_own_org_trials(self):
-		scheme = _make_api_scheme(self.my_org, "csv-key-t")
+		scheme = _make_api_scheme(self.my_org, "csv-key-t", site=self.my_site)
 		self.client.credentials(HTTP_AUTHORIZATION=scheme.api_key)
 		resp = self.client.get("/trials/?format=csv&all_results=true")
 		self.assertIn(resp.status_code, (200, 206))
@@ -327,7 +348,7 @@ class CSVExportTrialVisibilityTest(TrialVisibilityBase):
 		self.assertNotIn("Private Only", titles)
 
 	def test_api_key_csv_with_include_public_adds_public_trials(self):
-		scheme = _make_api_scheme(self.my_org, "csv-key-pub-t")
+		scheme = _make_api_scheme(self.my_org, "csv-key-pub-t", site=self.my_site)
 		self.client.credentials(HTTP_AUTHORIZATION=scheme.api_key)
 		resp = self.client.get(
 			"/trials/?format=csv&all_results=true&include_public=true"

--- a/django/api/tests/test_visibility_trials.py
+++ b/django/api/tests/test_visibility_trials.py
@@ -122,6 +122,17 @@ class TrialVisibilityBase(TestCase):
 			subjects=[self.my_subj, self.priv_subj],
 		)
 
+		# A second subject owned by pub_team but never curated onto ANY
+		# site's scope_subjects -- see test_visibility_articles.py's
+		# identical fixture for why (PR #863 review finding 1).
+		self.pub_subj_unpublished = _make_subject(
+			self.pub_team, "Pub Unpublished Subject T"
+		)
+		self.trial_pub_unpublished_subj = _make_trial(
+			"Public Team, Unpublished Subject", "https://trial.com/6",
+			teams=[self.pub_team], subjects=[self.pub_subj_unpublished],
+		)
+
 		self.client = APIClient()
 
 
@@ -177,6 +188,22 @@ class AnonymousTrialVisibilityTest(TrialVisibilityBase):
 			},
 		)
 		self.assertEqual(resp.status_code, 200)
+
+	def test_search_with_reachable_team_but_unpublished_subject_returns_404(self):
+		"""PR #863 review finding 1 -- see the identical test in
+		test_visibility_articles.py for the full explanation."""
+		for method in ("get", "post"):
+			with self.subTest(method=method):
+				params = {
+					"team_id": self.pub_team.id,
+					"subject_id": self.pub_subj_unpublished.id,
+				}
+				resp = (
+					self.client.get("/trials/search/", params)
+					if method == "get"
+					else self.client.post("/trials/search/", params, format="json")
+				)
+				self.assertEqual(resp.status_code, 404)
 
 	def test_include_public_is_noop_for_anonymous(self):
 		"""include_public=true is a no-op for anonymous callers (already see public only)."""

--- a/django/api/tests/visibility_helpers.py
+++ b/django/api/tests/visibility_helpers.py
@@ -1,0 +1,105 @@
+"""
+Test helpers for site-scoped API visibility.
+
+Under subject scoping a caller sees a row only when one of its subjects sits
+in the ``scope_subjects`` of a site that caller can reach. That makes two
+things load-bearing in a fixture which used not to be:
+
+  1. content must carry a subject at all, and
+  2. some site must publish that subject.
+
+Before Phase 4, ``OrganizationApiSettings.make_api_public = True`` was the
+whole story, so most fixtures in this suite set that and stopped. These
+helpers are the equivalent statement in the new model, kept in one place so
+that a change to the visibility rule is one edit rather than sixty.
+
+Typical use, at the end of a ``setUpTestData``::
+
+    cls.org = Organization.objects.create(name="Org", slug="org")
+    cls.team = Team.objects.create(organization=cls.org, name="T", slug="t")
+    cls.subject = Subject.objects.create(
+        subject_name="S", subject_slug="s", team=cls.team
+    )
+    article.subjects.add(cls.subject)
+    publish_subjects(cls.subject, organization=cls.org)
+
+``publish_subjects`` is for content that should be publicly readable. Use
+``private_site_publishing`` when a test needs a scope that an anonymous
+caller must NOT see -- that is the shape a second tenant has, and asserting
+against it is how these tests show isolation rather than assuming it.
+"""
+
+from django.contrib.sites.models import Site
+
+from gregory.models import OrganizationSite
+from sitesettings.models import CustomSetting
+
+# Domains are generated rather than fixed so that two helper calls in one
+# test (a public site and a private one, say) cannot collide on Site.domain.
+_counter = 0
+
+
+def _next_domain(prefix):
+	global _counter
+	_counter += 1
+	return f"{prefix}-{_counter}.test.example.com"
+
+
+def _make_site(*subjects, api_public, organization=None, domain=None, name=None):
+	site = Site.objects.create(
+		domain=domain or _next_domain("public" if api_public else "private"),
+		name=name or ("Public test site" if api_public else "Private test site"),
+	)
+	settings_row = CustomSetting.objects.create(
+		site=site,
+		title=name or f"{site.domain} settings",
+		api_public=api_public,
+	)
+	for subject in subjects:
+		settings_row.scope_subjects.add(subject)
+	if organization is not None:
+		# What visible_subject_ids walks for a signed-in member, and what it
+		# checks a site-bound API key against. Without it an authenticated
+		# caller sees nothing even though their organisation owns the team.
+		OrganizationSite.objects.get_or_create(
+			organization=organization,
+			site=site,
+			defaults={"is_default": True},
+		)
+	return site
+
+
+def publish_subjects(*subjects, organization=None, domain=None, name=None):
+	"""Make ``subjects`` readable by an anonymous caller.
+
+	Creates a Site with ``api_public=True`` whose scope is exactly those
+	subjects. Pass ``organization`` to also link the site to an organisation,
+	which is what an authenticated member or a site-bound API key resolves
+	through.
+
+	Returns the Site, so a test that needs the id (``?site_id=``, an API key
+	binding) can use it.
+	"""
+	return _make_site(
+		*subjects,
+		api_public=True,
+		organization=organization,
+		domain=domain,
+		name=name,
+	)
+
+
+def private_site_publishing(*subjects, organization=None, domain=None, name=None):
+	"""The counterpart: a site whose scope an anonymous caller cannot see.
+
+	``api_public=False``, so these subjects are reachable only through a key
+	bound to this site or a user in ``organization``. Use it for the "other
+	tenant" half of an isolation assertion.
+	"""
+	return _make_site(
+		*subjects,
+		api_public=False,
+		organization=organization,
+		domain=domain,
+		name=name,
+	)

--- a/django/api/tests/visibility_helpers.py
+++ b/django/api/tests/visibility_helpers.py
@@ -61,10 +61,20 @@ def _make_site(*subjects, api_public, organization=None, domain=None, name=None)
 		# What visible_subject_ids walks for a signed-in member, and what it
 		# checks a site-bound API key against. Without it an authenticated
 		# caller sees nothing even though their organisation owns the team.
+		#
+		# is_default only on the FIRST site an organisation gets: there is a
+		# UniqueConstraint(organization, condition=is_default=True), and a
+		# fixture that gives one organisation two sites -- a base fixture plus
+		# a subclass adding its own, which is the normal shape here -- would
+		# otherwise fail on the second with an IntegrityError that says
+		# nothing about the real cause.
+		already_has_default = OrganizationSite.objects.filter(
+			organization=organization, is_default=True
+		).exists()
 		OrganizationSite.objects.get_or_create(
 			organization=organization,
 			site=site,
-			defaults={"is_default": True},
+			defaults={"is_default": not already_has_default},
 		)
 	return site
 

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -1766,22 +1766,27 @@ class ArticleViewSet(
 ###
 
 
-def _visible_or_subjectless_q(content_prefix, visible_subject_ids):
-	"""Q object: the content reached via *content_prefix* has no subject at
-	all, OR has at least one subject in ``visible_subject_ids``.
+def _visible_content_q(content_prefix, visible_subject_ids):
+	"""Q object: the content reached via *content_prefix* carries at least
+	one subject in ``visible_subject_ids``.
 
 	*content_prefix* is the ORM path to Articles/Trials -- ``""`` when the
 	queryset being filtered IS Articles/Trials, or e.g. ``"articles__"``
 	when filtering a related model that reaches them through that relation.
 
-	This is the category-aggregate counterpart of StatsView's default
-	content filter (PR #863 review findings 4 and 6): a category assignment
-	whose article/trial carries ONLY an out-of-scope subject must not
-	inflate a category's counts or disclose its authors, but content with no
-	subject at all is not newly excluded by subject-scoping -- see
-	api/tests/test_visibility_stats.py's null-subject-Source fixtures
-	(test_source_with_null_subject_dropped_when_filtering's "unfiltered"
-	case) for why that distinction is load-bearing rather than incidental.
+	The category-aggregate counterpart of the list rule (PR #863 review
+	finding 4): a category shared between a visible and a hidden subject
+	must not have its counts inflated, or its authors disclosed, by rows the
+	caller cannot otherwise see.
+
+	Content with NO subject is excluded, exactly as
+	SubjectVisibilityMixin.get_queryset excludes it -- an Exists() over the
+	subjects through table fails for a row with no through rows, which
+	api/tests/test_visibility_org_filter_edge_cases.py pins as
+	test_subject_less_article_stays_invisible. Counting it here would make a
+	category report rows that its own list endpoint will not return, which
+	is a worse failure than under-counting: the numbers stop describing the
+	data the caller can actually reach.
 
 	Returns ``None`` when ``visible_subject_ids`` is ``None`` (no middleware
 	/ no scoping active), so callers can skip filtering entirely -- same
@@ -1789,9 +1794,7 @@ def _visible_or_subjectless_q(content_prefix, visible_subject_ids):
 	"""
 	if visible_subject_ids is None:
 		return None
-	return Q(**{f"{content_prefix}subjects__isnull": True}) | Q(
-		**{f"{content_prefix}subjects__id__in": visible_subject_ids}
-	)
+	return Q(**{f"{content_prefix}subjects__id__in": visible_subject_ids})
 
 
 def _category_through_count_subquery(through_model, content_fk, visible_subject_ids=None):
@@ -1819,7 +1822,7 @@ def _category_through_count_subquery(through_model, content_fk, visible_subject_
 	counts inflated by rows the caller cannot otherwise see).
 	"""
 	qs = through_model.objects.filter(teamcategory=OuterRef("pk"))
-	visible_q = _visible_or_subjectless_q(f"{content_fk}__", visible_subject_ids)
+	visible_q = _visible_content_q(f"{content_fk}__", visible_subject_ids)
 	if visible_q is not None:
 		qs = qs.filter(visible_q)
 	return Coalesce(
@@ -1850,7 +1853,7 @@ def _category_authors_count_subquery(visible_subject_ids=None):
 	through an article carrying solely a hidden subject must not be counted.
 	"""
 	qs = ArticleCategoryAssignment.objects.filter(teamcategory=OuterRef("pk"))
-	visible_q = _visible_or_subjectless_q("articles__", visible_subject_ids)
+	visible_q = _visible_content_q("articles__", visible_subject_ids)
 	if visible_q is not None:
 		qs = qs.filter(visible_q)
 	return Coalesce(
@@ -2066,9 +2069,15 @@ class CategoryViewSet(viewsets.ReadOnlyModelViewSet):
 		# intersects the caller's scope. Not the owning team's organisation:
 		# a category is a view onto subjects, so the subjects it names are
 		# what decides. distinct() because the M2M can match several times.
-		if hasattr(self.request, "visible_subject_ids"):
+		#
+		# The same set scopes the aggregates below. Filtering which category
+		# ROWS are visible without scoping their counts would leave a visible
+		# category reporting how much hidden content it holds (PR #863 review
+		# finding 4), including through ?ordering=-authors_count_annotated.
+		visible_subject_ids = getattr(self.request, "visible_subject_ids", None)
+		if visible_subject_ids is not None:
 			queryset = queryset.filter(
-				subjects__id__in=self.request.visible_subject_ids
+				subjects__id__in=visible_subject_ids
 			).distinct()
 
 		# Apply filters without expensive annotations
@@ -2108,8 +2117,12 @@ class CategoryViewSet(viewsets.ReadOnlyModelViewSet):
 		# per category, which spilled Postgres's hash aggregate to disk in
 		# production (see _category_through_count_subquery docstring).
 		queryset = queryset.select_related("team").prefetch_related("subjects").annotate(
-			article_count_annotated=_category_through_count_subquery(ArticleCategoryAssignment),
-			trials_count_annotated=_category_through_count_subquery(TrialCategoryAssignment),
+			article_count_annotated=_category_through_count_subquery(
+				ArticleCategoryAssignment, "articles", visible_subject_ids
+			),
+			trials_count_annotated=_category_through_count_subquery(
+				TrialCategoryAssignment, "trials", visible_subject_ids
+			),
 		)
 
 		# `authors_count_annotated` is an allowed ordering value but is NOT
@@ -2137,7 +2150,9 @@ class CategoryViewSet(viewsets.ReadOnlyModelViewSet):
 		# client happened to sort by it.
 		if self._orders_by_authors_count():
 			queryset = queryset.annotate(
-				authors_count_annotated=_category_authors_count_subquery()
+				authors_count_annotated=_category_authors_count_subquery(
+					visible_subject_ids
+				)
 			)
 
 		# No .distinct() needed: the count annotations are now correlated
@@ -3893,11 +3908,18 @@ class CategoriesByTeamAndSubject(viewsets.ModelViewSet):
 	def get_queryset(self):
 		team_id = self.kwargs.get("team_id")
 		subject_id = self.kwargs.get("subject_id")
+		visible_subject_ids = getattr(self.request, "visible_subject_ids", None)
 		if hasattr(self.request, "visible_org_ids"):
 			if not Team.objects.filter(
 				id=team_id, organization_id__in=self.request.visible_org_ids
 			).exists():
 				raise Http404
+		# The team_id check above is the org-keyed validation the spec keeps
+		# for team-addressed routes; it says nothing about the subject. Scope
+		# the requested subject too, or naming an out-of-scope subject_id
+		# returns that subject's categories and counts.
+		if visible_subject_ids is not None and int(subject_id) not in visible_subject_ids:
+			raise Http404
 		# See CategoryViewSet.get_queryset / _category_through_count_subquery:
 		# do NOT annotate both relations with Count(..., distinct=True) in
 		# one query — that fans out to an articles x trials cross product
@@ -3906,8 +3928,12 @@ class CategoriesByTeamAndSubject(viewsets.ModelViewSet):
 		return (
 			TeamCategory.objects.filter(team__id=team_id, subjects__id=subject_id)
 			.annotate(
-				article_count_annotated=_category_through_count_subquery(ArticleCategoryAssignment),
-				trials_count_annotated=_category_through_count_subquery(TrialCategoryAssignment),
+				article_count_annotated=_category_through_count_subquery(
+					ArticleCategoryAssignment, "articles", visible_subject_ids
+				),
+				trials_count_annotated=_category_through_count_subquery(
+					TrialCategoryAssignment, "trials", visible_subject_ids
+				),
 			)
 			.order_by("-id")
 		)

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -1399,6 +1399,23 @@ _OPTIONAL_API_KEY_SECURITY = [
 ]
 
 
+_INCLUDE_PUBLIC_PARAM = OpenApiParameter(
+	"include_public",
+	OpenApiTypes.BOOL,
+	OpenApiParameter.QUERY,
+	description=(
+		"Identified callers only (API key or signed-in user): add the scopes "
+		"of every publicly readable site to your own, so a private site's "
+		"frontend can read public content alongside its own. No-op for an "
+		"anonymous caller, whose scope already is exactly that set.\n\n"
+		"Undeclared but functional before Phase 4 of site-scoped API "
+		"visibility, when it read 'adds public organisations' — organisations "
+		"are no longer the visibility unit, so it is declared here with its "
+		"current meaning rather than left to be discovered."
+	),
+)
+
+
 def _ordering_param(fields, description):
 	"""Build an explicit ``ordering`` OpenApiParameter with a real enum.
 
@@ -1449,7 +1466,10 @@ _ARTICLES_ORDERING_PARAM = _ordering_param(
 
 
 @extend_schema_view(
-	list=extend_schema(auth=_OPTIONAL_API_KEY_SECURITY, parameters=[_ARTICLES_ORDERING_PARAM]),
+	list=extend_schema(
+		auth=_OPTIONAL_API_KEY_SECURITY,
+		parameters=[_ARTICLES_ORDERING_PARAM, _INCLUDE_PUBLIC_PARAM],
+	),
 	retrieve=extend_schema(auth=_OPTIONAL_API_KEY_SECURITY),
 )
 class ArticleViewSet(
@@ -2244,7 +2264,10 @@ _TRIALS_ORDERING_PARAM = _ordering_param(
 
 
 @extend_schema_view(
-	list=extend_schema(auth=_OPTIONAL_API_KEY_SECURITY, parameters=[_TRIALS_ORDERING_PARAM]),
+	list=extend_schema(
+		auth=_OPTIONAL_API_KEY_SECURITY,
+		parameters=[_TRIALS_ORDERING_PARAM, _INCLUDE_PUBLIC_PARAM],
+	),
 	retrieve=extend_schema(auth=_OPTIONAL_API_KEY_SECURITY),
 )
 class TrialViewSet(
@@ -2883,9 +2906,25 @@ _SPONSORS_ORDERING_PARAM = _ordering_param(
 class SponsorViewSet(viewsets.ReadOnlyModelViewSet):
 	"""
 	List canonical sponsor entities (deduplicated trial sponsors — see
-	docs/trials-field-normalization.md). Sponsors are global, not org-owned, so
-	unlike most other viewsets this one carries no OrgVisibilityMixin — same
-	reasoning as the by_sponsor/by_sponsor_type facets on /trials/stats/.
+	docs/trials-field-normalization.md).
+
+	A Sponsor carries no subject of its own; it reaches content only through
+	the trials that name it. So it is scoped to "has at least one trial in the
+	caller's scope" rather than by a field on the row — an Exists() over
+	Trials.primary_sponsor_normalized. Without that, a sponsor's existence
+	(and its name) would disclose that some trial the caller cannot read
+	exists, which is the thing subject scoping is for.
+
+	It carried no scoping at all before Phase 4 of site-scoped API visibility,
+	on the grounds that sponsors are global. That was defensible while
+	visibility was organisation-keyed and every caller effectively saw the same
+	trials; it stops being defensible with two tenants.
+
+	Measured after the 2026-09-10 orphan-sponsor prune: scoping hides 59 of
+	4,686 (1.3%), all Dihydroartemisinin (subject 15, internal research in no
+	site's scope) — the intended exclusion. Before that prune it looked like
+	43%, but 3,406 of those sponsors referenced no trial at all and were
+	debris left behind by the PROTECT FK when their trials were deleted.
 
 	# Query Parameters:
 	- **search** - search by sponsor name
@@ -2919,8 +2958,29 @@ class SponsorViewSet(viewsets.ReadOnlyModelViewSet):
 	ordering = ["name"]
 
 	def get_queryset(self):
-		return super().get_queryset().annotate(
-			trials_count=Count("trials", distinct=True)
+		qs = super().get_queryset()
+		visible = getattr(self.request, "visible_subject_ids", None)
+		if visible is None:
+			# No middleware (management command, some tests) -- no scoping,
+			# matching every other viewset's fallback.
+			return qs.annotate(trials_count=Count("trials", distinct=True))
+
+		# Exists() over Trials rather than a join + distinct on the outer
+		# query: a sponsor with many in-scope trials must appear once, and
+		# the paginator's COUNT(*) must not have to DISTINCT every column.
+		has_a_trial_in_scope = Trials.objects.filter(
+			primary_sponsor_normalized=OuterRef("pk"), subjects__in=visible
+		)
+		# trials_count is scoped too, and that is not cosmetic: an unscoped
+		# count on a visible sponsor would disclose how many trials the caller
+		# cannot read, and it is an orderable field (?ordering=-trials_count),
+		# so the ranking itself would leak the same information.
+		return qs.filter(Exists(has_a_trial_in_scope)).annotate(
+			trials_count=Count(
+				"trials",
+				filter=Q(trials__subjects__in=visible),
+				distinct=True,
+			)
 		)
 
 
@@ -3574,23 +3634,54 @@ class TeamsViewSet(viewsets.ReadOnlyModelViewSet):
 	"""
 	List teams that have opted into being listed.
 
-	Gated by the explicit ``Team.api_listed`` flag, not by subject scope. A
-	team is not content and owns no subject of its own, so deriving its
-	visibility from the subjects it owns cannot express either of the two
-	things an operator eventually wants: an internal lab that contributes to
-	public content but should not be named, or a partner an organisation
-	wants to credit that owns nothing in scope. The flag was seeded from the
-	derived answer by ``sitesettings/0019`` and can be overridden either way.
+	A team is listed when EITHER holds:
 
-	It gates listing, not access. ``api_listed = False`` removes a team from
-	this endpoint; it does not hide that team's content, which is governed by
+	  1. ``Team.api_listed`` is on -- the explicit publication switch, seeded
+	     from the derived answer by ``sitesettings/0019``; or
+	  2. the team owns a subject already in the caller's scope.
+
+	Rule 1 alone was the first cut, and it is what the spec says literally. It
+	has a cost that only shows up with a second tenant: a private site's own
+	authenticated frontend could not list its own teams, because the teams of
+	a private site are exactly the ones an operator marks unlisted. Rule 2
+	buys that back without reopening anything -- a caller who can already read
+	a team's articles and trials learns nothing new from its name.
+
+	A flag is still the right primary answer, for the reason the spec gives:
+	deriving listing purely from owned subjects cannot express an internal lab
+	that contributes to public content but should not be named, nor a partner
+	an organisation wants to credit that owns nothing in scope. Rule 2 only
+	ever adds, so both of those stay expressible.
+
+	It gates listing, not access. Being unlisted removes a team from this
+	endpoint; it does not hide that team's content, which is governed by
 	subject scope like everything else. Conflating the two is how a metadata
 	switch quietly becomes a data-visibility switch.
 	"""
 
+	# get_queryset() below is what actually runs; this attribute exists because
+	# the DRF router derives the URL basename from it, and it is set to the
+	# narrower of the two rules so that any path which somehow skipped
+	# get_queryset() would under-disclose rather than over-disclose.
 	queryset = Team.objects.filter(api_listed=True).order_by("id")
 	serializer_class = TeamSerializer
 	permission_classes = [permissions.IsAuthenticatedOrReadOnly]
+
+	def get_queryset(self):
+		# Team.objects is ActiveTeamManager (is_active=True); soft-deleted
+		# teams stay out either way.
+		qs = Team.objects.all().order_by("id")
+		if not hasattr(self.request, "visible_subject_ids"):
+			# No middleware (management command, some tests). The flag is an
+			# intrinsic property of the team rather than a per-caller scope,
+			# so it still applies -- there is simply no rule 2 to add.
+			return qs.filter(api_listed=True)
+		owns_a_visible_subject = Subject.objects.filter(
+			team_id=OuterRef("pk"), id__in=self.request.visible_subject_ids
+		)
+		# Exists() rather than a join on subjects, so the OR cannot duplicate
+		# a team that owns several in-scope subjects and no DISTINCT is needed.
+		return qs.filter(Q(api_listed=True) | Q(Exists(owns_a_visible_subject)))
 
 
 ###
@@ -4388,10 +4479,22 @@ class StatsView(APIView):
 	-------
 	?team=1,2,3
 	    Scope to one or more teams (comma-separated integer IDs).
-	?organization=1,2  (alias: ?org=)
+	?site=1,2
+	    Scope to the subjects one or more sites publish (their
+	    CustomSetting.scope_subjects). This is the filter to reach for now
+	    that visibility is site-scoped; it is sugar for ?subject= with that
+	    site's scope, and intersects with an explicit ?subject= rather than
+	    overriding it. A site the caller cannot reach 404s, like any other
+	    unreachable scope.
+	?organization=1,2  (alias: ?org=)  [DEPRECATED]
 	    Scope to one or more organisations (comma-separated integer IDs).
 	    When combined with ?team=, the effective scope is the intersection:
 	    teams that belong to the requested org(s).
+
+	    Deprecated because organisations are no longer the visibility unit --
+	    a site is. It still works, and still means exactly what it always
+	    meant, which is the point: silently redefining a documented parameter
+	    is the failure this project exists to prevent. Prefer ?site=.
 	?subject=1,2
 	    Scope to one or more subjects (comma-separated integer IDs, OR/union
 	    semantics). Adds a ``by_subject`` breakdown to the payload, listing
@@ -4424,17 +4527,36 @@ class StatsView(APIView):
 				OpenApiParameter.QUERY,
 				description="Scope to one or more teams (comma-separated integer IDs), e.g. ?team=1,2,3.",
 			),
+			_INCLUDE_PUBLIC_PARAM,
+			OpenApiParameter(
+				"site",
+				OpenApiTypes.STR,
+				OpenApiParameter.QUERY,
+				description=(
+					"Scope to the subjects one or more sites publish "
+					"(comma-separated integer site IDs). Sugar for ?subject= "
+					"with that site's scope; intersects with an explicit "
+					"?subject= rather than overriding it."
+				),
+			),
 			OpenApiParameter(
 				"organization",
 				OpenApiTypes.STR,
 				OpenApiParameter.QUERY,
-				description="Scope to one or more organisations (comma-separated integer IDs). Alias: org.",
+				deprecated=True,
+				description=(
+					"DEPRECATED — prefer ?site=. Scope to one or more "
+					"organisations (comma-separated integer IDs). Alias: org. "
+					"Organisations are no longer the visibility unit; this "
+					"still works and still means what it always meant."
+				),
 			),
 			OpenApiParameter(
 				"org",
 				OpenApiTypes.STR,
 				OpenApiParameter.QUERY,
-				description="Alias for organization.",
+				deprecated=True,
+				description="DEPRECATED — alias for organization. Prefer ?site=.",
 			),
 			OpenApiParameter(
 				"subject",
@@ -4452,7 +4574,11 @@ class StatsView(APIView):
 		from urllib.parse import urlparse
 		from subscriptions.models import Subscribers
 
+		# Both scopes are live here: ?team=/?organization= are org-keyed
+		# parameters validated against visible_org_ids, while the subject
+		# roster and every content count are subject-scoped (Phase 4).
 		visible_org_ids = getattr(request, "visible_org_ids", None)
+		visible_subject_ids = getattr(request, "visible_subject_ids", None)
 
 		# --- Parse ?team= -----------------------------------------------
 		team_param = request.query_params.get("team", None)
@@ -4499,6 +4625,44 @@ class StatsView(APIView):
 					},
 					status=status.HTTP_400_BAD_REQUEST,
 				)
+
+		# --- Parse ?site= -------------------------------------------------
+		# Sugar for "?subject= everything this site publishes". Resolved here
+		# rather than carried separately so it goes through exactly the same
+		# visibility validation, 404 behaviour and cache key as ?subject=.
+		# Combined with an explicit ?subject=, the two intersect -- a filter
+		# can only ever narrow.
+		site_param = request.query_params.get("site")
+		if site_param:
+			try:
+				site_ids = [int(x.strip()) for x in site_param.split(",") if x.strip()]
+			except ValueError:
+				return Response(
+					{
+						"error": "Invalid site parameter. Expected integer or comma-separated integers."
+					},
+					status=status.HTTP_400_BAD_REQUEST,
+				)
+			from sitesettings.models import CustomSetting
+
+			site_subject_ids = set(
+				CustomSetting.objects.filter(site_id__in=site_ids)
+				.exclude(scope_subjects__isnull=True)
+				.values_list("scope_subjects__id", flat=True)
+			)
+			# A site the caller cannot reach resolves to nothing, and an empty
+			# scope must not read as "no filter" -- that would silently widen
+			# the answer to everything. Force the 404 path instead, matching
+			# how an unreachable ?subject= behaves.
+			if not site_subject_ids:
+				raise Http404
+			subject_ids = (
+				sorted(site_subject_ids)
+				if subject_ids is None
+				else sorted(set(subject_ids) & site_subject_ids)
+			)
+			if not subject_ids:
+				raise Http404
 
 		# --- Visibility validation (no extra DB queries for org check) --
 		if org_ids and visible_org_ids is not None:
@@ -4572,8 +4736,9 @@ class StatsView(APIView):
 		# distinguishes a 404 from an all-zero payload (decision 7 in
 		# docs/spec-stats-subject-filter.md).
 		subj_qs = Subject.objects.all()
-		if visible_org_ids is not None:
-			subj_qs = subj_qs.filter(team__organization_id__in=visible_org_ids)
+		if visible_subject_ids is not None:
+			# Subject scope, not the owning team's organisation (Phase 4).
+			subj_qs = subj_qs.filter(id__in=visible_subject_ids)
 		if subject_ids is not None:
 			subj_qs = subj_qs.filter(id__in=subject_ids)
 		elif team_id_list is not None:

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -343,82 +343,73 @@ def _latest_ml_predictions_queryset():
 	).select_related("subject")
 
 
-class OrgVisibilityMixin:
+class SubjectVisibilityMixin:
 	"""
-	Viewset mixin that scopes the queryset to organisations the caller can see.
+	Viewset mixin that scopes the queryset to subjects the caller can see.
 
-	Uses ``request.visible_org_ids`` (set by ``VisibleOrgMiddleware``).  Falls
-	back to the full queryset when the attribute is absent so tests and
+	Uses ``request.visible_subject_ids`` (set by ``VisibleOrgMiddleware``).
+	Falls back to the full queryset when the attribute is absent so tests and
 	management commands that bypass middleware are not broken.
 
-	Override ``_org_filter_path`` in the subclass to set the ORM lookup path
-	from the model to the Organisation PK.  Defaults to
-	``teams__organization_id`` (Articles and Trials via M2M teams relation).
+	Replaces ``OrgVisibilityMixin`` (site-scoped API visibility, Phase 4).
+	The old mixin parameterised the ORM path from the model to an
+	Organisation PK; this one parameterises the path to a Subject PK. The
+	shapes it has to serve are:
 
-	Examples:
-	  - Team:          _org_filter_path = 'organization_id'
-	  - Subject/Source/Category:  _org_filter_path = 'team__organization_id'
+	  - Articles, Trials:  ``subjects``          (M2M on the model itself)
+	  - Subject:           ``id``                (the subject *is* the row)
+	  - Sources:           ``subject_id``        (FK)
+	  - TeamCategory:      ``subjects``          (M2M)
+
+	Note what is NOT here: ``/teams/`` and ``/organizations/`` are not
+	content and carry no subject, so they do not use this mixin. Teams are
+	gated by the explicit ``Team.api_listed`` flag and organisations still
+	read ``visible_org_ids`` -- see their viewsets. Conflating "which rows of
+	data may I read" with "whose name may I see listed" is the mistake this
+	separation avoids.
 	"""
 
-	_org_filter_path = "teams__organization_id"
-	# Set to False for viewsets that reach orgs via a simple FK (not M2M),
-	# where a plain filter() can't duplicate rows and Exists() would be
-	# unnecessary overhead. True means the path crosses a multi-valued (M2M)
-	# relation, so we use a correlated Exists() subquery instead of a
-	# join + distinct() to avoid duplicating rows without paying the cost of
-	# DISTINCT-ing every column in the paginator's COUNT(*) query.
-	_org_filter_distinct = True
+	#: ORM path from the model to a Subject PK.
+	_subject_filter_path = "subjects"
+	# Set to False where the path reaches subjects through a single-valued
+	# field (an FK, or the PK itself), so a plain filter() cannot duplicate
+	# rows and the Exists() subquery would be pure overhead. True means the
+	# path crosses a multi-valued (M2M) relation, where a join + distinct()
+	# would otherwise make the paginator's COUNT(*) DISTINCT every column.
+	_subject_filter_distinct = True
 
 	def get_queryset(self):
 		qs = super().get_queryset()
-		if not hasattr(self.request, "visible_org_ids"):
+		if not hasattr(self.request, "visible_subject_ids"):
 			return qs
-		if self._org_filter_distinct:
-			return qs.filter(Exists(self._org_visible_through_subquery(qs.model)))
-		return qs.filter(**{f"{self._org_filter_path}__in": self.request.visible_org_ids})
+		subject_ids = self.request.visible_subject_ids
+		if self._subject_filter_distinct:
+			# Correlated Exists() over the subjects M2M through table.
+			#
+			# Kept from the OrgVisibilityMixin rewrite this replaces
+			# (HOUSE-LOAD-SPIKE-P2-QUERY-COST.md item 2): filtering the outer
+			# model back through its own M2M joins the table to itself just
+			# to test the row it started from, and DISTINCT-ing that in the
+			# paginator's COUNT(*) was measured at 946ms/request. Traversing
+			# the through table directly is 15ms.
+			#
+			# Simpler than the org version was, and one query cheaper: that
+			# one had to resolve organisation ids to team ids in Python
+			# first, because the through table holds team ids and the filter
+			# was on Team.organization_id. Subject ids ARE what the through
+			# table holds, so there is nothing to resolve.
+			return qs.filter(Exists(self._subject_visible_subquery(qs.model, subject_ids)))
+		return qs.filter(**{f"{self._subject_filter_path}__in": subject_ids})
 
-	def _org_visible_through_subquery(self, model):
-		"""Correlated Exists() over the ``teams`` M2M through table.
-
-		HOUSE-LOAD-SPIKE-P2-QUERY-COST.md item 2: the previous subquery
-		(``qs.model.objects.filter(pk=OuterRef("pk"), teams__organization_id__in=...)``)
-		joined the outer model back to itself through ``teams`` just to filter
-		on the same row it started from — provably (and measurably) redundant.
-		This traverses the through table directly instead, and resolves
-		organisation ids to team ids in Python first: Postgres estimates the
-		through-table-only rewrite as cheap enough to still go parallel, but
-		only the resolved-team-ids form drops below the parallel-worker
-		threshold, which is what actually mattered for the load-spike
-		incident (3 backends per request vs. 1).
-
-		Uses ``Team.all_objects`` (not ``Team.objects``, which is
-		``ActiveTeamManager`` and filters ``is_active=True``) so soft-deleted
-		teams' content stays visible exactly as it was before this rewrite —
-		the raw SQL this replaces joined ``gregory_team`` with no active
-		filter. Changing that is a separate, deliberate decision, not a side
-		effect of a performance refactor.
-
-		Only reached via ``_org_filter_distinct = True``, whose only two
-		current users (ArticleViewSet, TrialViewSet) both use the default
-		``_org_filter_path = "teams__organization_id"`` — a 2-segment
-		``<m2m relation>__<field on Team>`` path — so that's the only shape
-		handled here.
-		"""
-		relation_name, _, team_field_lookup = self._org_filter_path.partition("__")
-		through = getattr(model, relation_name).through
+	def _subject_visible_subquery(self, model, subject_ids):
+		through = getattr(model, self._subject_filter_path).through
 		fk_fields = [f for f in through._meta.get_fields() if isinstance(f, ForeignKey)]
 		source_field = next(f for f in fk_fields if f.related_model is model)
-		team_field = next(f for f in fk_fields if f.related_model is Team)
-
-		team_ids = list(
-			Team.all_objects.filter(
-				**{f"{team_field_lookup}__in": self.request.visible_org_ids}
-			).values_list("id", flat=True)
-		)
+		subject_field = next(f for f in fk_fields if f.related_model is Subject)
 		return through.objects.filter(
 			**{
 				source_field.attname: OuterRef("pk"),
-				f"{team_field.attname}__in": team_ids,
+				f"{subject_field.attname}__in": subject_ids,
 			}
 		)
 
@@ -455,9 +446,9 @@ class CachedStatsActionMixin:
 	_stats_key_ignored_params = frozenset({"page", "page_size", "all_results"})
 
 	def _stats_cache_key(self, request):
-		visible_org_ids = getattr(request, "visible_org_ids", None)
-		orgs = (
-			None if visible_org_ids is None else sorted(visible_org_ids)
+		visible_subject_ids = getattr(request, "visible_subject_ids", None)
+		subjects = (
+			None if visible_subject_ids is None else sorted(visible_subject_ids)
 		)
 		# JSON of sorted (key, value) pairs is an unambiguous encoding: naive
 		# "k=v&k=v" concatenation lets a param value containing '&' or '=' (easy
@@ -492,10 +483,11 @@ class CachedStatsActionMixin:
 		on a multi-valued relation) with a distinct count per parent row.
 
 		SECURITY: an article/trial visible to the caller can be tagged with
-		a subject belonging to a NON-visible org. The list serializers strip
-		such subjects (OrgScopedSerializerMixin); the stats must not leak
-		them either, so when ``request.visible_org_ids`` exists only subjects
-		whose team's organisation is visible are included.
+		a subject OUTSIDE the caller's scope -- that is the ordinary case for
+		a row that qualified on one of its other subjects. The list
+		serializers strip those (ScopedSerializerMixin); the stats must not
+		leak them either, so only subjects in ``request.visible_subject_ids``
+		are counted.
 		"""
 		model = filtered_qs.model
 		through = model.subjects.through
@@ -503,9 +495,9 @@ class CachedStatsActionMixin:
 		qs = through.objects.filter(
 			**{f"{source_field}__in": filtered_qs.order_by().values("pk")}
 		)
-		visible_org_ids = getattr(self.request, "visible_org_ids", None)
-		if visible_org_ids is not None:
-			qs = qs.filter(subject__team__organization_id__in=visible_org_ids)
+		visible_subject_ids = getattr(self.request, "visible_subject_ids", None)
+		if visible_subject_ids is not None:
+			qs = qs.filter(subject_id__in=visible_subject_ids)
 		rows = (
 			qs.values("subject_id", "subject__subject_name")
 			.annotate(count=Count(f"{source_field}_id", distinct=True))
@@ -1463,7 +1455,7 @@ _ARTICLES_ORDERING_PARAM = _ordering_param(
 class ArticleViewSet(
 	BulkExportThrottleMixin,
 	CSVStreamingMixin,
-	OrgVisibilityMixin,
+	SubjectVisibilityMixin,
 	CachedStatsActionMixin,
 	viewsets.ReadOnlyModelViewSet,
 ):
@@ -1940,11 +1932,14 @@ class CategoryViewSet(viewsets.ReadOnlyModelViewSet):
 		"""
 		queryset = TeamCategory.objects.all()
 
-		# --- Org visibility: only categories whose team's org is visible ---
-		if hasattr(self.request, "visible_org_ids"):
+		# --- Visibility: a category is reachable when its own subjects M2M
+		# intersects the caller's scope. Not the owning team's organisation:
+		# a category is a view onto subjects, so the subjects it names are
+		# what decides. distinct() because the M2M can match several times.
+		if hasattr(self.request, "visible_subject_ids"):
 			queryset = queryset.filter(
-				team__organization_id__in=self.request.visible_org_ids
-			)
+				subjects__id__in=self.request.visible_subject_ids
+			).distinct()
 
 		# Apply filters without expensive annotations
 		team_id = self.request.query_params.get("team_id")
@@ -2255,7 +2250,7 @@ _TRIALS_ORDERING_PARAM = _ordering_param(
 class TrialViewSet(
 	BulkExportThrottleMixin,
 	CSVStreamingMixin,
-	OrgVisibilityMixin,
+	SubjectVisibilityMixin,
 	CachedStatsActionMixin,
 	viewsets.ReadOnlyModelViewSet,
 ):
@@ -2934,7 +2929,7 @@ class SponsorViewSet(viewsets.ReadOnlyModelViewSet):
 ###
 
 
-class SourceViewSet(OrgVisibilityMixin, viewsets.ReadOnlyModelViewSet):
+class SourceViewSet(SubjectVisibilityMixin, viewsets.ReadOnlyModelViewSet):
 	"""
 	List all sources of data with optional filters for team and subject.
 
@@ -2949,8 +2944,9 @@ class SourceViewSet(OrgVisibilityMixin, viewsets.ReadOnlyModelViewSet):
 	- **ordering** - sort field, prefix with `-` for descending. Allowed values: `name`, `source_id`
 	"""
 
-	_org_filter_path = "team__organization_id"
-	_org_filter_distinct = False
+	# Sources.subject is a plain FK, so a filter() cannot duplicate rows.
+	_subject_filter_path = "subject_id"
+	_subject_filter_distinct = False
 	queryset = Sources.objects.all().order_by("name")
 	serializer_class = SourceSerializer
 	permission_classes = [permissions.IsAuthenticatedOrReadOnly]
@@ -2970,19 +2966,23 @@ class SourceViewSet(OrgVisibilityMixin, viewsets.ReadOnlyModelViewSet):
 ###
 
 
-def author_articles_count_subquery(visible_org_ids=None, relevant_only=False):
+def author_articles_count_subquery(visible_subject_ids=None, relevant_only=False):
 	"""Correlated count of an author's articles, immune to outer-query joins.
 
 	A plain ``Count("articles", ...)`` annotation is corrupted whenever the
 	outer queryset already filters across the ``articles__`` join (Django
 	computes the aggregate over the same constrained join). A subquery avoids
 	that trap entirely.
+
+	``visible_subject_ids`` scopes the count to what the caller may see, so
+	the number an author's row reports matches the articles that caller can
+	actually list. None means "no scoping" (middleware absent).
 	"""
 	articles = Articles.objects.filter(authors__author_id=OuterRef("author_id"))
 	if relevant_only:
 		articles = articles.filter(relevant=True)
-	if visible_org_ids is not None:
-		articles = articles.filter(teams__organization_id__in=visible_org_ids)
+	if visible_subject_ids is not None:
+		articles = articles.filter(subjects__in=visible_subject_ids)
 	counts = (
 		articles.order_by()
 		.values("authors__author_id")
@@ -3172,13 +3172,14 @@ class AuthorsViewSet(viewsets.ReadOnlyModelViewSet):
 	def get_queryset(self):
 		queryset = Authors.objects.all()
 
-		# --- Org visibility: only authors with at least one article in a visible org ---
-		if hasattr(self.request, "visible_org_ids"):
+		# --- Visibility: an author is reachable through their articles, so
+		# they qualify when at least one carries a subject in scope. ---
+		if hasattr(self.request, "visible_subject_ids"):
 			queryset = queryset.filter(
 				Exists(
 					Articles.objects.filter(
 						authors=OuterRef("pk"),
-						teams__organization_id__in=self.request.visible_org_ids,
+						subjects__in=self.request.visible_subject_ids,
 					)
 				)
 			)
@@ -3348,12 +3349,13 @@ class AuthorsViewSet(viewsets.ReadOnlyModelViewSet):
 		# Add date filters to count filters
 		count_filters.update(date_filters)
 
-		# Build an org-visibility filter for the Count annotation so that
-		# article_count always reflects only visible articles (fixes sorting/
-		# filtering by article_count leaking hidden-org data).
-		has_org_scope = hasattr(self.request, "visible_org_ids")
+		# Build a visibility filter for the Count annotation so that
+		# article_count always reflects only visible articles (sorting or
+		# filtering by article_count would otherwise leak the size of what
+		# the caller cannot read).
+		has_org_scope = hasattr(self.request, "visible_subject_ids")
 		org_q = (
-			Q(articles__teams__organization_id__in=self.request.visible_org_ids)
+			Q(articles__subjects__in=self.request.visible_subject_ids)
 			if has_org_scope
 			else Q()
 		)
@@ -3408,7 +3410,7 @@ class AuthorsViewSet(viewsets.ReadOnlyModelViewSet):
 		target = page if page is not None else list(queryset)
 
 		if target:
-			visible_org_ids = getattr(request, "visible_org_ids", None)
+			visible_subject_ids = getattr(request, "visible_subject_ids", None)
 			author_ids = [obj.author_id for obj in target]
 
 			# article_count is already annotated on the page (via a cheap
@@ -3420,12 +3422,12 @@ class AuthorsViewSet(viewsets.ReadOnlyModelViewSet):
 
 			annotations = {
 				"_relevant_articles_count": author_articles_count_subquery(
-					visible_org_ids, relevant_only=True
+					visible_subject_ids, relevant_only=True
 				),
 			}
 			if needs_article_count:
 				annotations["_article_count"] = author_articles_count_subquery(
-					visible_org_ids, relevant_only=False
+					visible_subject_ids, relevant_only=False
 				)
 
 			counts_by_id = {
@@ -3511,11 +3513,11 @@ class AuthorsViewSet(viewsets.ReadOnlyModelViewSet):
 	def coauthors(self, request, pk=None):
 		"""Co-authors ordered by number of shared articles (desc)."""
 		author = self.get_object()
-		visible_org_ids = getattr(request, "visible_org_ids", None)
+		visible_subject_ids = getattr(request, "visible_subject_ids", None)
 
 		shared = Articles.objects.filter(authors__author_id=author.author_id)
-		if visible_org_ids is not None:
-			shared = shared.filter(teams__organization_id__in=visible_org_ids)
+		if visible_subject_ids is not None:
+			shared = shared.filter(subjects__in=visible_subject_ids)
 		shared_ids = shared.values("article_id").distinct()
 
 		coauthors_qs = (
@@ -3526,9 +3528,9 @@ class AuthorsViewSet(viewsets.ReadOnlyModelViewSet):
 				shared_articles=Count(
 					"articles", filter=Q(articles__article_id__in=shared_ids), distinct=True,
 				),
-				articles_count=author_articles_count_subquery(visible_org_ids),
+				articles_count=author_articles_count_subquery(visible_subject_ids),
 				relevant_articles_count=author_articles_count_subquery(
-					visible_org_ids, relevant_only=True,
+					visible_subject_ids, relevant_only=True,
 				),
 			)
 			.order_by("-shared_articles", "author_id")
@@ -3568,14 +3570,25 @@ class ProtectedEndpointView(APIView):
 ###
 
 
-class TeamsViewSet(OrgVisibilityMixin, viewsets.ReadOnlyModelViewSet):
+class TeamsViewSet(viewsets.ReadOnlyModelViewSet):
 	"""
-	List all teams
+	List teams that have opted into being listed.
+
+	Gated by the explicit ``Team.api_listed`` flag, not by subject scope. A
+	team is not content and owns no subject of its own, so deriving its
+	visibility from the subjects it owns cannot express either of the two
+	things an operator eventually wants: an internal lab that contributes to
+	public content but should not be named, or a partner an organisation
+	wants to credit that owns nothing in scope. The flag was seeded from the
+	derived answer by ``sitesettings/0019`` and can be overridden either way.
+
+	It gates listing, not access. ``api_listed = False`` removes a team from
+	this endpoint; it does not hide that team's content, which is governed by
+	subject scope like everything else. Conflating the two is how a metadata
+	switch quietly becomes a data-visibility switch.
 	"""
 
-	_org_filter_path = "organization_id"
-	_org_filter_distinct = False
-	queryset = Team.objects.all().order_by("id")
+	queryset = Team.objects.filter(api_listed=True).order_by("id")
 	serializer_class = TeamSerializer
 	permission_classes = [permissions.IsAuthenticatedOrReadOnly]
 
@@ -3621,7 +3634,7 @@ _SUBJECTS_ORDERING_PARAM = _ordering_param(
 	list=extend_schema(parameters=[_SUBJECTS_ORDERING_PARAM]),
 )
 
-class SubjectsViewSet(OrgVisibilityMixin, viewsets.ReadOnlyModelViewSet):
+class SubjectsViewSet(SubjectVisibilityMixin, viewsets.ReadOnlyModelViewSet):
 	"""
 	✅ **PREFERRED ENDPOINT**: This is the main subjects endpoint that supports filtering options.
 
@@ -3639,8 +3652,9 @@ class SubjectsViewSet(OrgVisibilityMixin, viewsets.ReadOnlyModelViewSet):
 	- Order by name: `/subjects/?ordering=subject_name`
 	"""
 
-	_org_filter_path = "team__organization_id"
-	_org_filter_distinct = False
+	# The subject is the row itself -- no relation to traverse.
+	_subject_filter_path = "id"
+	_subject_filter_distinct = False
 	queryset = Subject.objects.all().order_by("id")
 	serializer_class = SubjectsSerializer
 	permission_classes = [permissions.IsAuthenticatedOrReadOnly]
@@ -4226,10 +4240,10 @@ class AuthorSearchView(BodyParamsAsQueryParamsMixin, generics.ListAPIView):
 
 			queryset = queryset.annotate(
 				article_count=author_articles_count_subquery(
-					getattr(self.request, "visible_org_ids", None), relevant_only=False
+					getattr(self.request, "visible_subject_ids", None), relevant_only=False
 				),
 				relevant_articles_count=author_articles_count_subquery(
-					getattr(self.request, "visible_org_ids", None), relevant_only=True,
+					getattr(self.request, "visible_subject_ids", None), relevant_only=True,
 				)
 			)
 

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -460,7 +460,7 @@ class CachedStatsActionMixin:
 			for value in request.query_params.getlist(key)
 		)
 		digest = hashlib.sha256(
-			json.dumps({"orgs": orgs, "params": params}).encode()
+			json.dumps({"subjects": subjects, "params": params}).encode()
 		).hexdigest()
 		return f"{self.stats_cache_prefix}:{digest}"
 

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -4669,6 +4669,49 @@ class PublicSitesView(APIView):
 		return Response(PublicSiteSerializer(unique, many=True).data)
 
 
+def stats_payload_cache_key(team_id_list, visible_subject_ids, subject_ids):
+	"""Cache key for StatsView's whole-payload cache (layer 1).
+
+	Module-level and shared with the tests rather than built inline: the key
+	has three independent components and every one of them is load-bearing,
+	so a test that rebuilds the string by hand drifts silently the moment one
+	is added -- which is exactly what happened when the caller-scope
+	component went in.
+
+	  team_id_list         the requested ?team= narrowing; also the namespace
+	                       for the per-subject-row cache (layer 2), so a row
+	                       computed under one team scope is never served
+	                       under another.
+	  visible_subject_ids  the CALLER's own scope. Two site-bound API keys
+	                       belonging to the same organisation resolve to the
+	                       same team scope and, with no ?subject=, the same
+	                       "subj:all" -- but to different payloads and
+	                       different by_subject rosters. Without this
+	                       component one site is served the other's numbers
+	                       and subject names (PR #863 review finding 7).
+	                       Hashed to bound key length for the DB cache.
+	  subject_ids          the explicit ?subject=/?site= narrowing.
+	"""
+	team_part = (
+		"all"
+		if team_id_list is None
+		else ",".join(str(i) for i in sorted(team_id_list))
+	)
+	scope_part = (
+		"noscope"
+		if visible_subject_ids is None
+		else hashlib.sha256(
+			json.dumps(sorted(visible_subject_ids)).encode()
+		).hexdigest()[:32]
+	)
+	subject_part = (
+		"all"
+		if subject_ids is None
+		else ",".join(str(i) for i in sorted(set(subject_ids)))
+	)
+	return f"stats:{team_part}:scope:{scope_part}:subj:{subject_part}"
+
+
 class StatsView(APIView):
 	"""
 	Returns aggregate statistics about the data in the system.
@@ -4843,17 +4886,34 @@ class StatsView(APIView):
 				)
 			from sitesettings.models import CustomSetting
 
-			site_subject_ids = set(
+			# Validate EVERY requested site, not the union. Unioning first and
+			# checking only that the result is non-empty lets
+			# ?site=<reachable>,<unknown> succeed on the strength of the
+			# reachable one, silently ignoring the other -- so a caller
+			# probing site IDs cannot tell a real site from a typo, and a
+			# request that named something it cannot see still gets an
+			# answer. Each site must resolve to at least one subject the
+			# caller can already see, or the whole request 404s.
+			scope_by_site = {}
+			for row in (
 				CustomSetting.objects.filter(site_id__in=site_ids)
 				.exclude(scope_subjects__isnull=True)
-				.values_list("scope_subjects__id", flat=True)
-			)
-			# A site the caller cannot reach resolves to nothing, and an empty
-			# scope must not read as "no filter" -- that would silently widen
-			# the answer to everything. Force the 404 path instead, matching
-			# how an unreachable ?subject= behaves.
-			if not site_subject_ids:
-				raise Http404
+				.values_list("site_id", "scope_subjects__id")
+			):
+				scope_by_site.setdefault(row[0], set()).add(row[1])
+
+			site_subject_ids = set()
+			for requested in site_ids:
+				reachable = scope_by_site.get(requested, set())
+				if visible_subject_ids is not None:
+					reachable = reachable & set(visible_subject_ids)
+				# Covers all three cases the same way, deliberately: the site
+				# does not exist, it exists with an empty scope, or its whole
+				# scope is outside what this caller may see. Distinguishing
+				# them in the response would leak which site IDs are real.
+				if not reachable:
+					raise Http404
+				site_subject_ids |= reachable
 			subject_ids = (
 				sorted(site_subject_ids)
 				if subject_ids is None
@@ -4964,7 +5024,23 @@ class StatsView(APIView):
 				if team_id_list is None or s["team_id"] in team_id_list
 			]
 		else:
-			effective_subject_ids = None
+			# No explicit ?subject=/?site=. The content counts below must
+			# still be scoped, or an article, trial, source or subscriber
+			# attached only to an out-of-scope subject inflates /stats/ while
+			# being absent from every list endpoint -- the totals would
+			# describe data the caller cannot reach (PR #863 review finding
+			# 6). visible_subjects is already exactly the right default: it
+			# was filtered by visible_subject_ids above, and narrowed by
+			# ?team= when one was given.
+			#
+			# Stays None when the middleware is absent, so management commands
+			# and middleware-bypassing tests keep their unscoped behaviour --
+			# the same fallback contract as SubjectVisibilityMixin.
+			effective_subject_ids = (
+				None
+				if visible_subject_ids is None
+				else [s["id"] for s in visible_subjects]
+			)
 			by_subject_roster = visible_subjects
 
 		apply_subject = effective_subject_ids is not None
@@ -4978,15 +5054,8 @@ class StatsView(APIView):
 			if team_id_list is None
 			else ",".join(str(i) for i in sorted(team_id_list))
 		)
-		cache_key = (
-			"stats:"
-			+ team_part
-			+ ":subj:"
-			+ (
-				"all"
-				if subject_ids is None
-				else ",".join(str(i) for i in sorted(set(subject_ids)))
-			)
+		cache_key = stats_payload_cache_key(
+			team_id_list, visible_subject_ids, subject_ids
 		)
 		cached = cache.get(cache_key)
 		if cached is not None:

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -414,6 +414,56 @@ class SubjectVisibilityMixin:
 		)
 
 
+def visible_trial_references_queryset(visible_subject_ids):
+	"""``ArticleTrialReference`` rows whose TRIAL carries a visible subject.
+
+	Used to prefetch ``Articles.trial_references`` so
+	``ArticleSerializer.get_clinical_trials()`` cannot disclose a hidden
+	trial's id/title/summary/link through an otherwise-visible article (PR
+	#863 review finding 2) -- the row selecting the article says nothing
+	about whether the article's cross-referenced trials are in scope too.
+
+	Filtered here, in the prefetch queryset, rather than in
+	``get_clinical_trials()`` itself: a per-row Python filter would need
+	``ref.trial.subjects.all()``, which is not covered by this prefetch's
+	``select_related("trial")`` and would reintroduce an N+1 (one query per
+	referenced trial per article) -- see the query-budget tests this would
+	trip. An Exists() subquery, not a join + distinct(): the through table
+	already has one row per (article, trial, identifier_type), and a plain
+	``trial__subjects__in=`` join would fan that out once per matching
+	subject.
+
+	``None`` means "no middleware / no scoping" -- same fallback contract as
+	``SubjectVisibilityMixin``.
+	"""
+	qs = ArticleTrialReference.objects.select_related("trial")
+	if visible_subject_ids is not None:
+		qs = qs.filter(
+			Exists(
+				Trials.objects.filter(
+					pk=OuterRef("trial_id"), subjects__id__in=visible_subject_ids
+				)
+			)
+		)
+	return qs
+
+
+def visible_article_references_queryset(visible_subject_ids):
+	"""The reverse of ``visible_trial_references_queryset``: prefetches
+	``Trials.article_references`` filtered to referenced ARTICLES that carry
+	a visible subject, for ``TrialSerializer.get_articles()``."""
+	qs = ArticleTrialReference.objects.select_related("article")
+	if visible_subject_ids is not None:
+		qs = qs.filter(
+			Exists(
+				Articles.objects.filter(
+					pk=OuterRef("article_id"), subjects__id__in=visible_subject_ids
+				)
+			)
+		)
+	return qs
+
+
 class CachedStatsActionMixin:
 	"""
 	Shared machinery for filter-scoped, cached ``GET /<resource>/stats/`` actions.
@@ -1574,10 +1624,11 @@ class ArticleViewSet(
 			"article_subject_relevances",
 			queryset=ArticleSubjectRelevance.objects.select_related("subject__team"),
 		),
-		Prefetch(
-			"trial_references",
-			queryset=ArticleTrialReference.objects.select_related("trial"),
-		),
+		# trial_references is NOT prefetched here — it has to be scoped to
+		# the caller's visible_subject_ids (see get_queryset below), and a
+		# Prefetch object for the same lookup path cannot be added twice
+		# with different querysets (Django raises ValueError: "lookup was
+		# already seen with a different queryset").
 	).order_by("-discovery_date")
 	serializer_class = ArticleSerializer
 	permission_classes = [permissions.IsAuthenticatedOrReadOnly]
@@ -1604,6 +1655,18 @@ class ArticleViewSet(
 		fields without issuing one query per article.
 		"""
 		qs = super().get_queryset()
+		# Scoped here, not on the class-level `queryset` attribute, because it
+		# depends on the caller's visible_subject_ids -- see
+		# visible_trial_references_queryset's docstring (PR #863 review
+		# finding 2).
+		qs = qs.prefetch_related(
+			Prefetch(
+				"trial_references",
+				queryset=visible_trial_references_queryset(
+					getattr(self.request, "visible_subject_ids", None)
+				),
+			)
+		)
 		org = _resolve_per_org_fields_org(self.request)
 		if org is not None:
 			qs = qs.prefetch_related(
@@ -1703,7 +1766,35 @@ class ArticleViewSet(
 ###
 
 
-def _category_through_count_subquery(through_model):
+def _visible_or_subjectless_q(content_prefix, visible_subject_ids):
+	"""Q object: the content reached via *content_prefix* has no subject at
+	all, OR has at least one subject in ``visible_subject_ids``.
+
+	*content_prefix* is the ORM path to Articles/Trials -- ``""`` when the
+	queryset being filtered IS Articles/Trials, or e.g. ``"articles__"``
+	when filtering a related model that reaches them through that relation.
+
+	This is the category-aggregate counterpart of StatsView's default
+	content filter (PR #863 review findings 4 and 6): a category assignment
+	whose article/trial carries ONLY an out-of-scope subject must not
+	inflate a category's counts or disclose its authors, but content with no
+	subject at all is not newly excluded by subject-scoping -- see
+	api/tests/test_visibility_stats.py's null-subject-Source fixtures
+	(test_source_with_null_subject_dropped_when_filtering's "unfiltered"
+	case) for why that distinction is load-bearing rather than incidental.
+
+	Returns ``None`` when ``visible_subject_ids`` is ``None`` (no middleware
+	/ no scoping active), so callers can skip filtering entirely -- same
+	fallback contract as SubjectVisibilityMixin.
+	"""
+	if visible_subject_ids is None:
+		return None
+	return Q(**{f"{content_prefix}subjects__isnull": True}) | Q(
+		**{f"{content_prefix}subjects__id__in": visible_subject_ids}
+	)
+
+
+def _category_through_count_subquery(through_model, content_fk, visible_subject_ids=None):
 	"""Correlated scalar count of a category's rows in a single M2M through
 	table (article or trial category assignments).
 
@@ -1716,14 +1807,26 @@ def _category_through_count_subquery(through_model):
 	counts each through table independently (no cross join), and because
 	each through table already has a unique_together on
 	(article/trial, teamcategory), a plain COUNT(*) here already equals the
-	distinct count.
+	distinct count -- UNLESS visible_subject_ids narrows it (below), which
+	joins onward to the content's own subjects and can fan a single
+	through-row out into several, hence Count(content_fk, distinct=True)
+	rather than Count("*") whenever that join is added.
+
+	*content_fk* is the through model's FK field name to the content model
+	("articles" or "trials"), used both for that distinct-count target and
+	to build the subject-visibility predicate (PR #863 review finding 4: a
+	category shared by a visible and a hidden subject must not have its
+	counts inflated by rows the caller cannot otherwise see).
 	"""
+	qs = through_model.objects.filter(teamcategory=OuterRef("pk"))
+	visible_q = _visible_or_subjectless_q(f"{content_fk}__", visible_subject_ids)
+	if visible_q is not None:
+		qs = qs.filter(visible_q)
 	return Coalesce(
 		Subquery(
-			through_model.objects.filter(teamcategory=OuterRef("pk"))
-			.order_by()
+			qs.order_by()
 			.values("teamcategory")
-			.annotate(c=Count("*"))
+			.annotate(c=Count(content_fk, distinct=True))
 			.values("c"),
 			output_field=IntegerField(),
 		),
@@ -1731,7 +1834,7 @@ def _category_through_count_subquery(through_model):
 	)
 
 
-def _category_authors_count_subquery():
+def _category_authors_count_subquery(visible_subject_ids=None):
 	"""Correlated scalar count of the distinct authors behind a category's
 	articles.
 
@@ -1741,11 +1844,18 @@ def _category_authors_count_subquery():
 	of thousands of author rows). It is therefore NOT part of the default
 	/categories/ queryset — see CategoryViewSet.get_queryset, which adds it
 	only when the client explicitly sorts by it.
+
+	visible_subject_ids scopes which of the category's articles contribute
+	authors at all (PR #863 review finding 4) -- an author reachable only
+	through an article carrying solely a hidden subject must not be counted.
 	"""
+	qs = ArticleCategoryAssignment.objects.filter(teamcategory=OuterRef("pk"))
+	visible_q = _visible_or_subjectless_q("articles__", visible_subject_ids)
+	if visible_q is not None:
+		qs = qs.filter(visible_q)
 	return Coalesce(
 		Subquery(
-			ArticleCategoryAssignment.objects.filter(teamcategory=OuterRef("pk"))
-			.order_by()
+			qs.order_by()
 			.values("teamcategory")
 			.annotate(c=Count("articles__authors", distinct=True))
 			.values("c"),
@@ -2498,7 +2608,19 @@ class TrialViewSet(
 			.prefetch_related(
 				"sources",
 				"team_categories",
-				"article_references__article",
+				# Scoped to visible_subject_ids, not a plain
+				# "article_references__article" string lookup: an
+				# unfiltered prefetch would let TrialSerializer.get_articles()
+				# disclose a hidden article's id/title/summary/link through an
+				# otherwise-visible trial. See
+				# visible_article_references_queryset's docstring (PR #863
+				# review finding 2).
+				Prefetch(
+					"article_references",
+					queryset=visible_article_references_queryset(
+						getattr(self.request, "visible_subject_ids", None)
+					),
+				),
 				"trial_countries",
 				# TrialSerializer exposes nested subjects (added for site-scoped
 				# visibility, so a caller can check a trial's scope without a
@@ -3888,6 +4010,18 @@ class ArticleSearchView(
 			).exists():
 				raise Http404
 
+		# Visibility check: the requested subject_id must itself be in the
+		# caller's subject scope. The team check above only proves the team's
+		# ORGANISATION is reachable -- a reachable org can still own a subject
+		# outside the caller's site scope (Phase 4 site-scoped visibility), and
+		# without this check that subject's articles would be returned in
+		# full, unfiltered by ScopedSerializerMixin (which only strips a
+		# HIDDEN subject nested *inside* an otherwise-visible row, not a row
+		# selected entirely because of one).
+		if hasattr(self.request, "visible_subject_ids"):
+			if subject_id not in self.request.visible_subject_ids:
+				raise Http404
+
 		try:
 			# Filter via a correlated Exists() subquery instead of joining the
 			# teams/subjects M2M tables and calling .distinct() on the outer
@@ -3915,7 +4049,9 @@ class ArticleSearchView(
 				),
 				Prefetch(
 					"trial_references",
-					queryset=ArticleTrialReference.objects.select_related("trial"),
+					queryset=visible_trial_references_queryset(
+						getattr(self.request, "visible_subject_ids", None)
+					),
 				),
 			)
 
@@ -4133,6 +4269,14 @@ class TrialSearchView(
 			).exists():
 				raise Http404
 
+		# Visibility check: the requested subject_id must itself be in the
+		# caller's subject scope -- see the identical guard in
+		# ArticleSearchView.get_queryset for why the team check alone is not
+		# enough.
+		if hasattr(self.request, "visible_subject_ids"):
+			if subject_id not in self.request.visible_subject_ids:
+				raise Http404
+
 		try:
 			# Check if team and subject exist
 			team = Team.objects.get(id=team_id)
@@ -4151,7 +4295,17 @@ class TrialSearchView(
 		queryset = queryset.prefetch_related(
 			"sources",
 			"team_categories",
-			"article_references__article",
+			# Scoped to visible_subject_ids -- see
+			# visible_article_references_queryset's docstring (PR #863 review
+			# finding 2). subject_id itself is already validated against
+			# visible_subject_ids above, but a trial can carry OTHER,
+			# out-of-scope subjects too, and so can an article it references.
+			Prefetch(
+				"article_references",
+				queryset=visible_article_references_queryset(
+					getattr(self.request, "visible_subject_ids", None)
+				),
+			),
 			"trial_countries",
 			# Nested subjects on TrialSerializer. select_related("team") is
 			# required because SubjectsSerializer.team_id uses source="team.id"
@@ -4296,6 +4450,22 @@ class AuthorSearchView(BodyParamsAsQueryParamsMixin, generics.ListAPIView):
 			).exists():
 				raise Http404
 
+	def _check_subject_visibility(self, subject_id):
+		"""Raise Http404 if subject_id is not in the caller's subject scope.
+
+		The team check above only proves the team's ORGANISATION is
+		reachable; a reachable org can still own a subject outside the
+		caller's site scope (Phase 4 site-scoped visibility). Without this,
+		get_queryset() would select author_ids from articles carrying this
+		subject before any scoping applied to the rows themselves -- only
+		the article_count/relevant_articles_count annotations were subject
+		-scoped, so a hidden-only author would still be returned, just with
+		a zero count (PR #863 review findings 1 and 5).
+		"""
+		if hasattr(self.request, "visible_subject_ids"):
+			if int(subject_id) not in self.request.visible_subject_ids:
+				raise Http404
+
 	def get_queryset(self):
 		params = (
 			self.request.query_params
@@ -4388,6 +4558,7 @@ class AuthorSearchView(BodyParamsAsQueryParamsMixin, generics.ListAPIView):
 			)
 
 		self._check_team_visibility(team_id)
+		self._check_subject_visibility(subject_id)
 		return self.list(request, *args, **kwargs)
 
 	def get(self, request, *args, **kwargs):
@@ -4416,6 +4587,7 @@ class AuthorSearchView(BodyParamsAsQueryParamsMixin, generics.ListAPIView):
 			)
 
 		self._check_team_visibility(team_id)
+		self._check_subject_visibility(subject_id)
 		# Delegate to the list method
 		return self.list(request, *args, **kwargs)
 

--- a/django/gregory/tests/test_authors_api_sorting.py
+++ b/django/gregory/tests/test_authors_api_sorting.py
@@ -7,6 +7,8 @@ from gregory.models import Authors, Articles, Team, Subject, OrganizationApiSett
 from organizations.models import Organization
 from django.db.models import Count, Q
 
+from api.tests.visibility_helpers import publish_subjects
+
 
 class AuthorsAPISortingTestCase(TestCase):
 	"""
@@ -39,6 +41,7 @@ class AuthorsAPISortingTestCase(TestCase):
 			subject_slug="multiple-sclerosis",
 			team=self.team1,
 		)
+		publish_subjects(self.subject1, organization=self.organization)
 
 		# Create test authors with different article counts
 		self.author_high = Authors.objects.create(

--- a/django/gregory/tests/test_category_optimizations.py
+++ b/django/gregory/tests/test_category_optimizations.py
@@ -70,6 +70,9 @@ class CategoryOptimizationTestCase(TestCase):
 				summary=f"Summary for article {i}",
 			)
 			article.team_categories.add(self.category)
+			# Category aggregates are scoped to the caller's subjects, so
+			# untagged content contributes nothing to the counts asserted below.
+			article.subjects.add(self.subject)
 			article.authors.add(self.author1 if i < 3 else self.author2)
 
 		# Create test trials
@@ -80,6 +83,7 @@ class CategoryOptimizationTestCase(TestCase):
 				summary=f"Summary for trial {i}",
 			)
 			trial.team_categories.add(self.category)
+			trial.subjects.add(self.subject)
 
 	def test_category_list_performance(self):
 		"""Test that category listing is fast and returns correct counts"""
@@ -188,6 +192,7 @@ class CategoryOptimizationTestCase(TestCase):
 				summary=f"Summary {i}",
 			)
 			article.team_categories.add(self.category)
+			article.subjects.add(self.subject)
 
 		connection.queries.clear()
 		response = self.client.get(f"/categories/?team_id={self.team.id}")

--- a/django/gregory/tests/test_category_optimizations.py
+++ b/django/gregory/tests/test_category_optimizations.py
@@ -20,6 +20,8 @@ from gregory.models import (
 from organizations.models import Organization
 import time
 
+from api.tests.visibility_helpers import publish_subjects
+
 
 class CategoryOptimizationTestCase(TestCase):
 	"""Test cases for the optimized category queries"""
@@ -44,6 +46,7 @@ class CategoryOptimizationTestCase(TestCase):
 
 		# Create test subject
 		self.subject = Subject.objects.create(subject_name="Test Subject")
+		publish_subjects(self.subject, organization=self.organization)
 
 		# Create test category
 		self.category = TeamCategory.objects.create(

--- a/django/schema.yml
+++ b/django/schema.yml
@@ -188,6 +188,14 @@ paths:
           type: boolean
         description: Filter for articles linked to one or more clinical trials (true/false).
       - in: query
+        name: include_public
+        schema:
+          type: boolean
+        description: |-
+          Identified callers only (API key or signed-in user): add the scopes of every publicly readable site to your own, so a private site's frontend can read public content alongside its own. No-op for an anonymous caller, whose scope already is exactly that set.
+
+          Undeclared but functional before Phase 4 of site-scoped API visibility, when it read 'adds public organisations' — organisations are no longer the visibility unit, so it is declared here with its current meaning rather than left to be discovered.
+      - in: query
         name: journal_slug
         schema:
           type: string
@@ -2366,9 +2374,25 @@ paths:
       operationId: sponsors_list
       description: |-
         List canonical sponsor entities (deduplicated trial sponsors — see
-        docs/trials-field-normalization.md). Sponsors are global, not org-owned, so
-        unlike most other viewsets this one carries no OrgVisibilityMixin — same
-        reasoning as the by_sponsor/by_sponsor_type facets on /trials/stats/.
+        docs/trials-field-normalization.md).
+
+        A Sponsor carries no subject of its own; it reaches content only through
+        the trials that name it. So it is scoped to "has at least one trial in the
+        caller's scope" rather than by a field on the row — an Exists() over
+        Trials.primary_sponsor_normalized. Without that, a sponsor's existence
+        (and its name) would disclose that some trial the caller cannot read
+        exists, which is the thing subject scoping is for.
+
+        It carried no scoping at all before Phase 4 of site-scoped API visibility,
+        on the grounds that sponsors are global. That was defensible while
+        visibility was organisation-keyed and every caller effectively saw the same
+        trials; it stops being defensible with two tenants.
+
+        Measured after the 2026-09-10 orphan-sponsor prune: scoping hides 59 of
+        4,686 (1.3%), all Dihydroartemisinin (subject 15, internal research in no
+        site's scope) — the intended exclusion. Before that prune it looked like
+        43%, but 3,406 of those sponsors referenced no trial at all and were
+        debris left behind by the PROTECT FK when their trials were deleted.
 
         # Query Parameters:
         - **search** - search by sponsor name
@@ -2487,9 +2511,25 @@ paths:
       operationId: sponsors_retrieve
       description: |-
         List canonical sponsor entities (deduplicated trial sponsors — see
-        docs/trials-field-normalization.md). Sponsors are global, not org-owned, so
-        unlike most other viewsets this one carries no OrgVisibilityMixin — same
-        reasoning as the by_sponsor/by_sponsor_type facets on /trials/stats/.
+        docs/trials-field-normalization.md).
+
+        A Sponsor carries no subject of its own; it reaches content only through
+        the trials that name it. So it is scoped to "has at least one trial in the
+        caller's scope" rather than by a field on the row — an Exists() over
+        Trials.primary_sponsor_normalized. Without that, a sponsor's existence
+        (and its name) would disclose that some trial the caller cannot read
+        exists, which is the thing subject scoping is for.
+
+        It carried no scoping at all before Phase 4 of site-scoped API visibility,
+        on the grounds that sponsors are global. That was defensible while
+        visibility was organisation-keyed and every caller effectively saw the same
+        trials; it stops being defensible with two tenants.
+
+        Measured after the 2026-09-10 orphan-sponsor prune: scoping hides 59 of
+        4,686 (1.3%), all Dihydroartemisinin (subject 15, internal research in no
+        site's scope) — the intended exclusion. Before that prune it looked like
+        43%, but 3,406 of those sponsors referenced no trial at all and were
+        debris left behind by the PROTECT FK when their trials were deleted.
 
         # Query Parameters:
         - **search** - search by sponsor name
@@ -2547,10 +2587,22 @@ paths:
         -------
         ?team=1,2,3
             Scope to one or more teams (comma-separated integer IDs).
-        ?organization=1,2  (alias: ?org=)
+        ?site=1,2
+            Scope to the subjects one or more sites publish (their
+            CustomSetting.scope_subjects). This is the filter to reach for now
+            that visibility is site-scoped; it is sugar for ?subject= with that
+            site's scope, and intersects with an explicit ?subject= rather than
+            overriding it. A site the caller cannot reach 404s, like any other
+            unreachable scope.
+        ?organization=1,2  (alias: ?org=)  [DEPRECATED]
             Scope to one or more organisations (comma-separated integer IDs).
             When combined with ?team=, the effective scope is the intersection:
             teams that belong to the requested org(s).
+
+            Deprecated because organisations are no longer the visibility unit --
+            a site is. It still works, and still means exactly what it always
+            meant, which is the point: silently redefining a documented parameter
+            is the failure this project exists to prevent. Prefer ?site=.
         ?subject=1,2
             Scope to one or more subjects (comma-separated integer IDs, OR/union
             semantics). Adds a ``by_subject`` breakdown to the payload, listing
@@ -2580,16 +2632,34 @@ paths:
           - csv
           - json
       - in: query
+        name: include_public
+        schema:
+          type: boolean
+        description: |-
+          Identified callers only (API key or signed-in user): add the scopes of every publicly readable site to your own, so a private site's frontend can read public content alongside its own. No-op for an anonymous caller, whose scope already is exactly that set.
+
+          Undeclared but functional before Phase 4 of site-scoped API visibility, when it read 'adds public organisations' — organisations are no longer the visibility unit, so it is declared here with its current meaning rather than left to be discovered.
+      - in: query
         name: org
         schema:
           type: string
-        description: Alias for organization.
+        description: DEPRECATED — alias for organization. Prefer ?site=.
+        deprecated: true
       - in: query
         name: organization
         schema:
           type: string
-        description: 'Scope to one or more organisations (comma-separated integer
-          IDs). Alias: org.'
+        description: 'DEPRECATED — prefer ?site=. Scope to one or more organisations
+          (comma-separated integer IDs). Alias: org. Organisations are no longer the
+          visibility unit; this still works and still means what it always meant.'
+        deprecated: true
+      - in: query
+        name: site
+        schema:
+          type: string
+        description: Scope to the subjects one or more sites publish (comma-separated
+          integer site IDs). Sugar for ?subject= with that site's scope; intersects
+          with an explicit ?subject= rather than overriding it.
       - in: query
         name: subject
         schema:
@@ -2767,7 +2837,32 @@ paths:
   /teams/:
     get:
       operationId: teams_list
-      description: List all teams
+      description: |-
+        List teams that have opted into being listed.
+
+        A team is listed when EITHER holds:
+
+          1. ``Team.api_listed`` is on -- the explicit publication switch, seeded
+             from the derived answer by ``sitesettings/0019``; or
+          2. the team owns a subject already in the caller's scope.
+
+        Rule 1 alone was the first cut, and it is what the spec says literally. It
+        has a cost that only shows up with a second tenant: a private site's own
+        authenticated frontend could not list its own teams, because the teams of
+        a private site are exactly the ones an operator marks unlisted. Rule 2
+        buys that back without reopening anything -- a caller who can already read
+        a team's articles and trials learns nothing new from its name.
+
+        A flag is still the right primary answer, for the reason the spec gives:
+        deriving listing purely from owned subjects cannot express an internal lab
+        that contributes to public content but should not be named, nor a partner
+        an organisation wants to credit that owns nothing in scope. Rule 2 only
+        ever adds, so both of those stay expressible.
+
+        It gates listing, not access. Being unlisted removes a team from this
+        endpoint; it does not hide that team's content, which is governed by
+        subject scope like everything else. Conflating the two is how a metadata
+        switch quietly becomes a data-visibility switch.
       parameters:
       - in: query
         name: format
@@ -2814,7 +2909,32 @@ paths:
   /teams/{id}/:
     get:
       operationId: teams_retrieve
-      description: List all teams
+      description: |-
+        List teams that have opted into being listed.
+
+        A team is listed when EITHER holds:
+
+          1. ``Team.api_listed`` is on -- the explicit publication switch, seeded
+             from the derived answer by ``sitesettings/0019``; or
+          2. the team owns a subject already in the caller's scope.
+
+        Rule 1 alone was the first cut, and it is what the spec says literally. It
+        has a cost that only shows up with a second tenant: a private site's own
+        authenticated frontend could not list its own teams, because the teams of
+        a private site are exactly the ones an operator marks unlisted. Rule 2
+        buys that back without reopening anything -- a caller who can already read
+        a team's articles and trials learns nothing new from its name.
+
+        A flag is still the right primary answer, for the reason the spec gives:
+        deriving listing purely from owned subjects cannot express an internal lab
+        that contributes to public content but should not be named, nor a partner
+        an organisation wants to credit that owns nothing in scope. Rule 2 only
+        ever adds, so both of those stay expressible.
+
+        It gates listing, not access. Being unlisted removes a team from this
+        endpoint; it does not hide that team's content, which is governed by
+        subject scope like everything else. Conflating the two is how a metadata
+        switch quietly becomes a data-visibility switch.
       parameters:
       - in: query
         name: format
@@ -3223,6 +3343,14 @@ paths:
           unique) — use acronym for those.
         explode: false
         style: form
+      - in: query
+        name: include_public
+        schema:
+          type: boolean
+        description: |-
+          Identified callers only (API key or signed-in user): add the scopes of every publicly readable site to your own, so a private site's frontend can read public content alongside its own. No-op for an anonymous caller, whose scope already is exactly that set.
+
+          Undeclared but functional before Phase 4 of site-scoped API visibility, when it read 'adds public organisations' — organisations are no longer the visibility unit, so it is declared here with its current meaning rather than left to be discovered.
       - in: query
         name: inclusion_agemax
         schema:
@@ -5221,12 +5349,12 @@ components:
     Article:
       type: object
       description: |-
-        Mixin for DRF serializers that strips nested associations belonging to
-        organisations the caller cannot see.
+        Mixin for DRF serializers that strips nested associations the caller
+        cannot see.
 
         Usage::
 
-            class ArticleSerializer(OrgScopedSerializerMixin,
+            class ArticleSerializer(ScopedSerializerMixin,
                                     serializers.HyperlinkedModelSerializer):
                 ...
 
@@ -6259,12 +6387,12 @@ components:
     Trial:
       type: object
       description: |-
-        Mixin for DRF serializers that strips nested associations belonging to
-        organisations the caller cannot see.
+        Mixin for DRF serializers that strips nested associations the caller
+        cannot see.
 
         Usage::
 
-            class ArticleSerializer(OrgScopedSerializerMixin,
+            class ArticleSerializer(ScopedSerializerMixin,
                                     serializers.HyperlinkedModelSerializer):
                 ...
 

--- a/django/subscriptions/tests/test_author_optout_view.py
+++ b/django/subscriptions/tests/test_author_optout_view.py
@@ -16,13 +16,15 @@ from django.contrib.sites.models import Site
 from django.test import Client, TestCase
 from rest_framework.test import APIClient
 
-from gregory.models import Articles, Authors, OrganizationApiSettings, Team
+from gregory.models import Articles, Authors, OrganizationApiSettings, Subject, Team
 from organizations.models import Organization
 from subscriptions.models import (
 	AuthorContactOptOut,
 	AuthorOutreach,
 	AuthorOutreachCampaign,
 )
+
+from api.tests.visibility_helpers import publish_subjects
 
 
 class AuthorOptOutViewTest(TestCase):
@@ -108,6 +110,10 @@ class AuthorOptOutDoesNotAffectProfilePageTest(TestCase):
 		self.team = Team.objects.create(
 			organization=self.organization, name="Profile Team", slug="profile-team"
 		)
+		self.subject = Subject.objects.create(
+			subject_name="Profile Subject", subject_slug="profile-subject", team=self.team
+		)
+		publish_subjects(self.subject, organization=self.organization)
 		self.site = Site.objects.create(
 			domain="optout-profile.example.com", name="Profile"
 		)
@@ -128,6 +134,7 @@ class AuthorOptOutDoesNotAffectProfilePageTest(TestCase):
 		)
 		self.article.authors.add(self.author)
 		self.article.teams.add(self.team)
+		self.article.subjects.add(self.subject)
 		self.outreach = AuthorOutreach.objects.create(
 			campaign=self.campaign,
 			site=self.site,

--- a/docs/03-api-and-rss-feeds.md
+++ b/docs/03-api-and-rss-feeds.md
@@ -114,24 +114,35 @@ The key is validated against its date window (`begin_date` / `end_date`) and, if
 
 A user account that is a member of the organisation (an `OrganizationUser` record exists) sees that organisation's data automatically after logging in via the session-based endpoints.
 
-### Including public organisations alongside private data
+### Including public sites alongside private data
 
-Both caller types can append `?include_public=true` to any request to also receive data from organisations that have `make_api_public = True`.
+Identified callers can append `?include_public=true` to any request to add the scopes of every *API public* site to their own — how a private site's frontend reads public content alongside its own.
 
 ```bash
 GET /articles/?include_public=true
 ```
 
+It is a no-op for an anonymous caller, whose scope already is exactly that set. Before subject scoping this parameter meant "adds public organisations"; it now adds public *sites'* subject scopes, and is declared in the OpenAPI schema rather than being undeclared-but-working as it was.
+
 ### Visibility rules summary
 
-| Caller | Visible organisations |
-|:-------|:----------------------|
-| Anonymous (no credentials) | Public orgs only |
-| API key with no org (`organization = null`) | Public orgs only |
-| API key bound to org X | Org X only (+ public if `?include_public=true`) |
-| Authenticated user member of org X | Org X only (+ public if `?include_public=true`) |
+Content visibility is **subject-scoped**: a caller sees a row when one of its subjects is in the `scope_subjects` of a site that caller can reach.
+
+| Caller | Visible subjects |
+|:-------|:-----------------|
+| Anonymous (no credentials) | Every *API public* site's scope |
+| API key bound to a site | That site's scope (+ public sites' if `?include_public=true`) |
+| API key with no site set | Nothing (+ public sites' if `?include_public=true`) |
+| Authenticated user, member of org X | The scopes of every site org X owns (+ public if `?include_public=true`) |
 
 > **Note:** An expired key or a key used from a non-allowed IP is treated as anonymous.
+
+Two endpoints are not content and do not follow this rule:
+
+- **`/teams/`** lists a team when `Team.api_listed` is on, **or** when the team owns a subject already in the caller's scope. The flag is the publication switch; the second clause exists so a private site's own authenticated frontend can list its own teams. It gates *listing*, not access — an unlisted team's articles and trials are governed by subject scope like everything else. The same rule decides whether a team appears nested inside an article or trial.
+- **`/organizations/`** remains organisation-keyed.
+
+**`/sponsors/`** is scoped indirectly: a sponsor carries no subject and is visible when at least one of its trials is in scope. Its `trials_count` counts only in-scope trials, so neither the number nor `?ordering=-trials_count` discloses trials the caller cannot read.
 
 ---
 
@@ -221,7 +232,7 @@ GET /articles/?team_id=1&subjects=1,3&published_date_after=2022-06-01&format=csv
 | Email templates | `GET /emails/context/{template_name}/` | `template_name` (path) | |
 | RSS feeds | `GET /feed/author/{orcid}/` | `orcid` (path) | |
 | RSS feeds | `GET /feed/trials/subject/{subject_slug}/` | `subject_slug` (path) | |
-| Stats | `GET /stats/` | `team`, `organization` (alias `org`), `subject`, `include_public` | See [Stats endpoint](#stats-endpoint) below |
+| Stats | `GET /stats/` | `team`, `site`, `subject`, `include_public`, `organization` (alias `org`, deprecated) | See [Stats endpoint](#stats-endpoint) below |
 | Sites | `GET /sites/` | None | Publicly readable sites as `{site_id, domain, name}`. **Unscoped by design** — it is the discovery entry point for callers that need a `site_id`, so it cannot require one. Everything returned is already public |
 | Subscriptions | `POST /subscriptions/new/` | `first_name`, `last_name`, `email`, `profile`, `list` | POST-only; `GET` returns `405` with `Allow: POST` |
 
@@ -354,7 +365,9 @@ GET /trials/search/?team_id=1&subject_id=2&search=diabetes&format=csv&all_result
 
 ```
 GET /stats/
-GET /stats/?organization=3
+GET /stats/?site=2
+GET /stats/?site=2&subject=1
+GET /stats/?organization=3   # deprecated, still supported
 GET /stats/?organization=3,7
 GET /stats/?team=12
 GET /stats/?organization=3&team=12
@@ -395,7 +408,9 @@ in-scope team(s) have subjects, but the key is always present):
 | `organization` | int or CSV of ints | Scope counts to one or more organisations. Alias `org` is accepted. |
 | `team` | int or CSV of ints | Scope counts to one or more teams. |
 | `subject` | int or CSV of ints | Scope counts to one or more subjects (union, not intersection — matches `team`/`organization`, not the `subject_id` filter on the list endpoints). Adds/populates `by_subject`. IDs only — subject slugs are not unique across teams, so there is no slug form of this filter here. |
-| `include_public` | bool (`true`/`false`) | Handled by the visibility layer — adds public-org data for identified callers. |
+| `site` | int or comma-separated ints | Scope to the subjects one or more sites publish. Sugar for `subject=` with that site's scope; intersects with an explicit `subject=` rather than overriding it. A site the caller cannot reach returns 404. |
+| `include_public` | bool (`true`/`false`) | Handled by the visibility layer — adds public sites' scopes for identified callers. |
+| `organization` (alias `org`) | int or comma-separated ints | **Deprecated** — prefer `site`. Organisations are no longer the visibility unit. Still works and still means exactly what it always meant; it is deprecated rather than redefined, because silently changing what a documented parameter returns is worse than keeping it. |
 
 When both `organization` and `team` are given the effective scope is their **intersection**: teams that belong to the requested org(s). The same applies to `subject` versus `team`/`organization`: a subject the caller can see but that doesn't belong to the requested team/org scope does **not** 404 — it returns a well-formed payload with every count at zero and `by_subject: []`.
 

--- a/docs/03-api-and-rss-feeds.md
+++ b/docs/03-api-and-rss-feeds.md
@@ -405,7 +405,6 @@ in-scope team(s) have subjects, but the key is always present):
 
 | Parameter | Type | Behaviour |
 |:----------|:-----|:----------|
-| `organization` | int or CSV of ints | Scope counts to one or more organisations. Alias `org` is accepted. |
 | `team` | int or CSV of ints | Scope counts to one or more teams. |
 | `subject` | int or CSV of ints | Scope counts to one or more subjects (union, not intersection — matches `team`/`organization`, not the `subject_id` filter on the list endpoints). Adds/populates `by_subject`. IDs only — subject slugs are not unique across teams, so there is no slug form of this filter here. |
 | `site` | int or comma-separated ints | Scope to the subjects one or more sites publish. Sugar for `subject=` with that site's scope; intersects with an explicit `subject=` rather than overriding it. A site the caller cannot reach returns 404. |
@@ -419,7 +418,7 @@ When both `organization` and `team` are given the effective scope is their **int
 - Lists **every subject in scope**, including ones with zero articles and zero trials — this is deliberate (it doubles as the data a subject picker needs) and differs from `/articles/stats/` and `/trials/stats/`, which aggregate off the through table and omit empty subjects.
 - Scope: subjects whose team is in the resolved team scope, further narrowed to `?subject=` when given. Ordered by `subject_name` ascending.
 - Per-subject counts are `articles`, `trials`, `authors`, `sources` — **no per-subject `subscribers`**. With `Lists` as the only path from a subscriber to a subject, that number would describe list-tagging more than the subject itself.
-- `sources` counts distinct **domains** (matching the top-level `sources.total` semantics), not feed rows — two RSS feeds on the same domain count once. A `Sources` row with `subject` unset (`null`) is excluded from every `by_subject` row and, when `?subject=` is applied, from the filtered totals too.
+- `sources` counts distinct **domains** (matching the top-level `sources.total` semantics), not feed rows — two RSS feeds on the same domain count once. A `Sources` row with `subject` unset (`null`) is excluded from every `by_subject` row and from the totals, with or without `?subject=` — content counts are scoped to the caller's visible subjects, and a NULL subject matches none of them. This matches `/sources/`, where such a row has always been unreachable.
 - Neither `authors` nor `sources` in a `by_subject` row sums to the top-level total, and that's correct: both are *distinct within that subject*. An author publishing under two subjects appears in both rows and once at the top; a domain feeding two subjects likewise.
 - A trial with no subject assigned is excluded from every `by_subject` row, so a subject-filtered `trials` count can be lower than the team-scoped one. Coverage is now near-complete — measured 2026-09-09, 63 of 17,404 trials (0.4%) and 372 of 53,054 articles (0.7%) carry no subject — so the gap is small, but it is a gap, not a bug.
 

--- a/mcp-server/tests/test_schema_contract.py
+++ b/mcp-server/tests/test_schema_contract.py
@@ -82,6 +82,13 @@ def test_detail_endpoint_exists_in_schema(fn, path, schema_params):
 KNOWN_UNEXPOSED_PARAMS = {
 	"/articles/": {
 		"format",  # CSV — no export tool, see STAGE-2 plan "Risks"
+		# Adds public sites' scopes to an *identified* caller's own scope.
+		# GregoryClient sends no Authorization header (client.py) -- this
+		# server is always an anonymous caller upstream, and an anonymous
+		# caller's scope already IS the union of every public site's scope.
+		# So the parameter is a provable no-op here; exposing it would put a
+		# knob on the tool that cannot change any result.
+		"include_public",
 		# Not a *tool* parameter — no LLM caller ever chooses it. GregoryClient.get()
 		# adds it transport-side to every upstream call from its own per-request
 		# resolution (env override, else inbound Host via GET /sites/) — see
@@ -95,6 +102,13 @@ KNOWN_UNEXPOSED_PARAMS = {
 	},
 	"/trials/": {
 		"format",
+		# Adds public sites' scopes to an *identified* caller's own scope.
+		# GregoryClient sends no Authorization header (client.py) -- this
+		# server is always an anonymous caller upstream, and an anonymous
+		# caller's scope already IS the union of every public site's scope.
+		# So the parameter is a provable no-op here; exposing it would put a
+		# knob on the tool that cannot change any result.
+		"include_public",
 		"site_id",  # see /articles/'s entry above — same transport-level injection
 		"source_id",
 		"subjects",


### PR DESCRIPTION
Last of the four Phase 4 PRs. Converts `api/views.py` (16), `serializers/*` (3) and `pagination.py` (1) — the API surface and its cache keys together, as the plan requires: splitting them would leave a response whose rows are subject-selected while its fields are org-masked.

[#861](https://github.com/brunoamaral/gregory-ai/pull/861) and [#862](https://github.com/brunoamaral/gregory-ai/pull/862) are merged. **This closes the 64-trial sitemap window** flagged on #861.

> **Corrected after review.** The first version of this description claimed every endpoint sharing the paginator selected rows by subject. That was **not true** — the three search views still scoped by organisation, which was a real leak. Copilot caught it. See "What the review found" below.

## The mixin, and what it turned up

`OrgVisibilityMixin` → `SubjectVisibilityMixin`, one query cheaper: the org version resolved org ids → team ids in Python because the through table holds team ids while the filter was on `Team.organization_id`. Subject ids *are* what the through table holds.

Its five users no longer share one rule:

| Viewset | Reaches subjects via |
|:--|:--|
| Articles, Trials | `subjects` M2M — `Exists()` over the through table |
| Subject | the row itself (`id__in`) |
| Sources | `subject` FK |
| TeamCategory | its own `subjects` M2M |
| **Team** | **not subject-scoped at all** |

## `/teams/` — the decision worth reviewing

Listed when `api_listed` is on **OR** the team owns a subject already in the caller's scope.

`api_listed` alone is the spec's literal rule and was the first cut. It has a cost that only appears with a second tenant: a private site's own authenticated frontend could not list its own teams, because those are exactly the teams an operator marks unlisted. The second clause buys that back without reopening anything — a caller who can already read a team's articles learns nothing new from its name — and since it only ever *adds*, both cases the flag exists for stay expressible.

The serializer's nested-team stripping applies the identical rule. **If you change one, change the other** — noted in both.

The team tests passed under this change *without exercising it* (their fixture had no subjects, so the second clause never fired). Added a fixture and assertions that do, in both directions.

## `/sponsors/` — scoping it never had

A sponsor carries no subject and reaches content only through its trials, so it's filtered on `Exists()` over trials in scope. **`trials_count` is scoped too**: it's orderable, so an unscoped count would leak the size of what the caller can't read, then leak it again through `?ordering=-trials_count`. Post-prune this hides 59 of 4,686 (1.3%), all subject 15.

## `/stats/` — `?site=`, `?organization=` deprecated

`?site=` resolves to that site's `scope_subjects` and folds into the same `subject_ids` the existing machinery validates and caches. Each requested site is validated individually; nonexistent, empty-scope and unreachable all 404 identically, since distinguishing them would leak which site IDs are real.

`?organization=` keeps its exact old meaning and is marked deprecated. Silently redefining a documented parameter is the failure this project exists to prevent.

## What the review found

Nine findings, **all real**, all fixed. Six were leaks:

| # | Finding | Consequence |
|--:|:--|:--|
| 1 | Search views scoped by org, not subject | **Naming an out-of-scope subject returned real data.** My error: I applied the spec's team-addressed-route exemption to `/search/`, which the spec's own table puts under "subject in visible scope — direct" |
| 2 | `get_clinical_trials()` / `get_articles()` unscoped | A visible article disclosed a hidden trial's id, title, summary, link |
| 3 | `article_subject_relevances` not stripped | The one relation the mixin missed — leaked a hidden subject's name and `is_relevant` |
| 4 | Category aggregates unscoped | Rows filtered, counts not — leaked via totals and `?ordering=-authors_count_annotated` |
| 6 | `/stats/` default content filter | No `?subject=`/`?site=` → aggregates still org-scoped, inflating every total |
| 7 | by_subject cache key | **Cross-tenant**: two site-bound keys in one org could read each other's payload |
| 5, 8, 9 | Author-ID selection order; `?site=` union validation; duplicate docs row | |

Every leak fix has a regression **confirmed failing against the pre-fix code**.

Two corrections made while fixing:

- An earlier attempt counted content with **no subject** towards category aggregates. `SubjectVisibilityMixin` excludes subject-less rows (`test_subject_less_article_stays_invisible`), so a category would have reported rows its own list endpoint won't return.
- A `Sources` row with `subject=None` was counted in `/stats/` but has always been unreachable on `/sources/` (`subject_id__in` never matches NULL). The two now agree.

`stats_payload_cache_key()` is now module-level and shared with the tests, which had been rebuilding the key string by hand — the reason they broke the moment a component was added, and the reason this class of bug could hide.

## Deliberately still org-keyed, per spec

`/organizations/`; the `team_id` validation on `by_team_subject`, `by_team_category`, `categories/{id}/authors`, `teams/{id}/subjects/{id}/categories`; and `/stats/`'s `?team=`/`?organization=`.

## Verification

- Full Django suite **3,378 passed**, 0 failed
- `mcp-server` **208 passed**, contract test included
- `schema.yml` regenerated, then regenerated again and diffed — byte-identical
- `ruff` clean

## Still outstanding for Phase 4

`gregory/admin.py` (8 sites) is PR 3 and not in here — it converts to `source → team → organization`, a different rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)