### PR TITLE
Phase 4c: scope the Django admin via source → team → organisation

### DIFF
--- a/django/gregory/admin.py
+++ b/django/gregory/admin.py
@@ -129,11 +129,19 @@ class BaseOrganizationFilter(admin.SimpleListFilter):
 
 
 class ArticleOrganizationFilter(BaseOrganizationFilter):
-	"""Filter articles by organisation (via teams M2M → organization)."""
+	"""Filter articles by organisation, via sources -> team -> organization.
+
+	Matches OrganizationFilterMixin's content-attribution path below, not the
+	curated `teams` M2M this used before: a `teams`-based filter would go
+	empty-handed on any article the base queryset already shows precisely
+	*because* nobody has curated it yet.
+	"""
 
 	def queryset(self, request, queryset):
 		if self.value():
-			return queryset.filter(teams__organization__id=self.value()).distinct()
+			return queryset.filter(
+				sources__team__organization__id=self.value()
+			).distinct()
 		return queryset
 
 
@@ -150,6 +158,16 @@ class OrganizationFilterMixin:
 	"""
 	Mixin to restrict admin queryset visibility based on user's organization.
 	Superusers see everything; staff users only see objects from their organization.
+
+	Content (Articles, Trials -- any model carrying a `sources` M2M) is
+	deliberately scoped through source -> team -> organisation, NOT through
+	`teams`/`subjects`. Those are assigned by a curator after the fact, so
+	scoping admin on them would hide precisely the not-yet-curated rows this
+	admin exists to show -- a source, by contrast, is attached at ingestion
+	and so is complete for all but a sliver of legacy rows. See
+	docs/06-organisations-teams-and-sites.md ("Admin visibility") for the
+	full rationale, including why this deliberately does NOT match the
+	subject-scoping the public API uses.
 	"""
 
 	def get_queryset(self, request):
@@ -171,14 +189,110 @@ class OrganizationFilterMixin:
 		if hasattr(qs.model, "team"):
 			return qs.filter(team__organization__id__in=user_orgs)
 
-		# If the model has multiple teams (M2M), filter by any team's organization
+		# Content: attribute through source -> team -> organisation (see class
+		# docstring). A row whose sources all belong to other organisations --
+		# or which has no source at all -- simply never matches this filter,
+		# which is what makes a sourceless row superuser-only without a
+		# separate check for it.
 		try:
-			# Check if 'teams' is a M2M field
-			qs.model._meta.get_field("teams")
+			qs.model._meta.get_field("sources")
 		except FieldDoesNotExist:
-			# Model has no 'teams' field; fall through to the unscoped queryset.
+			# Model has neither an organization/team path nor a `sources` M2M;
+			# it isn't org-scoped at all, so leave it unfiltered.
 			return qs
-		return qs.filter(teams__organization__id__in=user_orgs).distinct()
+		return qs.filter(sources__team__organization__id__in=user_orgs).distinct()
+
+
+def _scoped_subject_ids():
+	"""Every Subject ID that appears in at least one site's ``scope_subjects``.
+
+	Unlike ``gregory.visibility._public_subject_ids()`` this does NOT filter
+	by ``api_public``: the admin curation queue below cares whether a subject
+	has been curated onto *any* site, published or not, not whether that
+	site is public yet.
+	"""
+	from sitesettings.models import CustomSetting
+
+	return set(
+		CustomSetting.objects.exclude(scope_subjects__isnull=True).values_list(
+			"scope_subjects__id", flat=True
+		)
+	)
+
+
+class UnpublishedContentFilter(admin.SimpleListFilter):
+	"""Curation queue: content none of whose subjects is in any site's scope.
+
+	Django's ChangeList always calls ``ModelAdmin.get_queryset()`` first and
+	passes each list filter the result, so for a non-superuser the queryset
+	this ``.queryset()`` receives is already restricted to their own
+	organisation's content by ``OrganizationFilterMixin`` (source -> team ->
+	organisation). Excluding "has a scoped subject" on top of that is what
+	makes this the caller's OWN organisation's curation queue rather than
+	everyone's -- curation state carries no organisation of its own to check,
+	so a filter that queried it in isolation would show every organisation's
+	uncurated content to every staff member. Superusers get the true global
+	queue, for the same reason: their base queryset is everything.
+	"""
+
+	title = "site scope"
+	parameter_name = "unpublished"
+
+	def lookups(self, request, model_admin):
+		return (("1", "Not in any site's scope (curation queue)"),)
+
+	def queryset(self, request, queryset):
+		if self.value() != "1":
+			return queryset
+		return queryset.exclude(subjects__in=_scoped_subject_ids())
+
+
+class SiteScopeFilter(admin.SimpleListFilter):
+	"""Narrow the changelist to one site the caller's organisation(s) own.
+
+	A pure narrower, never a widener: this ``.queryset()`` runs as an
+	additional ``.filter()`` on top of the already organisation-scoped
+	queryset ``OrganizationFilterMixin`` produced (see UnpublishedContentFilter's
+	docstring for why list filters always see that queryset, not the raw
+	table) -- so even a tampered ``?site=`` naming a site another
+	organisation owns can only narrow further within rows already limited to
+	the caller's own organisation, never add another organisation's content.
+	``lookups()`` still restricts the offered choices to the caller's own
+	organisation(s) via ``OrganizationSite``, so the dropdown itself never
+	discloses another organisation's site domains. Superusers may pick any
+	site.
+	"""
+
+	title = "site"
+	parameter_name = "site"
+
+	def lookups(self, request, model_admin):
+		from sitesettings.models import CustomSetting
+
+		if request.user.is_superuser:
+			settings_qs = CustomSetting.objects.select_related("site")
+		else:
+			user_orgs = get_user_organizations(request.user)
+			site_ids = OrganizationSite.objects.filter(
+				organization_id__in=user_orgs
+			).values_list("site_id", flat=True)
+			settings_qs = CustomSetting.objects.filter(
+				site_id__in=site_ids
+			).select_related("site")
+		return [
+			(cs.site_id, cs.site.domain)
+			for cs in settings_qs.order_by("site__domain")
+		]
+
+	def queryset(self, request, queryset):
+		if not self.value():
+			return queryset
+		from sitesettings.models import CustomSetting
+
+		subject_ids = CustomSetting.objects.filter(
+			site_id=self.value()
+		).values_list("scope_subjects__id", flat=True)
+		return queryset.filter(subjects__id__in=subject_ids).distinct()
 
 
 class ArticleTrialReferenceInline(admin.TabularInline):
@@ -831,6 +945,8 @@ class ArticleAdmin(OrganizationFilterMixin, SourceBulkActionMixin, SimpleHistory
 	search_fields = ["article_id", "title", "doi"]
 	list_filter = [
 		ArticleOrganizationFilter,
+		SiteScopeFilter,
+		UnpublishedContentFilter,
 		("teams", OrganizationRestrictedFieldListFilter),
 		("subjects", OrganizationRestrictedFieldListFilter),
 		("sources", OrganizationRestrictedFieldListFilter),
@@ -1391,6 +1507,8 @@ class TrialAdmin(OrganizationFilterMixin, SourceBulkActionMixin, SimpleHistoryAd
 		"ctg_detailed_description",
 	]
 	list_filter = [
+		SiteScopeFilter,
+		UnpublishedContentFilter,
 		("teams", OrganizationRestrictedFieldListFilter),
 		("subjects", OrganizationRestrictedFieldListFilter),
 		("sources", OrganizationRestrictedFieldListFilter),

--- a/django/gregory/admin.py
+++ b/django/gregory/admin.py
@@ -244,7 +244,7 @@ class UnpublishedContentFilter(admin.SimpleListFilter):
 	def queryset(self, request, queryset):
 		if self.value() != "1":
 			return queryset
-		return queryset.exclude(subjects__in=_scoped_subject_ids())
+		return queryset.exclude(subjects__id__in=_scoped_subject_ids())
 
 
 class SiteScopeFilter(admin.SimpleListFilter):
@@ -279,10 +279,17 @@ class SiteScopeFilter(admin.SimpleListFilter):
 			settings_qs = CustomSetting.objects.filter(
 				site_id__in=site_ids
 			).select_related("site")
-		return [
-			(cs.site_id, cs.site.domain)
-			for cs in settings_qs.order_by("site__domain")
-		]
+		# CustomSetting.site is a plain FK, NOT unique, so two rows for one
+		# site would offer the same domain twice. Exactly this shape produced
+		# duplicate rows in GET /sites/ (PR #859), so it is a latent bug here
+		# rather than a hypothetical one -- there happen to be no duplicate
+		# rows today. Selecting distinct (site_id, domain) pairs in SQL keeps
+		# the dropdown one-entry-per-site whatever the table holds.
+		return list(
+			settings_qs.order_by("site__domain")
+			.values_list("site_id", "site__domain")
+			.distinct()
+		)
 
 	def queryset(self, request, queryset):
 		if not self.value():

--- a/django/gregory/admin.py
+++ b/django/gregory/admin.py
@@ -235,7 +235,7 @@ class UnpublishedContentFilter(admin.SimpleListFilter):
 	queue, for the same reason: their base queryset is everything.
 	"""
 
-	title = "site scope"
+	title = "curation queue"
 	parameter_name = "unpublished"
 
 	def lookups(self, request, model_admin):

--- a/django/gregory/tests/test_admin_article_crossref_refresh.py
+++ b/django/gregory/tests/test_admin_article_crossref_refresh.py
@@ -18,7 +18,7 @@ from django.urls import reverse
 from organizations.models import Organization
 
 from gregory.classes import SciencePaper
-from gregory.models import Articles, Authors, Team
+from gregory.models import Articles, Authors, Sources, Team
 from gregory.services.crossref_refresh import build_change_reason
 
 User = get_user_model()
@@ -58,6 +58,14 @@ class ArticleCrossrefRefreshViewTest(TestCase):
 			doi="10.1000/xyz",
 		)
 		self.article.teams.add(self.team)
+		# OrganizationFilterMixin scopes content through source -> team ->
+		# organisation (not through `teams`, see the mixin's docstring), so
+		# test_staff_without_change_permission_is_forbidden's non-superuser
+		# needs this to resolve the article via get_object() at all.
+		self.source = Sources.objects.create(
+			name="Source", source_for="science paper", team=self.team
+		)
+		self.article.sources.add(self.source)
 
 		self.superuser = User.objects.create_superuser(
 			username="admin", email="admin@example.com", password="pw"

--- a/django/gregory/tests/test_admin_curation_queue_filter.py
+++ b/django/gregory/tests/test_admin_curation_queue_filter.py
@@ -1,0 +1,161 @@
+"""
+Tests for gregory.admin.UnpublishedContentFilter — the "not in any site's
+scope" admin list filter (Phase 4 PR 3, admin scoping).
+
+This is the curation queue: content none of whose subjects has been added to
+any site's `scope_subjects` yet. The filter's `.queryset()` runs on whatever
+queryset Django's ChangeList hands it, which is always the ModelAdmin's OWN
+`get_queryset(request)` result first (see ChangeList.get_queryset in
+django/contrib/admin/views/main.py) -- list filters chain on top of that, they
+never see the raw table. That ordering is load-bearing here: it is what scopes
+the queue to the caller's OWN organisation for free, per
+OrganizationFilterMixin's source -> team -> organisation scoping. A version of
+this filter that queried Articles/Trials directly instead of filtering the
+queryset it was given would leak every organisation's uncurated content to
+every staff member -- test_staff_curation_queue_has_no_cross_org_leak pins
+that down explicitly.
+
+Run with:
+    docker exec gregory python manage.py test gregory.tests.test_admin_curation_queue_filter
+"""
+
+from django.contrib import admin
+from django.contrib.admin.sites import AdminSite
+from django.contrib.auth import get_user_model
+from django.contrib.sites.models import Site
+from django.test import TestCase, RequestFactory
+from organizations.models import Organization, OrganizationUser
+
+from gregory.admin import OrganizationFilterMixin, UnpublishedContentFilter
+from gregory.models import Articles, Sources, Subject, Team
+from sitesettings.models import CustomSetting
+
+User = get_user_model()
+
+
+class _ArticleOrgAdmin(OrganizationFilterMixin, admin.ModelAdmin):
+	"""Minimal admin: just enough to exercise get_queryset() + the filter."""
+
+
+class UnpublishedContentFilterTests(TestCase):
+	def setUp(self):
+		self.factory = RequestFactory()
+		self.site = AdminSite()
+
+		self.org_a = Organization.objects.create(name="Org A", slug="uq-org-a")
+		self.org_b = Organization.objects.create(name="Org B", slug="uq-org-b")
+		self.team_a = Team.objects.create(
+			organization=self.org_a, name="Team A", slug="uq-team-a"
+		)
+		self.team_b = Team.objects.create(
+			organization=self.org_b, name="Team B", slug="uq-team-b"
+		)
+		self.source_a = Sources.objects.create(
+			name="Source A", source_for="science paper", team=self.team_a
+		)
+		self.source_b = Sources.objects.create(
+			name="Source B", source_for="science paper", team=self.team_b
+		)
+
+		# subject_a_published sits in a site's scope; subject_a_unpublished and
+		# subject_b sit in none.
+		self.subject_a_published = Subject.objects.create(
+			subject_name="A Published", subject_slug="uq-a-pub", team=self.team_a
+		)
+		self.subject_a_unpublished = Subject.objects.create(
+			subject_name="A Unpublished", subject_slug="uq-a-unpub", team=self.team_a
+		)
+		self.subject_b = Subject.objects.create(
+			subject_name="B", subject_slug="uq-b", team=self.team_b
+		)
+
+		django_site = Site.objects.create(domain="uq-site.test", name="UQ site")
+		self.custom_setting = CustomSetting.objects.create(
+			site=django_site, title="UQ site settings"
+		)
+		self.custom_setting.scope_subjects.add(self.subject_a_published)
+
+		self.article_a_published = Articles.objects.create(
+			title="A published", link="https://example.com/uq-a-pub"
+		)
+		self.article_a_published.sources.add(self.source_a)
+		self.article_a_published.subjects.add(self.subject_a_published)
+
+		self.article_a_unpublished = Articles.objects.create(
+			title="A unpublished", link="https://example.com/uq-a-unpub"
+		)
+		self.article_a_unpublished.sources.add(self.source_a)
+		self.article_a_unpublished.subjects.add(self.subject_a_unpublished)
+
+		self.article_a_no_subjects = Articles.objects.create(
+			title="A no subjects", link="https://example.com/uq-a-none"
+		)
+		self.article_a_no_subjects.sources.add(self.source_a)
+
+		self.article_b_unpublished = Articles.objects.create(
+			title="B unpublished", link="https://example.com/uq-b-unpub"
+		)
+		self.article_b_unpublished.sources.add(self.source_b)
+		self.article_b_unpublished.subjects.add(self.subject_b)
+
+		self.staff_a = User.objects.create_user(username="uq-staff-a", password="pw")
+		OrganizationUser.objects.create(organization=self.org_a, user=self.staff_a)
+
+		self.superuser = User.objects.create_superuser(
+			username="uq-root", email="uq-root@e.com", password="pw"
+		)
+
+	def _filter(self, value=None):
+		params = {"unpublished": [value]} if value is not None else {}
+		return UnpublishedContentFilter(
+			request=None, params=params, model=Articles, model_admin=_ArticleOrgAdmin
+		)
+
+	def _base_queryset(self, user):
+		model_admin = _ArticleOrgAdmin(Articles, self.site)
+		request = self.factory.get("/admin/")
+		request.user = user
+		return model_admin.get_queryset(request)
+
+	def test_lookups_is_a_single_opt_in_choice(self):
+		self.assertEqual(
+			self._filter().lookups(None, None),
+			(("1", "Not in any site's scope (curation queue)"),),
+		)
+
+	def test_no_value_returns_queryset_unchanged(self):
+		result = self._filter().queryset(None, Articles.objects.all())
+		self.assertEqual(result.count(), Articles.objects.count())
+
+	def test_excludes_content_with_a_scoped_subject(self):
+		result = self._filter("1").queryset(None, Articles.objects.all())
+		self.assertNotIn(self.article_a_published, result)
+
+	def test_includes_content_with_an_unscoped_subject(self):
+		result = self._filter("1").queryset(None, Articles.objects.all())
+		self.assertIn(self.article_a_unpublished, result)
+
+	def test_includes_content_with_no_subjects_at_all(self):
+		# Vacuously true: "none of its subjects is scoped" holds when there
+		# are no subjects to check.
+		result = self._filter("1").queryset(None, Articles.objects.all())
+		self.assertIn(self.article_a_no_subjects, result)
+
+	def test_staff_curation_queue_has_no_cross_org_leak(self):
+		"""The leak that matters most: stated as a bare "not in any site's
+		scope" query, org B's uncurated article would show up for an org-A
+		staff member too. Chaining onto get_queryset()'s result -- exactly
+		what Django's ChangeList does -- must prevent that."""
+		base_qs = self._base_queryset(self.staff_a)
+		result = self._filter("1").queryset(None, base_qs)
+		self.assertIn(self.article_a_unpublished, result)
+		self.assertIn(self.article_a_no_subjects, result)
+		self.assertNotIn(self.article_b_unpublished, result)
+		self.assertNotIn(self.article_a_published, result)
+
+	def test_superuser_sees_the_global_curation_queue(self):
+		base_qs = self._base_queryset(self.superuser)
+		result = self._filter("1").queryset(None, base_qs)
+		self.assertIn(self.article_a_unpublished, result)
+		self.assertIn(self.article_b_unpublished, result)
+		self.assertNotIn(self.article_a_published, result)

--- a/django/gregory/tests/test_admin_org_filter.py
+++ b/django/gregory/tests/test_admin_org_filter.py
@@ -5,6 +5,13 @@ queryset scoping that limits non-superusers to their own organisation's objects.
 Guards the fix where a bare `except: pass` could silently return the UNFILTERED
 queryset (an org-visibility leak) when the team-scoping branch raised.
 
+Content (Articles, Trials) is scoped through source -> team -> organisation,
+deliberately NOT through the model's own `teams` M2M -- see
+OrganizationFilterMixin's docstring in gregory/admin.py for the rationale.
+These tests attach `sources`, not `teams`, to pin that down, and
+test_article_scoped_via_its_sources_team_not_its_own_teams_field asserts the
+divergence directly.
+
 Run with:
     docker exec gregory python manage.py test gregory.tests.test_admin_org_filter
 """
@@ -16,13 +23,17 @@ from django.test import TestCase, RequestFactory
 from organizations.models import Organization, OrganizationUser
 
 from gregory.admin import OrganizationFilterMixin
-from gregory.models import Articles, Authors, Team
+from gregory.models import Articles, Authors, Sources, Team, Trials
 
 User = get_user_model()
 
 
 class _ArticleOrgAdmin(OrganizationFilterMixin, admin.ModelAdmin):
-	"""Minimal admin exercising the mixin on a model with a `teams` M2M."""
+	"""Minimal admin exercising the mixin on a model with a `sources` M2M."""
+
+
+class _TrialOrgAdmin(OrganizationFilterMixin, admin.ModelAdmin):
+	"""Minimal admin exercising the mixin on Trials, the other content model."""
 
 
 class _AuthorOrgAdmin(OrganizationFilterMixin, admin.ModelAdmin):
@@ -42,15 +53,40 @@ class OrganizationFilterMixinTests(TestCase):
 		self.team_b = Team.objects.create(
 			organization=self.org_b, name="Team B", slug="team-b-admin"
 		)
+		self.source_a = Sources.objects.create(
+			name="Source A", source_for="science paper", team=self.team_a
+		)
+		self.source_b = Sources.objects.create(
+			name="Source B", source_for="science paper", team=self.team_b
+		)
+		self.trial_source_a = Sources.objects.create(
+			name="Trial Source A", source_for="trials", team=self.team_a
+		)
+		self.trial_source_b = Sources.objects.create(
+			name="Trial Source B", source_for="trials", team=self.team_b
+		)
 
 		self.article_a = Articles.objects.create(
 			title="Article A", link="https://example.com/a"
 		)
-		self.article_a.teams.add(self.team_a)
+		self.article_a.sources.add(self.source_a)
 		self.article_b = Articles.objects.create(
 			title="Article B", link="https://example.com/b"
 		)
-		self.article_b.teams.add(self.team_b)
+		self.article_b.sources.add(self.source_b)
+		# No source at all: attributable to no organisation (spec rule 5).
+		self.article_sourceless = Articles.objects.create(
+			title="Article sourceless", link="https://example.com/sourceless"
+		)
+
+		self.trial_a = Trials.objects.create(
+			title="Trial A", link="https://example.com/trial-a"
+		)
+		self.trial_a.sources.add(self.trial_source_a)
+		self.trial_b = Trials.objects.create(
+			title="Trial B", link="https://example.com/trial-b"
+		)
+		self.trial_b.sources.add(self.trial_source_b)
 
 		# Non-superuser belonging only to org A.
 		self.user = User.objects.create_user(username="org-a-user", password="pw")
@@ -78,9 +114,42 @@ class OrganizationFilterMixinTests(TestCase):
 		self.assertIn(self.article_a, qs)
 		self.assertNotIn(self.article_b, qs)
 
+	def test_non_superuser_sees_only_their_org_trials(self):
+		# Same rule, other content model: Trials -> sources -> team -> org.
+		qs = self._queryset_for(_TrialOrgAdmin, Trials, self.user)
+		self.assertIn(self.trial_a, qs)
+		self.assertNotIn(self.trial_b, qs)
+
+	def test_superuser_sees_sourceless_article(self):
+		qs = self._queryset_for(_ArticleOrgAdmin, Articles, self.superuser)
+		self.assertIn(self.article_sourceless, qs)
+
+	def test_non_superuser_never_sees_sourceless_article(self):
+		# Spec rule 5: content with no source at all resolves to no
+		# organisation, so it is superuser-only. Not a special case in the
+		# mixin -- just what the source->team->org filter naturally excludes,
+		# for every non-superuser regardless of which org they belong to.
+		qs = self._queryset_for(_ArticleOrgAdmin, Articles, self.user)
+		self.assertNotIn(self.article_sourceless, qs)
+
+	def test_article_scoped_via_its_sources_team_not_its_own_teams_field(self):
+		# An article curated onto org A's team via the `teams` M2M, but whose
+		# only source belongs to org B, must be scoped by the SOURCE's team --
+		# not by the article's own (curator-assigned, sometimes-absent)
+		# `teams` field. Fails under the pre-change `teams`-based scoping,
+		# which would have shown this to the org-A user.
+		mismatched = Articles.objects.create(
+			title="Mismatched", link="https://example.com/mismatched"
+		)
+		mismatched.sources.add(self.source_b)
+		mismatched.teams.add(self.team_a)
+		qs = self._queryset_for(_ArticleOrgAdmin, Articles, self.user)
+		self.assertNotIn(mismatched, qs)
+
 	def test_model_without_teams_falls_through_unscoped(self):
-		# Authors has no organisation/team/teams: the FieldDoesNotExist branch
-		# returns the queryset unchanged (these models aren't org-scoped).
+		# Authors has no organisation/team/sources: the FieldDoesNotExist
+		# branch returns the queryset unchanged (these models aren't
+		# org-scoped).
 		author = Authors.objects.create(given_name="Jane", family_name="Doe")
 		qs = self._queryset_for(_AuthorOrgAdmin, Authors, self.user)
 		self.assertIn(author, qs)

--- a/django/gregory/tests/test_admin_site_scope_filter.py
+++ b/django/gregory/tests/test_admin_site_scope_filter.py
@@ -1,0 +1,197 @@
+"""
+Tests for gregory.admin.SiteScopeFilter — the "site" admin list filter that
+narrows a changelist to one site the caller's organisation(s) own (Phase 4 PR
+3, admin scoping).
+
+A pure narrower: `.queryset()` runs on top of whatever OrganizationFilterMixin
+already returned (see UnpublishedContentFilterTests' module docstring for why
+that ordering is guaranteed), so picking a site can only remove rows from an
+already org-scoped queryset -- never add another organisation's content, even
+if the site id named belongs to another organisation entirely.
+`test_selecting_a_foreign_site_id_cannot_widen_beyond_own_org` pins that down
+directly. `lookups()` is tested separately because it is the other half of the
+guarantee: it must not even disclose another organisation's site domains in
+the dropdown.
+
+Run with:
+    docker exec gregory python manage.py test gregory.tests.test_admin_site_scope_filter
+"""
+
+from django.contrib import admin
+from django.contrib.admin.sites import AdminSite
+from django.contrib.auth import get_user_model
+from django.contrib.sites.models import Site
+from django.test import TestCase, RequestFactory
+from organizations.models import Organization, OrganizationUser
+
+from gregory.admin import OrganizationFilterMixin, SiteScopeFilter
+from gregory.models import Articles, OrganizationSite, Sources, Subject, Team
+from sitesettings.models import CustomSetting
+
+User = get_user_model()
+
+
+class _ArticleOrgAdmin(OrganizationFilterMixin, admin.ModelAdmin):
+	"""Minimal admin: just enough to exercise get_queryset() + the filter."""
+
+
+class SiteScopeFilterTests(TestCase):
+	def setUp(self):
+		self.factory = RequestFactory()
+		self.admin_site = AdminSite()
+
+		self.org_a = Organization.objects.create(name="Org A", slug="ssf-org-a")
+		self.org_b = Organization.objects.create(name="Org B", slug="ssf-org-b")
+		self.team_a = Team.objects.create(
+			organization=self.org_a, name="Team A", slug="ssf-team-a"
+		)
+		self.team_b = Team.objects.create(
+			organization=self.org_b, name="Team B", slug="ssf-team-b"
+		)
+		self.source_a = Sources.objects.create(
+			name="Source A", source_for="science paper", team=self.team_a
+		)
+		self.source_b = Sources.objects.create(
+			name="Source B", source_for="science paper", team=self.team_b
+		)
+
+		self.subject_a1 = Subject.objects.create(
+			subject_name="A1", subject_slug="ssf-a1", team=self.team_a
+		)
+		self.subject_a2 = Subject.objects.create(
+			subject_name="A2", subject_slug="ssf-a2", team=self.team_a
+		)
+		self.subject_b = Subject.objects.create(
+			subject_name="B", subject_slug="ssf-b", team=self.team_b
+		)
+
+		self.django_site_a1 = Site.objects.create(
+			domain="ssf-a1.test", name="Org A site 1"
+		)
+		self.setting_a1 = CustomSetting.objects.create(
+			site=self.django_site_a1, title="Org A site 1 settings"
+		)
+		self.setting_a1.scope_subjects.add(self.subject_a1)
+		OrganizationSite.objects.create(
+			organization=self.org_a, site=self.django_site_a1, is_default=True
+		)
+
+		self.django_site_a2 = Site.objects.create(
+			domain="ssf-a2.test", name="Org A site 2"
+		)
+		self.setting_a2 = CustomSetting.objects.create(
+			site=self.django_site_a2, title="Org A site 2 settings"
+		)
+		self.setting_a2.scope_subjects.add(self.subject_a2)
+		OrganizationSite.objects.create(organization=self.org_a, site=self.django_site_a2)
+
+		self.django_site_b = Site.objects.create(
+			domain="ssf-b.test", name="Org B site"
+		)
+		self.setting_b = CustomSetting.objects.create(
+			site=self.django_site_b, title="Org B site settings"
+		)
+		self.setting_b.scope_subjects.add(self.subject_b)
+		OrganizationSite.objects.create(
+			organization=self.org_b, site=self.django_site_b, is_default=True
+		)
+
+		self.article_a1 = Articles.objects.create(
+			title="A1", link="https://example.com/ssf-a1"
+		)
+		self.article_a1.sources.add(self.source_a)
+		self.article_a1.subjects.add(self.subject_a1)
+
+		self.article_a2 = Articles.objects.create(
+			title="A2", link="https://example.com/ssf-a2"
+		)
+		self.article_a2.sources.add(self.source_a)
+		self.article_a2.subjects.add(self.subject_a2)
+
+		self.article_b = Articles.objects.create(
+			title="B", link="https://example.com/ssf-b"
+		)
+		self.article_b.sources.add(self.source_b)
+		self.article_b.subjects.add(self.subject_b)
+
+		self.staff_a = User.objects.create_user(username="ssf-staff-a", password="pw")
+		OrganizationUser.objects.create(organization=self.org_a, user=self.staff_a)
+
+		self.superuser = User.objects.create_superuser(
+			username="ssf-root", email="ssf-root@e.com", password="pw"
+		)
+
+	def _filter(self, request, value=None):
+		params = {"site": [str(value)]} if value is not None else {}
+		return SiteScopeFilter(
+			request=request, params=params, model=Articles, model_admin=_ArticleOrgAdmin
+		)
+
+	def _request_for(self, user):
+		request = self.factory.get("/admin/")
+		request.user = user
+		return request
+
+	def _base_queryset(self, user):
+		model_admin = _ArticleOrgAdmin(Articles, self.admin_site)
+		return model_admin.get_queryset(self._request_for(user))
+
+	def test_staff_lookups_lists_only_their_own_org_sites(self):
+		request = self._request_for(self.staff_a)
+		choices = self._filter(request).lookups(request, None)
+		domains = [label for _, label in choices]
+		self.assertIn(self.django_site_a1.domain, domains)
+		self.assertIn(self.django_site_a2.domain, domains)
+		# Info hygiene: org B's site domain must not even appear in the
+		# dropdown offered to an org-A staff member.
+		self.assertNotIn(self.django_site_b.domain, domains)
+
+	def test_superuser_lookups_lists_every_site(self):
+		request = self._request_for(self.superuser)
+		choices = self._filter(request).lookups(request, None)
+		domains = [label for _, label in choices]
+		self.assertIn(self.django_site_a1.domain, domains)
+		self.assertIn(self.django_site_a2.domain, domains)
+		self.assertIn(self.django_site_b.domain, domains)
+
+	def test_no_value_returns_queryset_unchanged(self):
+		request = self._request_for(self.staff_a)
+		base_qs = self._base_queryset(self.staff_a)
+		result = self._filter(request).queryset(request, base_qs)
+		self.assertEqual(set(result), set(base_qs))
+
+	def test_queryset_narrows_to_the_selected_site(self):
+		request = self._request_for(self.staff_a)
+		base_qs = self._base_queryset(self.staff_a)
+		# Sanity: both of org A's own articles are visible before narrowing.
+		self.assertIn(self.article_a1, base_qs)
+		self.assertIn(self.article_a2, base_qs)
+
+		result = self._filter(request, self.django_site_a1.pk).queryset(
+			request, base_qs
+		)
+		self.assertIn(self.article_a1, result)
+		self.assertNotIn(self.article_a2, result)
+
+	def test_selecting_a_foreign_site_id_cannot_widen_beyond_own_org(self):
+		"""Rule 4: a site filter narrows, it never widens. Even if a curious
+		(or malicious) staff member crafts `?site=<org B's site id>` -- a
+		value `lookups()` never offered them -- chaining onto their own
+		org-scoped queryset means the result can only be a subset of their
+		own organisation's content, never org B's."""
+		request = self._request_for(self.staff_a)
+		base_qs = self._base_queryset(self.staff_a)
+		result = self._filter(request, self.django_site_b.pk).queryset(
+			request, base_qs
+		)
+		self.assertNotIn(self.article_b, result)
+		self.assertEqual(result.count(), 0)
+
+	def test_superuser_can_select_any_site(self):
+		request = self._request_for(self.superuser)
+		base_qs = self._base_queryset(self.superuser)
+		result = self._filter(request, self.django_site_b.pk).queryset(
+			request, base_qs
+		)
+		self.assertIn(self.article_b, result)
+		self.assertNotIn(self.article_a1, result)

--- a/django/gregory/tests/test_admin_site_scope_filter.py
+++ b/django/gregory/tests/test_admin_site_scope_filter.py
@@ -146,6 +146,24 @@ class SiteScopeFilterTests(TestCase):
 		# dropdown offered to an org-A staff member.
 		self.assertNotIn(self.django_site_b.domain, domains)
 
+	def test_a_site_with_two_customsetting_rows_appears_once(self):
+		"""CustomSetting.site is a plain FK, not unique.
+
+		Two rows for one site would otherwise offer the same domain twice in
+		the dropdown. Not hypothetical: exactly this shape produced duplicate
+		rows in GET /sites/ (PR #859). No duplicate rows exist in production
+		today, so without this test the guard would be unexercised.
+		"""
+		CustomSetting.objects.create(
+			site=self.django_site_a1, title="Second settings row for A1"
+		)
+		request = self._request_for(self.staff_a)
+		choices = self._filter(request).lookups(request, None)
+		domains = [label for _, label in choices]
+		self.assertEqual(domains.count(self.django_site_a1.domain), 1)
+		site_ids = [value for value, _ in choices]
+		self.assertEqual(len(site_ids), len(set(site_ids)))
+
 	def test_superuser_lookups_lists_every_site(self):
 		request = self._request_for(self.superuser)
 		choices = self._filter(request).lookups(request, None)

--- a/docs/03-api-and-rss-feeds.md
+++ b/docs/03-api-and-rss-feeds.md
@@ -144,6 +144,8 @@ Two endpoints are not content and do not follow this rule:
 
 **`/sponsors/`** is scoped indirectly: a sponsor carries no subject and is visible when at least one of its trials is in scope. Its `trials_count` counts only in-scope trials, so neither the number nor `?ordering=-trials_count` discloses trials the caller cannot read.
 
+> **Note:** This subject-scoped rule is the API's and RSS feeds' alone. The Django admin uses a deliberately different rule — see [06-organisations-teams-and-sites.md#admin-visibility](06-organisations-teams-and-sites.md#admin-visibility).
+
 ---
 
 ## Articles query parameters

--- a/docs/06-organisations-teams-and-sites.md
+++ b/docs/06-organisations-teams-and-sites.md
@@ -67,7 +67,17 @@ This is a design choice, not an inconsistency to fix:
 | Staff user, "Not in any site's scope" filter | Their own organisation's content that is in no site's `scope_subjects` yet — the curation queue |
 | Superuser | Everything, including content with no source at all |
 
-Content with no `Sources` row at all cannot be attributed to any organisation, so it is visible only to superusers. This is a small sliver of legacy data rather than a normal outcome of ingestion (measured on the development database, before the September 2026 prunes: 375 articles, 0 trials — production, having been pruned, is not directly comparable).
+Content with no `Sources` row at all cannot be attributed to any organisation, so it is visible only to superusers. A source is attached at ingestion, so a row without one never came through the normal pipeline — it was created by hand in the admin, or by an importer that failed before linking a source.
+
+Two different counts get quoted about this population, so to be exact about which is which:
+
+| Measured | Articles | Trials |
+|:---|---:|---:|
+| No `Sources` row at all (development database, pre-prune) | 375 | 0 |
+| …of those, also carrying a team, so they *lose* admin visibility under this rule | 370 | 0 |
+| **Remaining in production**, after the September 2026 prunes removed 364 of them | **6** | **0** |
+
+Production is the number that matters operationally: six articles move from "visible to their team's organisation" to "superuser only". There is no cross-organisation case — **zero** articles or trials have sources pointing at a different organisation than their curated teams, so nothing is being taken from one organisation and given to another.
 
 ### List filters
 

--- a/docs/06-organisations-teams-and-sites.md
+++ b/docs/06-organisations-teams-and-sites.md
@@ -52,6 +52,34 @@ See [03-api-and-rss-feeds.md](03-api-and-rss-feeds.md#accessing-private-organisa
 
 ---
 
+## Admin visibility
+
+The Django admin (`/admin/`) uses a different visibility rule than the public API and RSS feeds. The API and feeds are [subject-scoped](03-api-and-rss-feeds.md#visibility-rules-summary): a caller sees a row when one of its subjects sits in a site's `scope_subjects`. The admin is deliberately **not** — it scopes content through **source → team → organisation** instead.
+
+This is a design choice, not an inconsistency to fix:
+
+- A `Sources` row is attached at ingestion, before anyone has looked at the content. `subjects` and `teams` are assigned by a curator afterwards. Scoping the admin on subjects would hide exactly the not-yet-curated rows a curator needs to see in order to curate them.
+- Publication (which sites, and anonymous callers, can read) and editorial access (which staff member can edit a row) are independent policies. Changing one must never silently change the other.
+
+| Caller | Sees |
+|:-------|:-----|
+| Staff user | Content whose source's team belongs to one of their organisations, optionally narrowed to a site that organisation owns |
+| Staff user, "Not in any site's scope" filter | Their own organisation's content that is in no site's `scope_subjects` yet — the curation queue |
+| Superuser | Everything, including content with no source at all |
+
+Content with no `Sources` row at all cannot be attributed to any organisation, so it is visible only to superusers. This is a small sliver of legacy data rather than a normal outcome of ingestion (measured on the development database, before the September 2026 prunes: 375 articles, 0 trials — production, having been pruned, is not directly comparable).
+
+### List filters
+
+The Articles and Trials admin changelists each carry two filters built on this rule:
+
+- **Site** — narrows the (already organisation-scoped) list to one site the caller's organisation owns, via `OrganizationSite`. It can only narrow: `get_queryset()` applies the organisation scoping first, and the filter's own choices never include another organisation's sites.
+- **Not in any site's scope (curation queue)** — the same "not yet curated" set that's invisible to the API, but scoped to the caller's own organisation rather than shown globally, which would otherwise leak every organisation's uncurated content to every staff member. Superusers see the true global queue.
+
+`/organizations/`- and `/teams/`-style admin pages are already organisation-keyed directly and carry neither filter.
+
+---
+
 ## Setting Up Sites
 
 Sites are managed at **Sites > Sites** in the Django admin (`/admin/sites/site/`).


### PR DESCRIPTION
The last piece of Phase 4. `gregory/admin.py`.

**This one deliberately does not follow the rest of the project.** Content endpoints moved to subject scope; admin uses `source → team → organisation` instead, and the difference is the design rather than an oversight:

- **The chain is complete.** Trials→source 100%, Articles→source 99.3%, `Sources.team` 100%, `Team.organization` non-null. Every trial and almost every article resolves to exactly one organisation *without anyone having curated it*. Subject scope cannot claim that — it is a publication decision, and uncurated content has none yet.
- **It is structural, not editorial.** A source attaches at ingestion; a subject is assigned by a person afterwards. Admin has to show things **before** that person acts — that is what a curation queue is for. Subject-scoping admin would hide the work from the people doing it.
- **Editorial and publication stay separate.** A publication decision must not silently change who can edit, and an editorial permission change must not silently publish.

## What changed

`OrganizationFilterMixin.get_queryset` now scopes through `sources__team__organization`. Every org-scoped ModelAdmin runs through it, but only Articles and Trials ever reached the old `teams` branch.

**The `teams` branch is removed, not left as a fallback.** It is unreachable once `sources` is checked first — verified against the admin registry: the only model with `teams` and no `sources` is `Organization`, whose admin comes from django-organizations and does not use this mixin. Keeping a dead branch would misrepresent `teams` as still a live scoping path.

`ArticleOrganizationFilter.queryset` converted too. It did not match the inventory's grep (it used `organization__id=`, not `organization_id__in`), and left alone it would have silently regressed: the dropdown would have hidden an org's own not-yet-curated content from its own staff once the base queryset stopped trusting `teams`.

**Two new list filters:**

- **Curation queue** — content none of whose subjects is in any site's scope. **Org-scoped**, which is the whole point: stated globally as "everything not on a site" it would show every organisation's uncurated content to every staff user, a leak introduced by a convenience filter. It narrows the mixin's already-scoped queryset rather than querying afresh.
- **Site filter** — lists only the sites the user's organisation owns, via `OrganizationSite`. Narrows, never widens; the organisation filter applies first.

Superusers are unrestricted throughout, including content with no source, using the existing `get_user_organizations()` convention (`None` means all organisations) rather than a parallel mechanism.

## Behaviour change, measured

Rows whose curated `teams` reach an organisation their `sources` do not:

| | Articles | Trials |
|:--|--:|--:|
| Sources pointing at a **different** org than the teams | **0** | **0** |
| Lose admin visibility | 370 (dev) | **0** |
| …of which have **no source at all** | **370 — all of them** | — |

There is no cross-organisation case in the data. Every row affected has no source whatsoever, which the spec designates superuser-only because such a row is attributable to no organisation.

**On production it is 6 rows.** 364 of the 370 also had no subject and were deleted by the September prune; the dev database has not had that prune applied. A source-less row never came through the normal pipeline — hand-created in the admin, or an importer that failed before linking a source — and someone then added a team by hand.

The cross-org case is pinned by a test anyway. That is a guard against a future state, not a description of today's data.

## Tests

- `test_admin_org_filter.py` — fixtures moved from `.teams.add()` to `.sources.add()`; Trials coverage; a source-less/superuser-only pair; and an article curated onto org A's `teams` but sourced from org B, which must **not** be visible to org A.
- `test_admin_curation_queue_filter.py` — `test_staff_curation_queue_has_no_cross_org_leak` is the load-bearing one: two orgs, org B's uncurated content never reaches org A's queue.
- `test_admin_site_scope_filter.py` — a crafted `?site=<org B's site>` against an org-A staffer returns zero, and `lookups()` never lists another org's domains.

All confirmed failing before the change. The two safety-critical filters were additionally verified by mutating each to ignore its incoming queryset — the exact shape the bug would take — and confirming the guard fires.

One pre-existing test needed a fixture fix, not an assertion change: `test_admin_article_crossref_refresh.py` had an article with `teams` but no `sources`, so its non-superuser could no longer resolve it. Adding a `Sources` row matches what the test's own comment already said it intended.

## Verification

- Full Django suite **3,395 passed**, 0 failed
- `ruff` clean
- `schema.yml` byte-identical — correct for an admin-only change
- Docs: new "Admin visibility" section in `docs/06-organisations-teams-and-sites.md`, cross-linked from `docs/03-api-and-rss-feeds.md`

## Known asymmetry, left alone

`TrialAdmin` has no analogue of `ArticleOrganizationFilter`. That pre-dates this PR and adding one was out of scope.

With this, Phase 4 is complete: all 34 call sites converted or explicitly justified as unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)