### PR TITLE
Phase 5: scope RSS feeds by site, with permanent redirects from the old URLs

### DIFF
--- a/django/admin/urls.py
+++ b/django/admin/urls.py
@@ -46,7 +46,12 @@ from api.views import (
 	StatsView,
 	PublicSitesView,
 )
-from rss.views import ArticlesByAuthorFeed, TrialsBySubjectFeed
+from rss.views import (
+	SiteArticlesByAuthorFeed,
+	SiteTrialsBySubjectFeed,
+	redirect_articles_by_author_feed,
+	redirect_trials_by_subject_feed,
+)
 from rss.sitemaps import sitemap_index, sitemap_section
 from subscriptions.views import (
 	subscribe_view,
@@ -106,16 +111,37 @@ urlpatterns = (
 		path("articles/post/", post_article),
 		path("articles/edit/", edit_article),
 		path("trials/edit/", edit_trial),
-		# Feed routes (supports ORCID or numeric author_id)
+		# Old feed routes (supports ORCID or numeric author_id). These now
+		# permanently redirect (301) to the site-scoped routes below, on
+		# brain-regeneration.com (site id 3) -- see rss/views.py. DO NOT
+		# DELETE these patterns in a future cleanup or Django upgrade:
+		# removing them turns a redirect into a 404, and a feed reader
+		# never surfaces that as an error -- it just goes silent, quietly
+		# dropping every subscriber still on the old URL. See
+		# PHASE-5-RSS-SITE-SCOPE-PLAN.md.
 		path(
 			"feed/author/<str:orcid>/",
-			ArticlesByAuthorFeed(),
+			redirect_articles_by_author_feed,
 			name="articles_by_author_feed",
 		),
 		path(
 			"feed/trials/subject/<str:subject_slug>/",
-			TrialsBySubjectFeed(),
+			redirect_trials_by_subject_feed,
 			name="trials_by_subject_feed",
+		),
+		# Site-scoped feed routes (see rss/views.py). Scoped to the
+		# REQUESTED site's CustomSetting.scope_subjects, not the caller's --
+		# crawler/reader-facing like the sitemaps below, not request-scoped
+		# like the rest of the API.
+		path(
+			"feed/sites/<int:site_id>/author/<str:orcid>/",
+			SiteArticlesByAuthorFeed(),
+			name="site_articles_by_author_feed",
+		),
+		path(
+			"feed/sites/<int:site_id>/trials/subject/<str:subject_slug>/",
+			SiteTrialsBySubjectFeed(),
+			name="site_trials_by_subject_feed",
 		),
 		# Site-scoped sitemaps (see rss/sitemaps.py)
 		path(

--- a/django/admin/urls.py
+++ b/django/admin/urls.py
@@ -111,14 +111,13 @@ urlpatterns = (
 		path("articles/post/", post_article),
 		path("articles/edit/", edit_article),
 		path("trials/edit/", edit_trial),
-		# Old feed routes (supports ORCID or numeric author_id). These now
-		# permanently redirect (301) to the site-scoped routes below, on
-		# brain-regeneration.com (site id 3) -- see rss/views.py. DO NOT
-		# DELETE these patterns in a future cleanup or Django upgrade:
-		# removing them turns a redirect into a 404, and a feed reader
-		# never surfaces that as an error -- it just goes silent, quietly
-		# dropping every subscriber still on the old URL. See
-		# PHASE-5-RSS-SITE-SCOPE-PLAN.md.
+		# Old feed routes. These now permanently redirect (301) to the
+		# site-scoped routes below, on brain-regeneration.com (site id 3)
+		# -- see rss/views.py. DO NOT DELETE these patterns in a future
+		# cleanup or Django upgrade: removing them turns a redirect into a
+		# 404, and a feed reader never surfaces that as an error -- it
+		# just goes silent, quietly dropping every subscriber still on the
+		# old URL. See docs/03-api-and-rss-feeds.md#old-feed-urls--permanent-redirect.
 		path(
 			"feed/author/<str:orcid>/",
 			redirect_articles_by_author_feed,

--- a/django/api/tests/test_visibility_rss.py
+++ b/django/api/tests/test_visibility_rss.py
@@ -8,7 +8,7 @@ an anonymous caller, a signed-in member, and an API key. Phase 5 replaced
 that: those URLs now permanently redirect (301) onto
 feed/sites/<site_id>/..., which is scoped to the REQUESTED SITE's
 CustomSetting.scope_subjects and CustomSetting.rss_enabled -- never to the
-caller. See rss/views.py's module docstring and PHASE-5-RSS-SITE-SCOPE-PLAN.md.
+caller. See rss/views.py's module docstring and docs/03-api-and-rss-feeds.md#rss-feeds.
 
 This file exercises exactly that property -- isolation between two sites'
 scopes, and invariance across caller archetypes for one site -- reusing the

--- a/django/api/tests/test_visibility_rss.py
+++ b/django/api/tests/test_visibility_rss.py
@@ -1,28 +1,22 @@
 """
-Tests for RSS feed visibility enforcement.
+Tests for the site-scoped RSS feeds (Phase 5 of site-scoped API visibility).
 
-Both feeds are scoped by SUBJECT (site-scoped API visibility, Phase 4);
-this file was written against the earlier organisation rule and its
-fixtures were converted with it. What a caller can see is now the union of
-``CustomSetting.scope_subjects`` over the sites they can reach -- api_public
-sites for an anonymous caller, the key's own site for an API key, the
-organisation's sites for a signed-in member -- so every org/team here now
-carries a Site and a curated subject, and content is tagged into it.
+Before Phase 5, both feeds read gregory.visibility.visible_subject_ids(request)
+directly on the unprefixed URLs (feed/author/<orcid>/,
+feed/trials/subject/<slug>/), so the same URL returned different content to
+an anonymous caller, a signed-in member, and an API key. Phase 5 replaced
+that: those URLs now permanently redirect (301) onto
+feed/sites/<site_id>/..., which is scoped to the REQUESTED SITE's
+CustomSetting.scope_subjects and CustomSetting.rss_enabled -- never to the
+caller. See rss/views.py's module docstring and PHASE-5-RSS-SITE-SCOPE-PLAN.md.
 
-Covers:
-  - ArticlesByAuthorFeed (/feed/author/<orcid>/):
-      - 404 when no article of the author carries a visible subject
-      - 200 and items filtered to visible-subject articles otherwise
-      - ?include_public=true extends visibility for identified callers
-  - TrialsBySubjectFeed (/feed/trials/subject/<slug>/):
-      - 404 when the subject is in no reachable site's scope
-      - 200 and the subject's trials when it is
-      - ?include_public=true extends visibility for identified callers
-  - Three caller archetypes: anonymous, authenticated member, API key.
-    (An earlier "null-org key" archetype is not reachable: APIAccessScheme
-    .organization is a non-null FK. A key whose *site* is null is reachable
-    and is covered below -- that is the state every key was in before the
-    Phase 1 backfill, and the one Phase 3 will start rejecting.)
+This file exercises exactly that property -- isolation between two sites'
+scopes, and invariance across caller archetypes for one site -- reusing the
+org/site/API-key scaffolding this suite already has. Redirect mechanics,
+the author-<link> element, and item-level content (which subjects show up
+in which site's feed) are covered in rss/tests.py instead; this file is for
+the interaction between the site-scoped feed and the rest of the
+site-visibility model (organisations, API keys, api_public).
 
 Run with:
     docker exec gregory python manage.py test api.tests.test_visibility_rss
@@ -33,6 +27,7 @@ from datetime import timedelta
 from django.contrib.auth import get_user_model
 from django.contrib.sites.models import Site
 from django.test import TestCase
+from django.urls import reverse
 from django.utils.timezone import now
 from organizations.models import Organization, OrganizationUser
 
@@ -83,18 +78,22 @@ def _make_author(given, family, orcid):
 	)
 
 
-def _make_site(name, org, *, api_public, scope_subjects=()):
-	"""A Site owned by `org`, with a CustomSetting carrying its subject scope.
+def _make_site(name, org, *, api_public, rss_enabled=True, scope_subjects=()):
+	"""A Site owned by `org`, with a CustomSetting carrying its RSS scope.
 
-	The org link goes through OrganizationSite because that is what
-	visible_subject_ids walks for a signed-in member, and what it checks a
-	site-bound API key against.
+	The org link goes through OrganizationSite purely so these tests can
+	build a signed-in-member / API-key caller and show their identity
+	changes nothing about the feed -- the feed views themselves never
+	consult it.
 	"""
 	slug = name.lower().replace(" ", "-")
 	site = Site.objects.create(domain=f"{slug}.example.com", name=name)
 	OrganizationSite.objects.create(organization=org, site=site, is_default=True)
 	settings_row = CustomSetting.objects.create(
-		site=site, title=f"{name} settings", api_public=api_public
+		site=site,
+		title=f"{name} settings",
+		api_public=api_public,
+		rss_enabled=rss_enabled,
 	)
 	for subject in scope_subjects:
 		settings_row.scope_subjects.add(subject)
@@ -122,8 +121,6 @@ def _make_trial(title, link, teams=(), subjects=()):
 
 
 def _make_api_scheme(org, name, site=None):
-	# `site` is what binds the key to a subject scope; a key without one
-	# resolves to no subjects at all (see visible_subject_ids).
 	return APIAccessScheme.objects.create(
 		client_name=name,
 		client_contacts=f"{name}@example.com",
@@ -135,389 +132,251 @@ def _make_api_scheme(org, name, site=None):
 	)
 
 
-# ---------------------------------------------------------------------------
-# Base setUp for author feed tests
-# ---------------------------------------------------------------------------
-
-ORCID_MINE = "0000-0001-0001-0001"
-ORCID_PUB = "0000-0001-0002-0002"
-ORCID_PRIV = "0000-0001-0003-0003"
+def _author_feed_url(site_id, orcid):
+	return reverse(
+		"site_articles_by_author_feed", kwargs={"site_id": site_id, "orcid": orcid}
+	)
 
 
-class AuthorFeedBase(TestCase):
-	def setUp(self):
-		self.my_org = _make_org("My Org", "my-org-rss-auth", public=False)
-		self.pub_org = _make_org("Public Org", "pub-org-rss-auth", public=True)
-		self.priv_org = _make_org("Private Org", "priv-org-rss-auth", public=False)
-
-		self.my_team = _make_team(self.my_org, "My Team RSS Auth")
-		self.pub_team = _make_team(self.pub_org, "Pub Team RSS Auth")
-		self.priv_team = _make_team(self.priv_org, "Priv Team RSS Auth")
-
-		self.my_subj = _make_subject(self.my_team, "my-subj-rss-auth")
-		self.pub_subj = _make_subject(self.pub_team, "pub-subj-rss-auth")
-		self.priv_subj = _make_subject(self.priv_team, "priv-subj-rss-auth")
-
-		# One site per organisation, each publishing its own subject. Only
-		# pub_site is api_public, so pub_subj is the whole anonymous scope.
-		self.my_site = _make_site(
-			"My Site RSS Auth", self.my_org, api_public=False,
-			scope_subjects=[self.my_subj],
-		)
-		self.pub_site = _make_site(
-			"Pub Site RSS Auth", self.pub_org, api_public=True,
-			scope_subjects=[self.pub_subj],
-		)
-		self.priv_site = _make_site(
-			"Priv Site RSS Auth", self.priv_org, api_public=False,
-			scope_subjects=[self.priv_subj],
-		)
-
-		# Authors
-		self.author_mine = _make_author("Alice", "Mine", ORCID_MINE)
-		self.author_pub = _make_author("Bob", "Public", ORCID_PUB)
-		self.author_priv = _make_author("Carol", "Private", ORCID_PRIV)
-
-		# Articles
-		_make_article(
-			"Mine Art",
-			"https://rss.ex/a1",
-			teams=[self.my_team],
-			authors=[self.author_mine],
-			subjects=[self.my_subj],
-		)
-		_make_article(
-			"Pub Art",
-			"https://rss.ex/a2",
-			teams=[self.pub_team],
-			authors=[self.author_pub],
-			subjects=[self.pub_subj],
-		)
-		_make_article(
-			"Priv Art",
-			"https://rss.ex/a3",
-			teams=[self.priv_team],
-			authors=[self.author_priv],
-			subjects=[self.priv_subj],
-		)
-		# author_mine also has a public article
-		_make_article(
-			"Mine+Pub Art",
-			"https://rss.ex/a4",
-			teams=[self.pub_team],
-			authors=[self.author_mine],
-			subjects=[self.pub_subj],
-		)
+def _trials_feed_url(site_id, subject_slug):
+	return reverse(
+		"site_trials_by_subject_feed",
+		kwargs={"site_id": site_id, "subject_slug": subject_slug},
+	)
 
 
 # ---------------------------------------------------------------------------
-# Anonymous: author feed
+# Isolation: site A's feed never carries site B's scope, or vice versa
 # ---------------------------------------------------------------------------
 
 
-class AnonymousAuthorFeedTest(AuthorFeedBase):
-	"""Anonymous → only public org articles visible."""
-
-	def test_public_author_returns_200(self):
-		resp = self.client.get(f"/feed/author/{ORCID_PUB}/")
-		self.assertEqual(resp.status_code, 200)
-
-	def test_private_author_returns_404(self):
-		"""author_priv only has articles in private org → 404 for anonymous."""
-		resp = self.client.get(f"/feed/author/{ORCID_PRIV}/")
-		self.assertEqual(resp.status_code, 404)
-
-	def test_private_author_feed_with_mine_and_pub_returns_200(self):
-		"""author_mine has both a private and a public article → visible because of pub article."""
-		resp = self.client.get(f"/feed/author/{ORCID_MINE}/")
-		self.assertEqual(resp.status_code, 200)
-		# The mine-only article should NOT appear; only the pub article
-		content = resp.content.decode()
-		self.assertIn("Mine+Pub Art", content)
-		self.assertNotIn("Mine Art", content)
-
-	def test_nonexistent_orcid_returns_404(self):
-		resp = self.client.get("/feed/author/0000-0000-0000-9999/")
-		self.assertEqual(resp.status_code, 404)
-
-
-# ---------------------------------------------------------------------------
-# Authenticated user (member of my_org): author feed
-# ---------------------------------------------------------------------------
-
-
-class AuthenticatedUserAuthorFeedTest(AuthorFeedBase):
-	def setUp(self):
-		super().setUp()
-		self.user = User.objects.create_user(username="rss-auth-member", password="pw")
-		OrganizationUser.objects.create(organization=self.my_org, user=self.user)
-		self.client.force_login(self.user)
-
-	def test_own_author_returns_200(self):
-		resp = self.client.get(f"/feed/author/{ORCID_MINE}/")
-		self.assertEqual(resp.status_code, 200)
-
-	def test_private_other_org_author_returns_404(self):
-		resp = self.client.get(f"/feed/author/{ORCID_PRIV}/")
-		self.assertEqual(resp.status_code, 404)
-
-	def test_public_author_hidden_without_flag(self):
-		"""author_pub only has articles in pub_org; not visible without include_public."""
-		resp = self.client.get(f"/feed/author/{ORCID_PUB}/")
-		self.assertEqual(resp.status_code, 404)
-
-	def test_public_author_visible_with_include_public(self):
-		resp = self.client.get(f"/feed/author/{ORCID_PUB}/?include_public=true")
-		self.assertEqual(resp.status_code, 200)
-
-	def test_own_feed_items_excludes_pub_articles_without_flag(self):
-		"""author_mine items should only include the mine-team article (not pub-team)."""
-		resp = self.client.get(f"/feed/author/{ORCID_MINE}/")
-		self.assertEqual(resp.status_code, 200)
-		content = resp.content.decode()
-		self.assertIn("Mine Art", content)
-		self.assertNotIn("Mine+Pub Art", content)
-
-	def test_own_feed_items_includes_pub_articles_with_flag(self):
-		resp = self.client.get(f"/feed/author/{ORCID_MINE}/?include_public=true")
-		self.assertEqual(resp.status_code, 200)
-		content = resp.content.decode()
-		self.assertIn("Mine Art", content)
-		self.assertIn("Mine+Pub Art", content)
-
-
-# ---------------------------------------------------------------------------
-# API key caller (bound to my_org): author feed
-# ---------------------------------------------------------------------------
-
-
-class APIKeyAuthorFeedTest(AuthorFeedBase):
-	def setUp(self):
-		super().setUp()
-		self.scheme = _make_api_scheme(
-			self.my_org, "rss-author-key", site=self.my_site
-		)
-		self.client.defaults["HTTP_AUTHORIZATION"] = self.scheme.api_key
-
-	def test_own_author_returns_200(self):
-		resp = self.client.get(f"/feed/author/{ORCID_MINE}/")
-		self.assertEqual(resp.status_code, 200)
-
-	def test_private_other_org_author_returns_404(self):
-		resp = self.client.get(f"/feed/author/{ORCID_PRIV}/")
-		self.assertEqual(resp.status_code, 404)
-
-	def test_public_author_hidden_without_flag(self):
-		resp = self.client.get(f"/feed/author/{ORCID_PUB}/")
-		self.assertEqual(resp.status_code, 404)
-
-	def test_public_author_visible_with_include_public(self):
-		resp = self.client.get(f"/feed/author/{ORCID_PUB}/?include_public=true")
-		self.assertEqual(resp.status_code, 200)
-
-
-# ---------------------------------------------------------------------------
-# Base setUp for trials feed tests
-# ---------------------------------------------------------------------------
-
-
-class TrialsFeedBase(TestCase):
-	def setUp(self):
-		self.my_org = _make_org("My Org", "my-org-rss-trial", public=False)
-		self.pub_org = _make_org("Public Org", "pub-org-rss-trial", public=True)
-		self.priv_org = _make_org("Private Org", "priv-org-rss-trial", public=False)
-
-		self.my_team = _make_team(self.my_org, "My Team RSS Trial")
-		self.pub_team = _make_team(self.pub_org, "Pub Team RSS Trial")
-		self.priv_team = _make_team(self.priv_org, "Priv Team RSS Trial")
-
-		self.my_subj = _make_subject(self.my_team, "my-subj-rss")
-		self.pub_subj = _make_subject(self.pub_team, "pub-subj-rss")
-		self.priv_subj = _make_subject(self.priv_team, "priv-subj-rss")
-
-		# One site per organisation, each publishing its own subject. Only
-		# pub_site is api_public, so pub_subj is the whole anonymous scope.
-		self.my_site = _make_site(
-			"My Site RSS Trial", self.my_org, api_public=False,
-			scope_subjects=[self.my_subj],
-		)
-		self.pub_site = _make_site(
-			"Pub Site RSS Trial", self.pub_org, api_public=True,
-			scope_subjects=[self.pub_subj],
-		)
-		self.priv_site = _make_site(
-			"Priv Site RSS Trial", self.priv_org, api_public=False,
-			scope_subjects=[self.priv_subj],
-		)
-
-		# Trials
-		_make_trial(
-			"Mine Trial",
-			"https://rss.ex/t1",
-			teams=[self.my_team],
-			subjects=[self.my_subj],
-		)
-		_make_trial(
-			"Pub Trial",
-			"https://rss.ex/t2",
-			teams=[self.pub_team],
-			subjects=[self.pub_subj],
-		)
-		_make_trial(
-			"Priv Trial",
-			"https://rss.ex/t3",
-			teams=[self.priv_team],
-			subjects=[self.priv_subj],
-		)
-
-
-# ---------------------------------------------------------------------------
-# Anonymous: trials feed
-# ---------------------------------------------------------------------------
-
-
-class AnonymousTrialsFeedTest(TrialsFeedBase):
-	def test_public_subject_returns_200(self):
-		resp = self.client.get(f"/feed/trials/subject/{self.pub_subj.subject_slug}/")
-		self.assertEqual(resp.status_code, 200)
-
-	def test_private_subject_returns_404(self):
-		resp = self.client.get(f"/feed/trials/subject/{self.priv_subj.subject_slug}/")
-		self.assertEqual(resp.status_code, 404)
-
-	def test_mine_subject_returns_404_for_anon(self):
-		resp = self.client.get(f"/feed/trials/subject/{self.my_subj.subject_slug}/")
-		self.assertEqual(resp.status_code, 404)
-
-	def test_nonexistent_slug_returns_404(self):
-		resp = self.client.get("/feed/trials/subject/does-not-exist/")
-		self.assertEqual(resp.status_code, 404)
-
-	def test_public_feed_contains_public_trial(self):
-		resp = self.client.get(f"/feed/trials/subject/{self.pub_subj.subject_slug}/")
-		self.assertIn("Pub Trial", resp.content.decode())
-
-
-# ---------------------------------------------------------------------------
-# Authenticated user: trials feed
-# ---------------------------------------------------------------------------
-
-
-class AuthenticatedUserTrialsFeedTest(TrialsFeedBase):
-	def setUp(self):
-		super().setUp()
-		self.user = User.objects.create_user(username="rss-trial-member", password="pw")
-		OrganizationUser.objects.create(organization=self.my_org, user=self.user)
-		self.client.force_login(self.user)
-
-	def test_own_subject_returns_200(self):
-		resp = self.client.get(f"/feed/trials/subject/{self.my_subj.subject_slug}/")
-		self.assertEqual(resp.status_code, 200)
-
-	def test_private_other_org_subject_returns_404(self):
-		resp = self.client.get(f"/feed/trials/subject/{self.priv_subj.subject_slug}/")
-		self.assertEqual(resp.status_code, 404)
-
-	def test_public_subject_hidden_without_flag(self):
-		resp = self.client.get(f"/feed/trials/subject/{self.pub_subj.subject_slug}/")
-		self.assertEqual(resp.status_code, 404)
-
-	def test_public_subject_visible_with_include_public(self):
-		resp = self.client.get(
-			f"/feed/trials/subject/{self.pub_subj.subject_slug}/?include_public=true"
-		)
-		self.assertEqual(resp.status_code, 200)
-
-	def test_own_feed_contains_own_trial(self):
-		resp = self.client.get(f"/feed/trials/subject/{self.my_subj.subject_slug}/")
-		self.assertIn("Mine Trial", resp.content.decode())
-
-	def test_own_feed_lists_the_subjects_trials_whatever_team_owns_them(self):
-		"""
-		The subject is the visibility boundary, so a feed for a visible
-		subject lists every trial tagged with it. Team ownership used to
-		filter within the feed as well; since Phase 4 it does not, and
-		test_public_subject_hidden_without_flag is what pins the boundary
-		that still exists.
-		"""
-		_make_trial(
-			"Pub Trial In My Subj",
-			"https://rss.ex/t99",
-			teams=[self.pub_team],
-			subjects=[self.my_subj],
-		)
-		resp = self.client.get(f"/feed/trials/subject/{self.my_subj.subject_slug}/")
-		content = resp.content.decode()
-		self.assertIn("Mine Trial", content)
-		self.assertIn("Pub Trial In My Subj", content)
-		# ...and a trial with no tie to my_subj is still absent.
-		self.assertNotIn("Priv Trial", content)
-
-
-# ---------------------------------------------------------------------------
-# API key: trials feed
-# ---------------------------------------------------------------------------
-
-
-class APIKeyTrialsFeedTest(TrialsFeedBase):
-	def setUp(self):
-		super().setUp()
-		self.scheme = _make_api_scheme(
-			self.my_org, "rss-trials-key", site=self.my_site
-		)
-		self.client.defaults["HTTP_AUTHORIZATION"] = self.scheme.api_key
-
-	def test_own_subject_returns_200(self):
-		resp = self.client.get(f"/feed/trials/subject/{self.my_subj.subject_slug}/")
-		self.assertEqual(resp.status_code, 200)
-
-	def test_private_other_org_subject_returns_404(self):
-		resp = self.client.get(f"/feed/trials/subject/{self.priv_subj.subject_slug}/")
-		self.assertEqual(resp.status_code, 404)
-
-	def test_public_subject_hidden_without_flag(self):
-		resp = self.client.get(f"/feed/trials/subject/{self.pub_subj.subject_slug}/")
-		self.assertEqual(resp.status_code, 404)
-
-	def test_public_subject_visible_with_include_public(self):
-		resp = self.client.get(
-			f"/feed/trials/subject/{self.pub_subj.subject_slug}/?include_public=true"
-		)
-		self.assertEqual(resp.status_code, 200)
-
-
-class SitelessAPIKeyTrialsFeedTest(TrialsFeedBase):
+class SiteScopedFeedIsolationTest(TestCase):
 	"""
-	A key with no site resolves to no subjects of its own. Every key has a
-	site in production (backfilled by sitesettings/0019) but the field is
-	still nullable until Phase 3 enforces it, so the branch is live and
-	needs pinning: without a site the key sees nothing, and with
-	?include_public=true it sees exactly the public scope -- public subjects
-	being public to everyone, key or no key.
+	The case org-level (and, before Phase 5, caller-level) visibility could
+	not express: two sites, each with its own subject, each rss_enabled.
+	Site A's feed must carry only site A's content, whatever the caller and
+	whatever site B publishes -- the leak canary for RSS.
 	"""
 
 	def setUp(self):
-		super().setUp()
-		self.scheme = _make_api_scheme(self.my_org, "rss-siteless-key", site=None)
-		self.client.defaults["HTTP_AUTHORIZATION"] = self.scheme.api_key
+		self.org_a = _make_org("Org A", "org-a-rss-iso")
+		self.org_b = _make_org("Org B", "org-b-rss-iso")
+		self.team_a = _make_team(self.org_a, "Team A RSS Iso")
+		self.team_b = _make_team(self.org_b, "Team B RSS Iso")
+		self.subj_a = _make_subject(self.team_a, "subj-a-rss-iso")
+		self.subj_b = _make_subject(self.team_b, "subj-b-rss-iso")
 
-	def test_own_org_subject_404s_without_a_site(self):
-		# The organisation owns my_subj, but the key is not bound to the site
-		# that publishes it, and organisation membership no longer grants
-		# anything on its own.
-		resp = self.client.get(f"/feed/trials/subject/{self.my_subj.subject_slug}/")
-		self.assertEqual(resp.status_code, 404)
-
-	def test_public_subject_404s_without_the_flag(self):
-		resp = self.client.get(f"/feed/trials/subject/{self.pub_subj.subject_slug}/")
-		self.assertEqual(resp.status_code, 404)
-
-	def test_include_public_still_grants_the_public_scope(self):
-		resp = self.client.get(
-			f"/feed/trials/subject/{self.pub_subj.subject_slug}/?include_public=true"
+		self.site_a = _make_site(
+			"Site A RSS Iso", self.org_a, api_public=False, scope_subjects=[self.subj_a]
 		)
+		self.site_b = _make_site(
+			"Site B RSS Iso", self.org_b, api_public=True, scope_subjects=[self.subj_b]
+		)
+
+		self.author_a = _make_author("A", "Author", "0000-0003-0001-0001")
+		self.author_b = _make_author("B", "Author", "0000-0003-0002-0002")
+		_make_article(
+			"Article A",
+			"https://rss-iso.ex/a1",
+			teams=[self.team_a],
+			authors=[self.author_a],
+			subjects=[self.subj_a],
+		)
+		_make_article(
+			"Article B",
+			"https://rss-iso.ex/a2",
+			teams=[self.team_b],
+			authors=[self.author_b],
+			subjects=[self.subj_b],
+		)
+		_make_trial(
+			"Trial A", "https://rss-iso.ex/t1", teams=[self.team_a], subjects=[self.subj_a]
+		)
+		_make_trial(
+			"Trial B", "https://rss-iso.ex/t2", teams=[self.team_b], subjects=[self.subj_b]
+		)
+
+	def test_site_as_trials_feed_excludes_site_bs_subject(self):
+		resp = self.client.get(_trials_feed_url(self.site_a.pk, self.subj_a.subject_slug))
 		self.assertEqual(resp.status_code, 200)
-		self.assertIn("Pub Trial", resp.content.decode())
+		self.assertIn("Trial A", resp.content.decode())
+
+	def test_site_a_cannot_serve_site_bs_subject_at_all(self):
+		# subj_b was never added to site_a's scope, so requesting it through
+		# site_a's own feed URL 404s -- the subject/site pairing is what's
+		# checked, not just "is this subject visible somewhere".
+		resp = self.client.get(_trials_feed_url(self.site_a.pk, self.subj_b.subject_slug))
+		self.assertEqual(resp.status_code, 404)
+
+	def test_site_bs_author_feed_excludes_site_as_article(self):
+		# author_a has no article under subj_b, so site B's feed 404s for them.
+		resp = self.client.get(_author_feed_url(self.site_b.pk, self.author_a.ORCID))
+		self.assertEqual(resp.status_code, 404)
+
+	def test_site_as_author_feed_serves_only_site_as_content(self):
+		resp = self.client.get(_author_feed_url(self.site_a.pk, self.author_a.ORCID))
+		self.assertEqual(resp.status_code, 200)
+		self.assertIn("Article A", resp.content.decode())
 
 
 # ---------------------------------------------------------------------------
+# Invariance: caller identity changes nothing about a given site's feed
+# ---------------------------------------------------------------------------
+
+
+class SiteScopedFeedCallerInvarianceTest(TestCase):
+	"""
+	The defining behaviour change of Phase 5. Pinned explicitly so a
+	well-meaning "restore per-caller filtering" change fails loudly here
+	rather than silently reintroducing cache-poisoning-by-identity on a
+	surface that's actually cached and has no notion of identity.
+	"""
+
+	def setUp(self):
+		self.owning_org = _make_org("Owning Org RSS Inv", "owning-org-rss-inv")
+		self.other_org = _make_org("Other Org RSS Inv", "other-org-rss-inv")
+		self.team = _make_team(self.owning_org, "Team RSS Inv")
+		self.subject = _make_subject(self.team, "subj-rss-inv")
+		self.site = _make_site(
+			"Site RSS Inv",
+			self.owning_org,
+			api_public=False,
+			scope_subjects=[self.subject],
+		)
+		# A second, unrelated site the "other" API key is bound to, so that
+		# key resolves to a real but disjoint scope rather than an
+		# unresolvable one.
+		self.other_site = _make_site(
+			"Other Site RSS Inv", self.other_org, api_public=False, scope_subjects=[]
+		)
+
+		self.author = _make_author("Inv", "Author", "0000-0003-0003-0003")
+		_make_article(
+			"Inv Article",
+			"https://rss-inv.ex/a1",
+			teams=[self.team],
+			authors=[self.author],
+			subjects=[self.subject],
+		)
+		_make_trial(
+			"Inv Trial", "https://rss-inv.ex/t1", teams=[self.team], subjects=[self.subject]
+		)
+
+	def _bodies_for(self, url):
+		bodies = []
+
+		# Anonymous.
+		bodies.append(self.client.get(url).content.decode())
+
+		# Signed-in member of an UNRELATED organisation.
+		user = User.objects.create_user(username="rss-inv-member", password="pw")
+		OrganizationUser.objects.create(organization=self.other_org, user=user)
+		self.client.force_login(user)
+		bodies.append(self.client.get(url).content.decode())
+		self.client.logout()
+
+		# API key bound to an UNRELATED site.
+		scheme = _make_api_scheme(self.other_org, "rss-inv-key", site=self.other_site)
+		self.client.defaults["HTTP_AUTHORIZATION"] = scheme.api_key
+		bodies.append(self.client.get(url).content.decode())
+		del self.client.defaults["HTTP_AUTHORIZATION"]
+
+		return bodies
+
+	def test_author_feed_identical_across_callers(self):
+		url = _author_feed_url(self.site.pk, self.author.ORCID)
+		bodies = self._bodies_for(url)
+		self.assertEqual(len(set(bodies)), 1, bodies)
+		self.assertIn("Inv Article", bodies[0])
+
+	def test_trials_feed_identical_across_callers(self):
+		url = _trials_feed_url(self.site.pk, self.subject.subject_slug)
+		bodies = self._bodies_for(url)
+		self.assertEqual(len(set(bodies)), 1, bodies)
+		self.assertIn("Inv Trial", bodies[0])
+
+
+# ---------------------------------------------------------------------------
+# rss_enabled / CustomSetting gating
+# ---------------------------------------------------------------------------
+
+
+class RssEnabledGateTest(TestCase):
+	def setUp(self):
+		self.org = _make_org("Gate Org", "gate-org-rss")
+		self.team = _make_team(self.org, "Gate Team RSS")
+		self.subject = _make_subject(self.team, "gate-subj-rss")
+		_make_trial(
+			"Gate Trial", "https://rss-gate.ex/t1", teams=[self.team], subjects=[self.subject]
+		)
+
+	def test_site_with_rss_disabled_404s(self):
+		site = _make_site(
+			"Disabled Site RSS",
+			self.org,
+			api_public=True,
+			rss_enabled=False,
+			scope_subjects=[self.subject],
+		)
+		resp = self.client.get(_trials_feed_url(site.pk, self.subject.subject_slug))
+		self.assertEqual(resp.status_code, 404)
+
+	def test_site_with_no_customsetting_404s(self):
+		bare_site = Site.objects.create(domain="bare-rss-gate.example.com", name="Bare")
+		resp = self.client.get(_trials_feed_url(bare_site.pk, self.subject.subject_slug))
+		self.assertEqual(resp.status_code, 404)
+
+	def test_unknown_site_id_404s(self):
+		resp = self.client.get(_trials_feed_url(999999, self.subject.subject_slug))
+		self.assertEqual(resp.status_code, 404)
+
+	def test_site_with_rss_enabled_serves_the_feed(self):
+		site = _make_site(
+			"Enabled Site RSS",
+			self.org,
+			api_public=True,
+			rss_enabled=True,
+			scope_subjects=[self.subject],
+		)
+		resp = self.client.get(_trials_feed_url(site.pk, self.subject.subject_slug))
+		self.assertEqual(resp.status_code, 200)
+		self.assertIn("Gate Trial", resp.content.decode())
+
+
+# ---------------------------------------------------------------------------
+# A private site's own feed is not gated by api_public
+# ---------------------------------------------------------------------------
+
+
+class PrivateSiteFeedTest(TestCase):
+	"""
+	rss_enabled is the whole gate; api_public plays no part, mirroring how
+	a site-bound API key reads its own scope_subjects "whether or not the
+	site is api_public" (gregory.visibility.visible_subject_ids). Pinned so
+	a later change doesn't quietly ALSO require api_public=True for the
+	feed -- that would be a different, narrower design than the one this
+	phase built, and should be a deliberate decision, not a regression.
+	"""
+
+	def setUp(self):
+		self.org = _make_org("Private Feed Org", "private-feed-org-rss")
+		self.team = _make_team(self.org, "Private Feed Team RSS")
+		self.subject = _make_subject(self.team, "private-feed-subj-rss")
+		self.site = _make_site(
+			"Private Feed Site RSS",
+			self.org,
+			api_public=False,
+			rss_enabled=True,
+			scope_subjects=[self.subject],
+		)
+		_make_trial(
+			"Private Feed Trial",
+			"https://rss-priv.ex/t1",
+			teams=[self.team],
+			subjects=[self.subject],
+		)
+
+	def test_anonymous_caller_with_no_credential_reads_the_private_sites_feed(self):
+		resp = self.client.get(_trials_feed_url(self.site.pk, self.subject.subject_slug))
+		self.assertEqual(resp.status_code, 200)
+		self.assertIn("Private Feed Trial", resp.content.decode())

--- a/django/rss/tests.py
+++ b/django/rss/tests.py
@@ -8,12 +8,13 @@ Covers:
     orcid.org otherwise. See
     docs/06-organisations-teams-and-sites.md#author-profile-page-links.
   - Site-scoped feed visibility: a feed is scoped to the REQUESTED site's
-    scope_subjects, not team ownership and not caller identity (Phase 5,
-    PHASE-5-RSS-SITE-SCOPE-PLAN.md). Caller-identity-scoped behaviour for
-    RSS lived here before Phase 5; it now belongs to sitemaps'-style
-    site-scoping instead, so those cases moved to this file too --
-    api/tests/test_visibility_rss.py is for the redirect/404/rss_enabled
-    surface that touches API-visibility fixtures.
+    scope_subjects, not team ownership and not caller identity (Phase 5 of
+    site-scoped API visibility -- see docs/03-api-and-rss-feeds.md#rss-feeds).
+    Caller-identity-scoped behaviour for RSS lived here before Phase 5; it
+    now belongs to sitemaps'-style site-scoping instead, so those cases
+    moved to this file too -- api/tests/test_visibility_rss.py is for the
+    isolation/invariance surface that touches API-visibility fixtures
+    (organisations, API keys).
 """
 
 from django.contrib.sites.models import Site
@@ -167,7 +168,7 @@ class SiteAuthorFeedLinkTest(TestCase):
 class SiteFeedScopeTest(TestCase):
 	"""
 	Both site-scoped feeds are scoped to the REQUESTED SITE's
-	scope_subjects -- not team ownership, and not the calling caller's own
+	scope_subjects -- not team ownership, and not the caller's own
 	visibility (Phase 5). This is the behaviour change from the pre-Phase-5
 	feeds, which read gregory.visibility.visible_subject_ids(request) and
 	therefore varied by who was asking.

--- a/django/rss/tests.py
+++ b/django/rss/tests.py
@@ -1,7 +1,19 @@
 """
-The author RSS feed's <link> element points at the site's author profile
-page when CustomSetting.has_author_pages is on, and at orcid.org
-otherwise. See docs/06-organisations-teams-and-sites.md#author-profile-page-links.
+Covers:
+  - The old unprefixed feed URLs (feed/author/<orcid>/,
+    feed/trials/subject/<slug>/) permanently redirect (301) onto the
+    site-scoped equivalents, preserving any query string.
+  - The author feed's <link> element points at the requested site's author
+    profile page when its CustomSetting.has_author_pages is on, and at
+    orcid.org otherwise. See
+    docs/06-organisations-teams-and-sites.md#author-profile-page-links.
+  - Site-scoped feed visibility: a feed is scoped to the REQUESTED site's
+    scope_subjects, not team ownership and not caller identity (Phase 5,
+    PHASE-5-RSS-SITE-SCOPE-PLAN.md). Caller-identity-scoped behaviour for
+    RSS lived here before Phase 5; it now belongs to sitemaps'-style
+    site-scoping instead, so those cases moved to this file too --
+    api/tests/test_visibility_rss.py is for the redirect/404/rss_enabled
+    surface that touches API-visibility fixtures.
 """
 
 from django.contrib.sites.models import Site
@@ -20,7 +32,64 @@ from organizations.models import Organization
 from sitesettings.models import CustomSetting
 
 
-class AuthorFeedLinkTest(TestCase):
+class OldFeedUrlRedirectTest(TestCase):
+	"""The load-bearing requirement of Phase 5: old URLs must 301, not 404."""
+
+	def setUp(self):
+		self.author = Authors.objects.create(
+			given_name="Jane", family_name="Doe", ORCID="0000-0002-7922-9785"
+		)
+
+	def test_author_feed_redirects_permanently_to_site_3(self):
+		response = self.client.get(
+			reverse("articles_by_author_feed", args=[self.author.ORCID])
+		)
+		self.assertEqual(response.status_code, 301)
+		self.assertEqual(
+			response.headers["Location"],
+			f"/feed/sites/3/author/{self.author.ORCID}/",
+		)
+
+	def test_trials_feed_redirects_permanently_to_site_3(self):
+		response = self.client.get(
+			reverse("trials_by_subject_feed", args=["some-subject"])
+		)
+		self.assertEqual(response.status_code, 301)
+		self.assertEqual(
+			response.headers["Location"], "/feed/sites/3/trials/subject/some-subject/"
+		)
+
+	def test_author_feed_redirect_preserves_query_string(self):
+		response = self.client.get(
+			reverse("articles_by_author_feed", args=[self.author.ORCID])
+			+ "?include_public=true"
+		)
+		self.assertEqual(response.status_code, 301)
+		self.assertEqual(
+			response.headers["Location"],
+			f"/feed/sites/3/author/{self.author.ORCID}/?include_public=true",
+		)
+
+	def test_trials_feed_redirect_preserves_query_string(self):
+		response = self.client.get(
+			reverse("trials_by_subject_feed", args=["some-subject"]) + "?p=2"
+		)
+		self.assertEqual(response.status_code, 301)
+		self.assertEqual(
+			response.headers["Location"],
+			"/feed/sites/3/trials/subject/some-subject/?p=2",
+		)
+
+	def test_redirect_does_not_validate_the_orcid_or_slug(self):
+		# A redirect is issued whatever the path segment is; the new URL is
+		# what 404s for a bad orcid/slug, exactly as it would have here.
+		response = self.client.get(
+			reverse("articles_by_author_feed", args=["not-a-real-orcid"])
+		)
+		self.assertEqual(response.status_code, 301)
+
+
+class SiteAuthorFeedLinkTest(TestCase):
 	def setUp(self):
 		self.organization = Organization.objects.create(
 			name="RSS Author Org", slug="rss-author-org"
@@ -38,25 +107,9 @@ class AuthorFeedLinkTest(TestCase):
 			team=self.team,
 			subject_slug="rss-author-subject",
 		)
-		self.site = Site.objects.get_or_create(
-			id=1, defaults={"domain": "testserver", "name": "Test Site"}
-		)[0]
-		if self.site.domain != "testserver":
-			self.site.domain = "testserver"
-			self.site.save()
-		# What makes the feed's content visible to an anonymous caller is a
-		# subject in some api_public site's scope -- not the org flag, and
-		# not this site's own CustomSetting. It lives on a separate site so
-		# that each test below is still free to create, vary or omit the
-		# CustomSetting for `self.site`, which is the only thing these tests
-		# are actually about (has_author_pages -> <link> target).
-		self.scope_site = Site.objects.create(
-			domain="scope.example.com", name="Scope Site"
+		self.site = Site.objects.create(
+			domain="link-test.example.com", name="Link Test Site"
 		)
-		scope_settings = CustomSetting.objects.create(
-			site=self.scope_site, title="Scope settings", api_public=True
-		)
-		scope_settings.scope_subjects.add(self.subject)
 		self.author = Authors.objects.create(
 			given_name="Jane", family_name="Doe", ORCID="0000-0002-7922-9785"
 		)
@@ -70,74 +123,79 @@ class AuthorFeedLinkTest(TestCase):
 		article.authors.add(self.author)
 
 	def _fetch_feed(self):
-		url = reverse("articles_by_author_feed", args=[self.author.ORCID])
+		url = reverse(
+			"site_articles_by_author_feed",
+			kwargs={"site_id": self.site.pk, "orcid": self.author.ORCID},
+		)
 		response = self.client.get(url)
 		self.assertEqual(response.status_code, 200)
 		return response.content.decode()
 
 	def test_link_points_to_site_when_flag_on(self):
 		CustomSetting.objects.create(
-			site=self.site, title="Flag On Site", has_author_pages=True
-		)
+			site=self.site,
+			title="Flag On Site",
+			rss_enabled=True,
+			has_author_pages=True,
+		).scope_subjects.add(self.subject)
 		content = self._fetch_feed()
 		self.assertIn(
-			"<link>https://testserver/authors/0000-0002-7922-9785/</link>", content
+			f"<link>https://{self.site.domain}/authors/0000-0002-7922-9785/</link>",
+			content,
 		)
 
 	def test_link_points_to_orcid_when_flag_off(self):
 		CustomSetting.objects.create(
-			site=self.site, title="Flag Off Site", has_author_pages=False
-		)
+			site=self.site,
+			title="Flag Off Site",
+			rss_enabled=True,
+			has_author_pages=False,
+		).scope_subjects.add(self.subject)
 		content = self._fetch_feed()
 		self.assertIn(
 			"<link>https://orcid.org/0000-0002-7922-9785</link>", content
 		)
 
-	def test_link_points_to_orcid_when_no_custom_setting(self):
+	def test_item_link_uses_the_requested_sites_domain(self):
+		CustomSetting.objects.create(
+			site=self.site, title="Item Link Site", rss_enabled=True
+		).scope_subjects.add(self.subject)
 		content = self._fetch_feed()
-		self.assertIn(
-			"<link>https://orcid.org/0000-0002-7922-9785</link>", content
-		)
+		self.assertIn(f"https://{self.site.domain}/articles/", content)
 
 
-class FeedVisibilityTest(TestCase):
+class SiteFeedScopeTest(TestCase):
 	"""
-	Both RSS feeds are scoped by subject, not by the owning team's
-	organisation (site-scoped API visibility, Phase 4). A subject reaches an
-	anonymous caller only by sitting in the scope_subjects of some site with
-	api_public on; nothing else grants access, and team ownership grants
-	none.
+	Both site-scoped feeds are scoped to the REQUESTED SITE's
+	scope_subjects -- not team ownership, and not the calling caller's own
+	visibility (Phase 5). This is the behaviour change from the pre-Phase-5
+	feeds, which read gregory.visibility.visible_subject_ids(request) and
+	therefore varied by who was asking.
 	"""
 
 	def setUp(self):
-		self.org = Organization.objects.create(name="Feed Org", slug="feed-org")
-		OrganizationApiSettings.objects.filter(organization=self.org).update(
-			make_api_public=True
-		)
+		self.org = Organization.objects.create(name="Feed Org", slug="feed-org-p5")
 		self.team = Team.objects.create(
-			name="Feed Team", organization=self.org, slug="feed-team"
+			name="Feed Team", organization=self.org, slug="feed-team-p5"
 		)
 		self.published = Subject.objects.create(
-			subject_name="Published", subject_slug="published", team=self.team
+			subject_name="Published", subject_slug="published-p5", team=self.team
 		)
-		# Owned by the same public organisation's team, but never curated
-		# into a site's scope. Under the old organisation rule this was
-		# visible; it is the narrowing this conversion introduces.
+		# Owned by the same team, but never curated into this site's scope.
 		self.uncurated = Subject.objects.create(
-			subject_name="Uncurated", subject_slug="uncurated", team=self.team
+			subject_name="Uncurated", subject_slug="uncurated-p5", team=self.team
 		)
-		# No team at all. The old check skipped subjects like this entirely
-		# ("if subject.team_id is not None"), so they were served to anyone
-		# who guessed the slug -- the hole this conversion closes.
+		# No team at all -- curation is the whole grant, so this resolves
+		# like any other subject once a site's scope names it (pinned below).
 		self.teamless = Subject.objects.create(
-			subject_name="Teamless", subject_slug="teamless", team=None
+			subject_name="Teamless", subject_slug="teamless-p5", team=None
 		)
 
-		self.site = Site.objects.create(domain="feeds.example.com", name="Feeds")
-		settings_row = CustomSetting.objects.create(
-			site=self.site, title="Feed settings", api_public=True
+		self.site = Site.objects.create(domain="feeds-p5.example.com", name="Feeds P5")
+		self.settings_row = CustomSetting.objects.create(
+			site=self.site, title="Feed settings P5", rss_enabled=True
 		)
-		settings_row.scope_subjects.add(self.published)
+		self.settings_row.scope_subjects.add(self.published)
 
 		for subject in (self.published, self.uncurated, self.teamless):
 			trial = Trials.objects.create(
@@ -147,66 +205,106 @@ class FeedVisibilityTest(TestCase):
 			trial.teams.add(self.team)
 			trial.subjects.add(subject)
 
-	def _trials_feed(self, subject):
+	def _trials_feed(self, subject, site_id=None):
 		return self.client.get(
-			reverse("trials_by_subject_feed", args=[subject.subject_slug])
+			reverse(
+				"site_trials_by_subject_feed",
+				kwargs={
+					"site_id": site_id if site_id is not None else self.site.pk,
+					"subject_slug": subject.subject_slug,
+				},
+			)
 		)
 
-	def test_subject_in_a_public_sites_scope_is_served(self):
+	def _author_feed(self, orcid, site_id=None):
+		return self.client.get(
+			reverse(
+				"site_articles_by_author_feed",
+				kwargs={
+					"site_id": site_id if site_id is not None else self.site.pk,
+					"orcid": orcid,
+				},
+			)
+		)
+
+	def test_subject_in_the_requested_sites_scope_is_served(self):
 		response = self._trials_feed(self.published)
 		self.assertEqual(response.status_code, 200)
-		self.assertIn("trial-published", response.content.decode())
+		self.assertIn("trial-published-p5", response.content.decode())
 
-	def test_subject_owned_by_a_public_org_but_uncurated_404s(self):
+	def test_subject_owned_by_the_same_team_but_uncurated_404s(self):
 		self.assertEqual(self._trials_feed(self.uncurated).status_code, 404)
 
-	def test_subject_with_no_team_404s(self):
+	def test_subject_with_no_team_404s_until_curated(self):
 		self.assertEqual(self._trials_feed(self.teamless).status_code, 404)
 
-	def test_subject_with_no_team_is_served_once_a_site_curates_it(self):
-		# The counterpart to the test above, and the reason it passes: a
-		# team-less subject is unreachable because nothing publishes it, not
-		# because it has no team. Curation is the whole grant, so an
-		# administrator who puts one in a public site's scope has published
-		# it deliberately and it resolves like any other subject. Pinned so
-		# that a well-meaning "team-less subjects are never public" guard
-		# cannot be added back without failing here.
-		settings_row = CustomSetting.objects.get(site=self.site)
-		settings_row.scope_subjects.add(self.teamless)
+	def test_subject_with_no_team_is_served_once_this_site_curates_it(self):
+		self.settings_row.scope_subjects.add(self.teamless)
 		response = self._trials_feed(self.teamless)
 		self.assertEqual(response.status_code, 200)
-		self.assertIn("trial-teamless", response.content.decode())
+		self.assertIn("trial-teamless-p5", response.content.decode())
 
-	def test_author_feed_404s_when_no_article_carries_a_visible_subject(self):
+	def test_unknown_site_id_404s(self):
+		self.assertEqual(self._trials_feed(self.published, site_id=999999).status_code, 404)
+
+	def test_site_with_rss_disabled_404s(self):
+		self.settings_row.rss_enabled = False
+		self.settings_row.save()
+		self.assertEqual(self._trials_feed(self.published).status_code, 404)
+
+	def test_site_with_no_customsetting_404s(self):
+		bare_site = Site.objects.create(domain="bare-p5.example.com", name="Bare P5")
+		self.assertEqual(self._trials_feed(self.published, site_id=bare_site.pk).status_code, 404)
+
+	def test_response_does_not_vary_by_caller(self):
+		"""
+		The defining property of Phase 5: unlike the pre-Phase-5 feeds, an
+		anonymous caller, a signed-in member of the owning organisation, and
+		a caller with no relationship to it at all see exactly the same
+		body -- because the scope is the requested site's, not theirs.
+		"""
+		from django.contrib.auth import get_user_model
+		from organizations.models import OrganizationUser
+
+		User = get_user_model()
+		user = User.objects.create_user(username="member-p5", password="pw")
+		OrganizationUser.objects.create(organization=self.org, user=user)
+
+		anon_body = self._trials_feed(self.published).content.decode()
+
+		self.client.force_login(user)
+		member_body = self._trials_feed(self.published).content.decode()
+		self.client.logout()
+
+		self.assertEqual(anon_body, member_body)
+		# Uncurated content stays absent for the org's own member too --
+		# team ownership grants nothing here, matching the org-member case
+		# below for the author feed.
+		self.assertEqual(self._trials_feed(self.uncurated).status_code, 404)
+
+	def test_author_feed_404s_when_no_article_carries_the_sites_subject(self):
 		author = Authors.objects.create(
-			given_name="Un", family_name="Seen", ORCID="0000-0002-0000-0009"
+			given_name="Un", family_name="Seen", ORCID="0000-0002-0000-0019"
 		)
 		article = Articles.objects.create(
-			title="uncurated-article", link="https://example.org/uncurated"
+			title="uncurated-article-p5", link="https://example.org/uncurated-p5"
 		)
 		article.teams.add(self.team)
 		article.subjects.add(self.uncurated)
 		article.authors.add(author)
-		self.assertEqual(
-			self.client.get(
-				reverse("articles_by_author_feed", args=[author.ORCID])
-			).status_code,
-			404,
-		)
+		self.assertEqual(self._author_feed(author.ORCID).status_code, 404)
 
-	def test_author_feed_lists_only_visible_subject_articles(self):
+	def test_author_feed_lists_only_this_sites_scope_articles(self):
 		author = Authors.objects.create(
-			given_name="Mixed", family_name="Bag", ORCID="0000-0002-0000-0010"
+			given_name="Mixed", family_name="Bag", ORCID="0000-0002-0000-0020"
 		)
-		for subject, slug in ((self.published, "shown"), (self.uncurated, "hidden")):
+		for subject, slug in ((self.published, "shown-p5"), (self.uncurated, "hidden-p5")):
 			article = Articles.objects.create(
 				title=f"{slug}-article", link=f"https://example.org/{slug}"
 			)
 			article.teams.add(self.team)
 			article.subjects.add(subject)
 			article.authors.add(author)
-		body = self.client.get(
-			reverse("articles_by_author_feed", args=[author.ORCID])
-		).content.decode()
-		self.assertIn("shown-article", body)
-		self.assertNotIn("hidden-article", body)
+		body = self._author_feed(author.ORCID).content.decode()
+		self.assertIn("shown-p5-article", body)
+		self.assertNotIn("hidden-p5-article", body)

--- a/django/rss/views.py
+++ b/django/rss/views.py
@@ -1,72 +1,114 @@
+"""
+rss/views.py
+
+Site-scoped RSS feeds: /feed/sites/<site_id>/author/<orcid>/ and
+/feed/sites/<site_id>/trials/subject/<subject_slug>/.
+
+A feed serves the REQUESTED SITE's CustomSetting.scope_subjects, not the
+calling caller's own visibility -- these are crawler-and-reader-facing
+surfaces like rss/sitemaps.py, not request-scoped ones like the rest of the
+API. A feed reader has no identity and its response is cached, so the body
+must not vary by who (or what) is asking. See
+PHASE-5-RSS-SITE-SCOPE-PLAN.md and rss/sitemaps.py's module docstring for
+the same reasoning applied to sitemaps.
+
+404 when the site doesn't exist, has no CustomSetting, or has
+CustomSetting.rss_enabled=False -- matching how sitemaps 404 on
+generate_sitemap=False. 404 (not an empty feed) when the author/subject
+carries no subject in that site's scope.
+
+The old caller-scoped, unprefixed URLs (feed/author/<orcid>/,
+feed/trials/subject/<slug>/) still resolve, via redirect_articles_by_author_feed
+/redirect_trials_by_subject_feed below, to a permanent (301) redirect onto
+the equivalent site-scoped URL for brain-regeneration.com (site id 3), the
+project's one api_public site. Feed readers cache a 301 and stop
+re-requesting the old path, which is the entire reason a redirect was
+chosen over reimplementing the old caller-scoped behaviour here: a feed
+reader never sees an error, so a silent 404 loses a subscriber permanently
+rather than visibly. See the spec's "Old URLs redirect permanently" section.
+"""
+
 from django.contrib.syndication.views import Feed
 from django.contrib.sites.models import Site
 from django.db.models import F
-from django.http import Http404
+from django.http import Http404, HttpResponsePermanentRedirect
+from django.shortcuts import get_object_or_404
+from django.urls import reverse
 from gregory.models import Articles, Authors, Trials, Subject
 from gregory.functions import normalize_orcid
-from gregory.visibility import visible_subject_ids as _visible_subject_ids
+from sitesettings.models import CustomSetting
 from sitesettings.utils import author_page_base
 
+# brain-regeneration.com -- the project's only api_public site today, and
+# the fixed redirect target for the old unprefixed feed URLs. Revisit only
+# if a second public site ever makes that ambiguous (spec: "Old URLs
+# redirect permanently").
+_REDIRECT_TARGET_SITE_ID = 3
 
-def get_website_domain():
-	current_site = Site.objects.get_current()
-	# Always return a domain, never an email
-	return current_site.domain
+
+def _site_feed_scope(site_id):
+	"""Resolve the Site, its CustomSetting and its RSS-visible subject ids.
+
+	404s exactly like rss/sitemaps.py's _site_sitemaps: unknown site, no
+	CustomSetting row, or the feature switch off. Unlike sitemaps there is
+	no "narrow to the public scope" step -- a feed's scope IS its site's
+	scope_subjects regardless of whether that site is api_public, mirroring
+	how a site-bound API key reads its own scope in
+	gregory.visibility.visible_subject_ids.
+	"""
+	site = get_object_or_404(Site, pk=site_id)
+	# CustomSetting.site is a plain FK (not unique) -- order explicitly so
+	# the chosen row is deterministic if more than one ever exists for a site.
+	settings_row = CustomSetting.objects.filter(site=site).order_by("setting_id").first()
+	if settings_row is None or not settings_row.rss_enabled:
+		raise Http404("RSS feed not enabled for this site.")
+	subject_ids = set(settings_row.scope_subjects.values_list("id", flat=True))
+	return site, settings_row, subject_ids
 
 
-class ArticlesByAuthorFeed(Feed):
-	def get_object(self, request, orcid):
-		# Resolve strictly by normalized ORCID only
-		normalized = normalize_orcid(orcid)
-		if not normalized:
-			raise Authors.DoesNotExist
-		author = Authors.objects.get(ORCID=normalized)
+def _redirect_preserving_query(request, target_url):
+	query_string = request.META.get("QUERY_STRING", "")
+	if query_string:
+		target_url = f"{target_url}?{query_string}"
+	return HttpResponsePermanentRedirect(target_url)
 
-		# Compute visibility and attach to the per-request obj (not self)
-		# so concurrent requests on the shared Feed instance don't interfere.
-		author._visible_subject_ids = _visible_subject_ids(request)
 
-		# 404 if the author has no articles under any visible subject
-		if not author.articles_set.filter(
-			subjects__in=author._visible_subject_ids
-		).exists():
-			raise Http404
+def redirect_articles_by_author_feed(request, orcid):
+	"""301 from the old feed/author/<orcid>/ onto its site-scoped equivalent.
 
-		return author
+	Always redirects, whatever the orcid -- an invalid one 404s at the new
+	URL exactly as it would have here, and a redirect costs nothing extra
+	to compute. See the module docstring for why this is a redirect and not
+	a reimplementation of the old caller-scoped view.
+	"""
+	target = reverse(
+		"site_articles_by_author_feed",
+		kwargs={"site_id": _REDIRECT_TARGET_SITE_ID, "orcid": orcid},
+	)
+	return _redirect_preserving_query(request, target)
 
-	# Feed metadata (dynamic per author)
-	def title(self, obj):
-		return f"Articles by {obj.full_name or 'Author'}"
 
-	def link(self, obj):
-		# Link to the site's author page when it publishes one, else orcid.org
-		base = author_page_base(Site.objects.get_current())
-		if base:
-			return f"{base}/{obj.ORCID}/"
-		return f"https://orcid.org/{obj.ORCID}"
+def redirect_trials_by_subject_feed(request, subject_slug):
+	"""301 from the old feed/trials/subject/<slug>/ onto its site-scoped equivalent."""
+	target = reverse(
+		"site_trials_by_subject_feed",
+		kwargs={"site_id": _REDIRECT_TARGET_SITE_ID, "subject_slug": subject_slug},
+	)
+	return _redirect_preserving_query(request, target)
 
-	description = "RSS feed for articles by a specific author."
 
-	def items(self, obj):
-		return (
-			Articles.objects.filter(
-				authors=obj,
-				subjects__in=obj._visible_subject_ids,
-			)
-			.distinct()
-			# nulls_last: articles ingested without a date (filled later from
-			# CrossRef) must not pin to the top of the feed
-			.order_by(F("published_date").desc(nulls_last=True))[:50]
-		)
+class _ArticleFeedItemMixin:
+	"""item_* methods shared by author-scoped article feeds.
+
+	item_link is deliberately not here: it needs the requested site's
+	domain, which differs per feed class (see SiteArticlesByAuthorFeed).
+	"""
 
 	def item_title(self, item):
 		return item.title
 
 	def item_description(self, item):
 		return item.summary
-
-	def item_link(self, item):
-		return f"https://{get_website_domain()}/articles/{str(item.pk)}/"
 
 	def item_guid(self, item):
 		if item.doi:
@@ -82,41 +124,8 @@ class ArticlesByAuthorFeed(Feed):
 		return item.discovery_date
 
 
-class TrialsBySubjectFeed(Feed):
-	"""RSS feed for clinical trials filtered by subject slug."""
-
-	def get_object(self, request, subject_slug):
-		subject = Subject.objects.get(subject_slug=subject_slug)
-
-		# The subject IS the visibility unit now, so this is a set membership
-		# test rather than a walk up to the owning team's organisation. It
-		# also closes a hole the old check left open: a subject with no team
-		# skipped the check entirely and was served to anyone, which is how
-		# an internal-research subject could be read by slug.
-		if subject.id not in _visible_subject_ids(request):
-			raise Http404
-
-		return subject
-
-	# Feed metadata (dynamic per subject)
-	def title(self, obj):
-		return f"Clinical Trials - {obj.subject_name}"
-
-	def link(self, obj):
-		return f"https://{get_website_domain()}/trials/subject/{obj.subject_slug}/"
-
-	def description(self, obj):
-		return f"RSS feed for clinical trials related to {obj.subject_name}."
-
-	def items(self, obj):
-		return (
-			# get_object() has already established that obj is a visible
-			# subject, so matching on it is the whole visibility test — no
-			# second filter to add.
-			Trials.objects.filter(subjects=obj)
-			.distinct()
-			.order_by("-discovery_date")[:50]
-		)
+class _TrialFeedItemMixin:
+	"""item_* methods shared by subject-scoped trial feeds."""
 
 	def item_title(self, item):
 		return item.title
@@ -214,3 +223,93 @@ class TrialsBySubjectFeed(Feed):
 
 	def item_updateddate(self, item):
 		return item.last_updated
+
+
+class SiteArticlesByAuthorFeed(_ArticleFeedItemMixin, Feed):
+	"""feed/sites/<site_id>/author/<orcid>/ -- see module docstring."""
+
+	def get_object(self, request, site_id, orcid):
+		site, settings_row, subject_ids = _site_feed_scope(site_id)
+
+		normalized = normalize_orcid(orcid)
+		if not normalized:
+			raise Authors.DoesNotExist
+		author = Authors.objects.get(ORCID=normalized)
+
+		# Attach to the per-request obj (not self) so concurrent requests on
+		# the shared Feed instance don't interfere.
+		author._site = site
+		author._settings_row = settings_row
+		author._subject_ids = subject_ids
+
+		# 404 if the author has no articles under this site's scope.
+		if not author.articles_set.filter(subjects__in=subject_ids).exists():
+			raise Http404
+
+		return author
+
+	def title(self, obj):
+		return f"Articles by {obj.full_name or 'Author'}"
+
+	def link(self, obj):
+		# Link to the site's author page when it publishes one, else orcid.org.
+		base = author_page_base(obj._site, obj._settings_row)
+		if base:
+			return f"{base}/{obj.ORCID}/"
+		return f"https://orcid.org/{obj.ORCID}"
+
+	description = "RSS feed for articles by a specific author."
+
+	def items(self, obj):
+		articles = list(
+			Articles.objects.filter(
+				authors=obj,
+				subjects__in=obj._subject_ids,
+			)
+			.distinct()
+			# nulls_last: articles ingested without a date (filled later from
+			# CrossRef) must not pin to the top of the feed
+			.order_by(F("published_date").desc(nulls_last=True))[:50]
+		)
+		# item_link() below only receives the item, not obj -- stash the
+		# requested site's domain on each item rather than on self, for the
+		# same concurrency reason obj carries its own state above.
+		for article in articles:
+			article._feed_site_domain = obj._site.domain
+		return articles
+
+	def item_link(self, item):
+		return f"https://{item._feed_site_domain}/articles/{str(item.pk)}/"
+
+
+class SiteTrialsBySubjectFeed(_TrialFeedItemMixin, Feed):
+	"""feed/sites/<site_id>/trials/subject/<subject_slug>/ -- see module docstring."""
+
+	def get_object(self, request, site_id, subject_slug):
+		site, _settings_row, subject_ids = _site_feed_scope(site_id)
+		subject = Subject.objects.get(subject_slug=subject_slug)
+
+		if subject.id not in subject_ids:
+			raise Http404
+
+		subject._site = site
+		return subject
+
+	def title(self, obj):
+		return f"Clinical Trials - {obj.subject_name}"
+
+	def link(self, obj):
+		return f"https://{obj._site.domain}/trials/subject/{obj.subject_slug}/"
+
+	def description(self, obj):
+		return f"RSS feed for clinical trials related to {obj.subject_name}."
+
+	def items(self, obj):
+		return (
+			# get_object() has already established that obj's subject is in
+			# this site's scope, so matching on it is the whole visibility
+			# test -- no second filter to add.
+			Trials.objects.filter(subjects=obj)
+			.distinct()
+			.order_by("-discovery_date")[:50]
+		)

--- a/django/rss/views.py
+++ b/django/rss/views.py
@@ -5,12 +5,12 @@ Site-scoped RSS feeds: /feed/sites/<site_id>/author/<orcid>/ and
 /feed/sites/<site_id>/trials/subject/<subject_slug>/.
 
 A feed serves the REQUESTED SITE's CustomSetting.scope_subjects, not the
-calling caller's own visibility -- these are crawler-and-reader-facing
-surfaces like rss/sitemaps.py, not request-scoped ones like the rest of the
-API. A feed reader has no identity and its response is cached, so the body
-must not vary by who (or what) is asking. See
-PHASE-5-RSS-SITE-SCOPE-PLAN.md and rss/sitemaps.py's module docstring for
-the same reasoning applied to sitemaps.
+caller's own visibility -- these are crawler-and-reader-facing surfaces
+like rss/sitemaps.py, not request-scoped ones like the rest of the API. A
+feed reader has no identity and its response is cached, so the body must
+not vary by who (or what) is asking. See docs/03-api-and-rss-feeds.md#rss-feeds
+and rss/sitemaps.py's module docstring for the same reasoning applied to
+sitemaps.
 
 404 when the site doesn't exist, has no CustomSetting, or has
 CustomSetting.rss_enabled=False -- matching how sitemaps 404 on
@@ -25,7 +25,7 @@ project's one api_public site. Feed readers cache a 301 and stop
 re-requesting the old path, which is the entire reason a redirect was
 chosen over reimplementing the old caller-scoped behaviour here: a feed
 reader never sees an error, so a silent 404 loses a subscriber permanently
-rather than visibly. See the spec's "Old URLs redirect permanently" section.
+rather than visibly. See docs/03-api-and-rss-feeds.md#old-feed-urls--permanent-redirect.
 """
 
 from django.contrib.syndication.views import Feed

--- a/docs/03-api-and-rss-feeds.md
+++ b/docs/03-api-and-rss-feeds.md
@@ -26,18 +26,20 @@ A read-only [MCP server](07-mcp-server.md) also exposes this API to LLM clients 
 
 | Feed | URL pattern |
 |:-----|:------------|
-| Articles by author (ORCID) | `GET /feed/author/{orcid}/` |
-| Clinical trials by subject | `GET /feed/trials/subject/{subject_slug}/` |
+| Articles by author (ORCID) | `GET /feed/sites/{site_id}/author/{orcid}/` |
+| Clinical trials by subject | `GET /feed/sites/{site_id}/trials/subject/{subject_slug}/` |
 
 Both feeds return the 50 most recent items, ordered by newest first.
 
-Both are scoped by subject. A subject is readable when it sits in the `scope_subjects` of a site the caller can see — for an anonymous caller, any site with *API public* on; for a site-bound API key, that key's own site; for a signed-in user, the sites owned by their organisations. The trials feed 404s when the requested subject is not one of those, and the author feed 404s when none of the author's articles carries one, otherwise listing only the articles that do.
+**Feeds are site-scoped, not caller-scoped** — the same design as the [sitemaps](#sitemaps) below, and a deliberate change from how this worked before. A feed serves the *requested site's* `CustomSetting.scope_subjects`: the trials feed 404s when the requested subject is not in that site's scope, and the author feed 404s when none of the author's articles carries a subject in it, otherwise listing only the articles that do. The response never varies by who (or what) is asking — a feed reader has no identity and the response is cached, so there is nothing to key a caller-specific response on. `?include_public=true` and any notion of "the caller's own scope" (API key, signed-in user) do not apply to these URLs at all.
 
-Curation into a site's scope is the whole grant, so team ownership neither adds nor removes access. A subject owned by a team in a publicly visible organisation is *not* readable unless some site publishes it, and a subject with no team at all is readable if a site does — team-less subjects are unreachable by default because nothing curates them, not by rule.
+A site's feed is gated by its own `CustomSetting.rss_enabled` alone — 404 when it's off, or when the site has no `CustomSetting` row, or when `site_id` doesn't exist. Unlike the sitemaps, a feed's scope is **not** narrowed to the publicly-visible subject set: `rss_enabled` and `scope_subjects` are the whole gate, whether or not the site is `api_public` — the same rule a site-bound API key follows for its own scope (see [Visibility rules summary](#visibility-rules-summary)). Curation into the site's scope is the whole grant otherwise, so team ownership plays no part: a subject with no team is served once some site's scope names it, exactly as for the API and sitemaps.
 
-`?include_public=true` adds the scopes of every *API public* site to an identified caller's own scope, which is how a private site's frontend reads public content alongside its own. It is a no-op for an anonymous caller, whose scope already is exactly that set. (Under the previous organisation-scoped rule this flag read "adds public organisations".)
+The author feed's `<link>` element points at the requested site's author profile page (`https://{site.domain}/authors/{orcid}/`) when that site's `CustomSetting.has_author_pages` is on, and at `https://orcid.org/{orcid}` otherwise. See [Author profile page links](06-organisations-teams-and-sites.md#author-profile-page-links).
 
-The author feed's `<link>` element points at the site's author profile page (`https://{site.domain}/authors/{orcid}/`) when the current Site's `CustomSetting.has_author_pages` is on, and at `https://orcid.org/{orcid}` otherwise. See [Author profile page links](06-organisations-teams-and-sites.md#author-profile-page-links).
+### Old feed URLs — permanent redirect
+
+`GET /feed/author/{orcid}/` and `GET /feed/trials/subject/{subject_slug}/` (no `site_id`) still resolve, but now return **301** to their `/feed/sites/3/...` equivalent (`3` = brain-regeneration.com, the project's one `api_public` site), preserving any query string. They are not reimplemented against a caller's own scope any more — before this change they were the only caller-scoped surface on this list, returning different content to an anonymous caller, a signed-in member, and an API key on the exact same URL. A feed reader caches a permanent redirect and stops re-requesting the old path; a `404` would instead go unnoticed and silently drop the subscription. **These routes are permanent** — do not remove them in a future cleanup, or the redirect becomes a 404 for every reader still on the old path.
 
 ---
 
@@ -144,7 +146,7 @@ Two endpoints are not content and do not follow this rule:
 
 **`/sponsors/`** is scoped indirectly: a sponsor carries no subject and is visible when at least one of its trials is in scope. Its `trials_count` counts only in-scope trials, so neither the number nor `?ordering=-trials_count` discloses trials the caller cannot read.
 
-> **Note:** This subject-scoped rule is the API's and RSS feeds' alone. The Django admin uses a deliberately different rule — see [06-organisations-teams-and-sites.md#admin-visibility](06-organisations-teams-and-sites.md#admin-visibility).
+> **Note:** This caller-scoped rule is the API's alone. RSS feeds are scoped to the *requested site*, not the caller — see [RSS feeds](#rss-feeds) — much like the [sitemaps](#sitemaps) below. The Django admin uses a deliberately different rule again — see [06-organisations-teams-and-sites.md#admin-visibility](06-organisations-teams-and-sites.md#admin-visibility).
 
 ---
 
@@ -232,8 +234,9 @@ GET /articles/?team_id=1&subjects=1,3&published_date_after=2022-06-01&format=csv
 | Email templates | `GET /emails/` | None | Template preview dashboard |
 | Email templates | `GET /emails/preview/{template_name}/` | `template_name` (path) | |
 | Email templates | `GET /emails/context/{template_name}/` | `template_name` (path) | |
-| RSS feeds | `GET /feed/author/{orcid}/` | `orcid` (path) | |
-| RSS feeds | `GET /feed/trials/subject/{subject_slug}/` | `subject_slug` (path) | |
+| RSS feeds | `GET /feed/sites/{site_id}/author/{orcid}/` | `site_id`, `orcid` (path) | Site-scoped — see [RSS feeds](#rss-feeds) |
+| RSS feeds | `GET /feed/sites/{site_id}/trials/subject/{subject_slug}/` | `site_id`, `subject_slug` (path) | Site-scoped — see [RSS feeds](#rss-feeds) |
+| RSS feeds (old, no `site_id`) | `GET /feed/author/{orcid}/`, `GET /feed/trials/subject/{subject_slug}/` | `orcid` / `subject_slug` (path) | **301** to the `/feed/sites/3/...` equivalent — see [Old feed URLs](#old-feed-urls--permanent-redirect) |
 | Stats | `GET /stats/` | `team`, `site`, `subject`, `include_public`, `organization` (alias `org`, deprecated) | See [Stats endpoint](#stats-endpoint) below |
 | Sites | `GET /sites/` | None | Publicly readable sites as `{site_id, domain, name}`. **Unscoped by design** — it is the discovery entry point for callers that need a `site_id`, so it cannot require one. Everything returned is already public |
 | Subscriptions | `POST /subscriptions/new/` | `first_name`, `last_name`, `email`, `profile`, `list` | POST-only; `GET` returns `405` with `Allow: POST` |

--- a/docs/06-organisations-teams-and-sites.md
+++ b/docs/06-organisations-teams-and-sites.md
@@ -13,7 +13,7 @@ GregoryAI supports a multi-tenant structure where content, credentials, and emai
 | **Organisation** | Top-level grouping (provided by `django-organizations`). Owns teams, credentials, and sites. |
 | **Team** | Belongs to one Organisation. Owns subjects, sources, and optionally its own site and credentials. |
 | **Site** | A Django `sites` framework entry (`domain` + `name`). Used as the base URL for email sender addresses. |
-| **CustomSetting** | Per-site settings: site title, email footer, admin email, sender email prefix, whether the site publishes author profile pages, the [sitemap](03-api-and-rss-feeds.md#sitemaps) switches (master switch, curated subjects, articles-relevant-only, include trials, trial recruitment statuses), and the export/about metadata (description, contact email, data licence, citation) shown on the "About this file" sheet of `export_trials_xlsx` workbooks. |
+| **CustomSetting** | Per-site settings: site title, email footer, admin email, sender email prefix, whether the site publishes author profile pages, `scope_subjects` (what the site owns for anonymous API/RSS visibility) and `api_public` (whether that scope is visible to anonymous API callers), `rss_enabled` (whether the site serves [RSS feeds](03-api-and-rss-feeds.md#rss-feeds) at `/feed/sites/{site_id}/...`, scoped to `scope_subjects` regardless of `api_public`), the [sitemap](03-api-and-rss-feeds.md#sitemaps) switches (master switch, curated subjects, articles-relevant-only, include trials, trial recruitment statuses), and the export/about metadata (description, contact email, data licence, citation) shown on the "About this file" sheet of `export_trials_xlsx` workbooks. |
 | **TeamCredentials** | Postmark API token and URL scoped to a specific team. |
 | **OrganisationCredentials** | Postmark API token and URL scoped to an organisation. Used as fallback when a team has no credentials. |
 | **OrganisationSite** | Links an Organisation to one or more Sites. One can be marked as `is_default`. |
@@ -124,7 +124,7 @@ Only one Site per Organisation can be marked as default (enforced by a database 
 Some sites publish an author profile page for each author at `/authors/<orcid>/`. Tick **Has author pages** in the Site's Custom Setting (under **Website URLs**) to have GregoryAI link author names there instead of `orcid.org`:
 
 - **Weekly digest and admin summary emails** — each author's name links to `https://{site.domain}/authors/{ORCID}/`.
-- **Author RSS feed** (`/feed/author/<orcid>/`) — the feed's `<link>` element points at the same URL.
+- **Author RSS feed** (`/feed/sites/<site_id>/author/<orcid>/`) — the feed's `<link>` element points at the same URL.
 
 When the flag is off (the default), all of the above link to `https://orcid.org/{ORCID}` instead. The base URL is derived from the Site's `domain`, so no separate URL field is needed.
 

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -124,8 +124,8 @@ GET /authors/?team_id=1&sort_by=article_count&order=desc
 # Get authors for a specific subject this year
 GET /authors/?team_id=1&subject_id=2&timeframe=year&sort_by=article_count
 
-# Get author RSS feed by ORCID
-GET /feed/author/0000-0000-0000-1234/
+# Get author RSS feed by ORCID (site-scoped; 3 = brain-regeneration.com)
+GET /feed/sites/3/author/0000-0000-0000-1234/
 ```
 
 Reference: [authors-api.md](authors-api.md), [03-api-and-rss-feeds.md](03-api-and-rss-feeds.md)


### PR DESCRIPTION
## Summary

Part of the [site-scoped API visibility project](https://github.com/brunoamaral/gregory-ai) — Phase 5, RSS feeds. Full context in the parent plan/spec (local, untracked planning docs).

- Adds `GET /feed/sites/{site_id}/author/{orcid}/` and `GET /feed/sites/{site_id}/trials/subject/{subject_slug}/`, scoped to the **requested site's** `CustomSetting.scope_subjects` and gated solely by `CustomSetting.rss_enabled` — never by the calling caller's own visibility. A feed reader has no identity and the response is cached, so it must not vary by who's asking (same reasoning as `rss/sitemaps.py`, not the old caller-scoped `rss/views.py`).
- The old `GET /feed/author/{orcid}/` and `GET /feed/trials/subject/{subject_slug}/` now return a permanent **301** to the `/feed/sites/3/...` (brain-regeneration.com) equivalent, preserving any query string, instead of serving content directly. A feed reader caches a 301 and stops re-requesting the old path; a 404 would instead go unnoticed and silently drop the subscription. The old URL patterns/names stay registered, with a comment against ever deleting them.
- Docs updated: `docs/03-api-and-rss-feeds.md`, `docs/06-organisations-teams-and-sites.md`, `docs/cookbook.md`. `schema.yml` regenerated — byte-identical (RSS isn't in the OpenAPI schema).

### One judgment call for reviewer attention

A feed's scope is **not** narrowed to the public-subject union the way sitemaps are — `rss_enabled` + the site's own `scope_subjects` is the whole gate, mirroring how a site-bound API key reads its own scope "whether or not the site is `api_public`" (`gregory.visibility.visible_subject_ids`). Today this is moot — only brain-regeneration.com (public) has `rss_enabled=True` — but it means a hypothetical *private* site with `rss_enabled=True` would serve its feed to anyone with no credential, unlike its API scope which still requires a key. Pinned as `PrivateSiteFeedTest` in `api/tests/test_visibility_rss.py` rather than silently assumed; flag if you'd rather it narrow to the public scope like sitemaps do.

## Test plan

- [x] Full Django suite passes (3384 passed) — `docker exec gregory python -m pytest -q -p no:cacheprovider`
- [x] `rss/` and `api/tests/test_visibility_rss.py` rewritten: redirect + query-string preservation, site-scope isolation (leak canary between two sites), caller-invariance (anonymous / signed-in member of an unrelated org / API key bound to an unrelated site all get an identical body), `rss_enabled` off / no `CustomSetting` / unknown `site_id` all 404, author `<link>` uses the requested site's domain
- [x] Verified each new guard by deliberately breaking it (removing the `rss_enabled` check, reintroducing caller-scoped filtering) and confirming the corresponding test fails
- [x] Manually verified against the prod-synced dev DB once migrated (`sitesettings` 0018/0019 applied): old URLs 301 to `/feed/sites/3/...` preserving query strings; site 3 (brain-regeneration.com, `rss_enabled=True`) serves real feed content with correct article/author links on its own domain; site 1 (gregory-ms.com, `rss_enabled=False`) and an unknown site both 404
- [x] `uvx ruff@0.16.00 check django/` clean
- [x] `schema.yml` regenerated — no diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)