### PR TITLE
Phase 3: anonymous site resolution with a conditional fail-closed 400

### DIFF
--- a/django/admin/settings.py
+++ b/django/admin/settings.py
@@ -286,6 +286,12 @@ REST_FRAMEWORK = {
 		'rest_framework.filters.OrderingFilter',
 	],
 	'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
+	# Delegates to DRF's own default handler for everything except
+	# gregory.site_resolution.NoSiteResolvedError (Phase 3 of site-scoped
+	# API visibility's fail-closed 400), whose int fields it restores after
+	# DRF's default handling would otherwise stringify them -- see that
+	# module's exception_handler and NoSiteResolvedError docstrings.
+	'EXCEPTION_HANDLER': 'gregory.site_resolution.exception_handler',
 }
 
 # drf-spectacular — OpenAPI schema generation. See /api/schema/, /api/schema/swagger-ui/,

--- a/django/api/tests/test_article_query_efficiency.py
+++ b/django/api/tests/test_article_query_efficiency.py
@@ -39,6 +39,13 @@ def _build_articles(n, suffix):
 	serializer touches (authors, teams, subjects, sources, team_categories,
 	article_subject_relevances, trial_references) so an un-prefetched
 	relation shows up as O(n) queries instead of O(1).
+
+	Returns the ``Site`` that publishes this batch's subject, so a caller can
+	pin an anonymous request to it (``?site_id=``) -- this helper creates a
+	brand-new Organization + public site every call, so two calls in one test
+	leave more than one ``api_public`` site around and an anonymous request
+	naming none of them is ambiguous under Phase 3 site resolution
+	(gregory/site_resolution.py).
 	"""
 	org = Organization.objects.create(name=f"Org {suffix}", slug=f"org-{suffix}")
 	# Anonymous requests only see orgs flagged public (gregory/visibility.py).
@@ -51,7 +58,7 @@ def _build_articles(n, suffix):
 	subject = Subject.objects.create(
 		team=team, subject_name=f"Subject {suffix}", subject_slug=f"subject-{suffix}"
 	)
-	publish_subjects(subject, organization=org)
+	site = publish_subjects(subject, organization=org)
 	source = Sources.objects.create(
 		name=f"Source {suffix}", source_for="science paper"
 	)
@@ -87,6 +94,8 @@ def _build_articles(n, suffix):
 			identifier_value=f"NCT{suffix}{i}",
 		)
 
+	return site
+
 
 class TestArticleListQueryEfficiency(TestCase):
 	"""Locks in the ArticleViewSet prefetch_related from Phase 0.1."""
@@ -101,16 +110,32 @@ class TestArticleListQueryEfficiency(TestCase):
 
 		Site.objects.get_current()
 
-		_build_articles(3, "a")
+		# Each _build_articles call creates its own Organization + public
+		# site, so pin each anonymous request to that call's own site via
+		# Origin -- otherwise, once both exist, an anonymous request naming
+		# neither is ambiguous under Phase 3 site resolution
+		# (gregory/site_resolution.py) and 400s. NOT ?site_id=: ArticleFilter
+		# already defines that param to mean "articles on a team attached to
+		# this site" (Team.site), an unrelated content filter that would
+		# zero out these results since these teams have no Team.site set.
+		site_a = _build_articles(3, "a")
 		with CaptureQueriesContext(connection) as small:
-			response = client.get("/articles/", {"page_size": 100})
+			response = client.get(
+				"/articles/",
+				{"page_size": 100},
+				HTTP_ORIGIN=f"https://{site_a.domain}",
+			)
 		self.assertEqual(response.status_code, 200)
 		self.assertEqual(len(response.data["results"]), 3)
 
 		Articles.objects.all().delete()
-		_build_articles(9, "b")
+		site_b = _build_articles(9, "b")
 		with CaptureQueriesContext(connection) as large:
-			response = client.get("/articles/", {"page_size": 100})
+			response = client.get(
+				"/articles/",
+				{"page_size": 100},
+				HTTP_ORIGIN=f"https://{site_b.domain}",
+			)
 		self.assertEqual(response.status_code, 200)
 		self.assertEqual(len(response.data["results"]), 9)
 

--- a/django/api/tests/test_articles_stats.py
+++ b/django/api/tests/test_articles_stats.py
@@ -44,6 +44,7 @@ from gregory.models import (
 	Subject,
 	Team,
 )
+from sitesettings.models import CustomSetting
 
 # Mirrors test_trials_stats.py: under subject-scoped visibility a row with no
 # subject is invisible to everyone, but nearly every `_make_article(...)`
@@ -190,6 +191,14 @@ class ArticleStatsBase(TestCase):
 		)
 
 		self.client = APIClient()
+		# Anonymous site resolution (Phase 3, gregory/site_resolution.py)
+		# needs a site indicator once more than one api_public site exists --
+		# this fixture creates two (self.org and other_org, both public by
+		# default via _make_org_team). Resolve every request in this class to
+		# self.org's site via Origin, matching what "the caller's own scope"
+		# has always meant in these tests -- self.other_org/other_team/
+		# other_subject stay the "should NOT appear" counterexample.
+		self.client.defaults["HTTP_ORIGIN"] = f"https://{_ORG_SITES[self.org.pk].domain}"
 
 
 class ArticleListNoStatsTest(ArticleStatsBase):
@@ -217,10 +226,12 @@ class ArticleStatsEndpointTest(ArticleStatsBase):
 		resp = self.client.get("/articles/stats/")
 		self.assertEqual(resp.status_code, 200)
 		stats = resp.data
-		self.assertEqual(stats["total"], 4)
+		# self.client resolves to self.org's site only (Phase 3), so a4
+		# (other_team/other_subject, a different site) is out of scope: a1-a3.
+		self.assertEqual(stats["total"], 3)
 		self.assertEqual(stats["relevant"], 1)
 		self.assertEqual(stats["retracted"], 1)
-		self.assertEqual(stats["missing_doi"], 2)  # a3 ('') + a4 (NULL)
+		self.assertEqual(stats["missing_doi"], 1)  # a3 ('')
 
 	def test_by_access_folds_null_into_unknown(self):
 		resp = self.client.get("/articles/stats/")
@@ -228,9 +239,9 @@ class ArticleStatsEndpointTest(ArticleStatsBase):
 		by_access = resp.data["by_access"]
 		self.assertEqual(by_access["open"], 1)
 		self.assertEqual(by_access["restricted"], 1)
-		# a3 (explicit 'unknown') + a4 (NULL) — consumers must not see the
-		# internal NULL/'unknown' split.
-		self.assertEqual(by_access["unknown"], 2)
+		# a3 (explicit 'unknown'); a4 (NULL) is other_subject -- a different
+		# site than self.client resolves to (Phase 3) -- so it's out of scope.
+		self.assertEqual(by_access["unknown"], 1)
 		self.assertEqual(set(by_access.keys()), {"open", "restricted", "unknown"})
 
 	def test_stats_with_team_filter_scopes_totals(self):
@@ -248,7 +259,9 @@ class ArticleStatsEndpointTest(ArticleStatsBase):
 		resp = self.client.get("/articles/stats/")
 		self.assertEqual(resp.status_code, 200)
 		stats = resp.data
-		self.assertEqual(stats["total"], 4)  # still 4 distinct articles
+		# a1-a3 visible (self.org's site); a4 is other_team/other_subject, a
+		# different site, out of scope for self.client regardless of this test.
+		self.assertEqual(stats["total"], 3)  # still 3 distinct articles
 		self.assertEqual(stats["by_access"]["open"], 1)
 		self.assertEqual(stats["relevant"], 1)
 
@@ -260,11 +273,15 @@ class ArticleStatsBySubjectTest(ArticleStatsBase):
 		other_subject = _make_subject(
 			self.other_team, "A-Other Subject", "a-other-subject"
 		)
-		# No organization= here: other_org already has a default site from
-		# _make_org_team, and OrganizationSite allows only one default per
-		# org. Anonymous visibility only needs an api_public site scoping
-		# the subject, so this stands alone.
-		publish_subjects(other_subject)
+		# Publishing other_subject on its own (org-less) site would put it on
+		# a different site than self.client resolves to (Phase 3 scopes an
+		# anonymous caller to exactly ONE site), so it would never show up
+		# alongside self.subject in one response. This test just wants both
+		# subjects visible together, so add other_subject to self.org's
+		# existing site scope instead.
+		CustomSetting.objects.get(site=_ORG_SITES[self.org.pk]).scope_subjects.add(
+			other_subject
+		)
 		self.a3.subjects.add(self.subject)
 		self.a4.subjects.add(other_subject)
 
@@ -304,7 +321,9 @@ class ArticleStatsBySubjectTest(ArticleStatsBase):
 
 		resp = self.client.get("/articles/stats/")
 		self.assertEqual(resp.status_code, 200)
-		self.assertEqual(resp.data["total"], 4)  # a1 still counted
+		# a1-a3 visible (self.org's site); a4 is other_team/other_subject, a
+		# different site, out of scope for self.client regardless of this test.
+		self.assertEqual(resp.data["total"], 3)  # a1 still counted
 		subject_ids = [row["subject_id"] for row in resp.data["by_subject"]]
 		self.assertIn(self.subject.id, subject_ids)
 		self.assertNotIn(hidden_subject.id, subject_ids)
@@ -339,9 +358,12 @@ class ArticleStatsCachingTest(ArticleStatsBase):
 		other_stats = self.client.get(
 			"/articles/stats/", {"team_id": self.other_team.id}
 		)
-		self.assertEqual(all_stats.data["total"], 4)
+		# self.client resolves to self.org's site only: a1-a3 visible, a4
+		# (other_team/other_subject) is out of scope, so the other_team filter
+		# now yields an empty result instead of other_team's own article.
+		self.assertEqual(all_stats.data["total"], 3)
 		self.assertEqual(team_stats.data["total"], 3)
-		self.assertEqual(other_stats.data["total"], 1)
+		self.assertEqual(other_stats.data["total"], 0)
 
 	def test_cache_is_isolated_per_visible_org_context(self):
 		# A private org with its own article: anonymous callers cannot see
@@ -369,24 +391,28 @@ class ArticleStatsCachingTest(ArticleStatsBase):
 		scheme = _make_api_scheme(priv_org, "a-stats-key")
 
 		anon = APIClient()
+		# Two api_public sites now exist (self.org, other_org); resolve
+		# anonymous requests to self.org's site specifically, same as
+		# self.client in setUp.
+		anon.defaults["HTTP_ORIGIN"] = f"https://{_ORG_SITES[self.org.pk].domain}"
 		anon_resp = anon.get("/articles/stats/")
 		self.assertEqual(anon_resp.status_code, 200)
-		# Anonymous sees only the two public orgs' 4 articles.
-		self.assertEqual(anon_resp.data["total"], 4)
+		# Anonymous resolves to self.org's site only: a1-a3.
+		self.assertEqual(anon_resp.data["total"], 3)
 
 		keyed = APIClient()
 		keyed.credentials(HTTP_AUTHORIZATION=scheme.api_key)
 		keyed_resp = keyed.get("/articles/stats/")
 		self.assertEqual(keyed_resp.status_code, 200)
 		# The org-scoped caller sees only its own org's single article — if
-		# it got the anonymous caller's cached payload this would be 4.
+		# it got the anonymous caller's cached payload this would be 3.
 		self.assertEqual(keyed_resp.data["total"], 1)
 		self.assertEqual(keyed_resp.data["relevant"], 1)
 
 		# And the reverse: a fresh anonymous request after the keyed one must
 		# not pick up the keyed caller's entry.
 		anon_again = anon.get("/articles/stats/")
-		self.assertEqual(anon_again.data["total"], 4)
+		self.assertEqual(anon_again.data["total"], 3)
 
 
 class ArticleStatsSubjectScopedRelevantTest(TestCase):
@@ -408,7 +434,7 @@ class ArticleStatsSubjectScopedRelevantTest(TestCase):
 		# Anonymous only; the org already has a default site from
 		# _make_org_team, and a second organization= link would collide with
 		# OrganizationSite's one-default-per-org constraint.
-		publish_subjects(self.subject_n, self.subject_m)
+		self.subjects_site = publish_subjects(self.subject_n, self.subject_m)
 
 		# In both subjects, manually relevant ONLY for M.
 		self.article = _make_article(
@@ -424,6 +450,10 @@ class ArticleStatsSubjectScopedRelevantTest(TestCase):
 		)
 
 		self.client = APIClient()
+		# _make_org_team's own default site (self.org) is a SECOND api_public
+		# site here alongside self.subjects_site (subject_n/subject_m); resolve
+		# anonymous requests to the latter, which is what this test is about.
+		self.client.defaults["HTTP_ORIGIN"] = f"https://{self.subjects_site.domain}"
 
 	def _stats(self, **params):
 		resp = self.client.get("/articles/stats/", params)

--- a/django/api/tests/test_author_api.py
+++ b/django/api/tests/test_author_api.py
@@ -14,6 +14,7 @@ from organizations.models import Organization
 from django_countries.fields import Country
 
 from api.tests.visibility_helpers import publish_subjects
+from sitesettings.models import CustomSetting
 
 
 class AuthorAPITest(TestCase):
@@ -34,7 +35,7 @@ class AuthorAPITest(TestCase):
 		self.subject = Subject.objects.create(
 			subject_name="Test Subject", subject_slug="test-subject", team=self.team
 		)
-		publish_subjects(self.subject, organization=self.organization)
+		self.site = publish_subjects(self.subject, organization=self.organization)
 
 		# Create test category
 		self.category = TeamCategory.objects.create(
@@ -202,7 +203,13 @@ class AuthorAPITest(TestCase):
 		other_subject = Subject.objects.create(
 			subject_name="Other Subject", subject_slug="other-subject", team=self.team
 		)
-		publish_subjects(other_subject)
+		# Publishing other_subject on its own (org-less) site would put it on
+		# a different site than self.client resolves to (Phase 3 scopes an
+		# anonymous caller to exactly ONE site), so it would never show up
+		# alongside self.subject in one response. This test just wants both
+		# subjects visible together, so add other_subject to self.site's
+		# existing scope instead.
+		CustomSetting.objects.get(site=self.site).scope_subjects.add(other_subject)
 		other_author = Authors.objects.create(
 			given_name="Extra", family_name="Author"
 		)

--- a/django/api/tests/test_author_coauthors.py
+++ b/django/api/tests/test_author_coauthors.py
@@ -239,7 +239,11 @@ class AuthorCoauthorsQueryCountTest(TestCase):
 		# reasoning as clear_cache() in setUp).
 		self.client.get(url)
 		Site.objects.clear_cache()
-		expected_queries = 5 if _count_cache_hit_is_a_db_query() else 4
+		# +1 for gregory.site_resolution.resolve_anonymous_site's public-site-
+		# count query (Phase 3): this anonymous, no-Origin caller now falls
+		# through to the public-union step, which costs one extra query
+		# compared to the old single-query _public_subject_ids() lookup.
+		expected_queries = 6 if _count_cache_hit_is_a_db_query() else 5
 		with self.assertNumQueries(expected_queries):
 			response = self.client.get(url)
 		self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -272,7 +276,11 @@ class AuthorCoauthorsQueryCountTest(TestCase):
 		# test_coauthors_query_budget_flat_with_page_content for why.
 		self.client.get("/authors/")
 		Site.objects.clear_cache()
-		expected_queries = 5 if _count_cache_hit_is_a_db_query() else 4
+		# +1 for gregory.site_resolution.resolve_anonymous_site's public-site-
+		# count query (Phase 3): this anonymous, no-Origin caller now falls
+		# through to the public-union step, which costs one extra query
+		# compared to the old single-query _public_subject_ids() lookup.
+		expected_queries = 6 if _count_cache_hit_is_a_db_query() else 5
 		with self.assertNumQueries(expected_queries):
 			response = self.client.get("/authors/")
 		self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/django/api/tests/test_site_resolution_visibility.py
+++ b/django/api/tests/test_site_resolution_visibility.py
@@ -15,7 +15,9 @@ Covers the acceptance list in PHASE-3-SITE-RESOLUTION-PLAN.md end to end:
     Origin as a private site never grants that site's scope.
   - A site-bound API key ignores a conflicting Origin entirely; so does a
     signed-in member.
-  - Vary: Origin is set exactly when the outcome could depend on it.
+  - Vary: Origin, Referer are set exactly when the outcome could depend on
+    either (resolve_anonymous_site() falls back to Referer when Origin is
+    absent, so a cache must not key on Origin alone).
   - GET /sites/ itself is never gated -- it's the discovery entry point.
   - RSS feeds and sitemaps (which resolve by SITE, not by caller -- Phase
     4b/5) are unaffected by any of this, since they never read
@@ -142,19 +144,37 @@ class TwoPublicSitesAmbiguityTest(TestCase):
 		resp = self.client.get("/articles/", HTTP_ORIGIN="https://not-a-registered-site.example")
 		self.assertEqual(resp.status_code, 400)
 
-	def test_vary_origin_set_on_the_400(self):
+	def test_vary_origin_and_referer_set_on_the_400(self):
 		resp = self.client.get("/articles/")
-		self.assertIn("Origin", resp.headers.get("Vary", ""))
+		vary = resp.headers.get("Vary", "")
+		self.assertIn("Origin", vary)
+		self.assertIn("Referer", vary)
 
-	def test_vary_origin_set_when_origin_actually_resolves(self):
+	def test_vary_origin_and_referer_set_when_origin_actually_resolves(self):
 		resp = self.client.get("/articles/", HTTP_ORIGIN=f"https://{self.site_a.domain}")
-		self.assertIn("Origin", resp.headers.get("Vary", ""))
+		vary = resp.headers.get("Vary", "")
+		self.assertIn("Origin", vary)
+		self.assertIn("Referer", vary)
 
-	def test_vary_origin_not_set_when_explicit_site_id_alone_settles_it(self):
-		"""?site_id= short-circuits before Origin is ever consulted, so a
-		cache keyed on this response need not vary by it."""
+	def test_vary_origin_and_referer_set_when_referer_actually_resolves(self):
+		"""resolve_anonymous_site() falls back to Referer when Origin is
+		absent, so the outcome can depend on Referer's value too -- a cache
+		must not vary by Origin alone."""
+		resp = self.client.get(
+			"/articles/", HTTP_REFERER=f"https://{self.site_a.domain}/page/"
+		)
+		vary = resp.headers.get("Vary", "")
+		self.assertIn("Origin", vary)
+		self.assertIn("Referer", vary)
+
+	def test_vary_not_set_when_explicit_site_id_alone_settles_it(self):
+		"""?site_id= short-circuits before Origin/Referer are ever
+		consulted, so a cache keyed on this response need not vary by
+		either."""
 		resp = self.client.get("/articles/", {"site_id": self.site_a.pk})
-		self.assertNotIn("Origin", resp.headers.get("Vary", ""))
+		vary = resp.headers.get("Vary", "")
+		self.assertNotIn("Origin", vary)
+		self.assertNotIn("Referer", vary)
 
 
 class SpoofedOriginNarrowingTest(TestCase):

--- a/django/api/tests/test_site_resolution_visibility.py
+++ b/django/api/tests/test_site_resolution_visibility.py
@@ -1,0 +1,331 @@
+"""
+End-to-end tests for Phase 3 of site-scoped API visibility: anonymous site
+resolution and its fail-closed 400, exercised through real HTTP requests
+(not direct calls to gregory.visibility.visible_subject_ids -- those are
+pinned in gregory/tests/test_visibility_subjects.py and
+gregory/tests/test_site_resolution.py).
+
+Covers the acceptance list in PHASE-3-SITE-RESOLUTION-PLAN.md end to end:
+  - Two or more api_public sites and no site indicator -> 400, body lists
+    the public sites, and that body is byte-for-byte the same list GET
+    /sites/ returns (one code path: gregory.site_resolution.public_sites).
+  - ?site_id=<public> resolves to that site's own scope.
+  - ?site_id=<private> never grants that site's scope.
+  - Origin resolves; Referer resolves when Origin is absent; spoofing
+    Origin as a private site never grants that site's scope.
+  - A site-bound API key ignores a conflicting Origin entirely; so does a
+    signed-in member.
+  - Vary: Origin is set exactly when the outcome could depend on it.
+  - GET /sites/ itself is never gated -- it's the discovery entry point.
+  - RSS feeds and sitemaps (which resolve by SITE, not by caller -- Phase
+    4b/5) are unaffected by any of this, since they never read
+    visible_subject_ids at all.
+
+Run with:
+    docker exec gregory python manage.py test api.tests.test_site_resolution_visibility
+"""
+
+from datetime import timedelta
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.utils.timezone import now
+from organizations.models import Organization, OrganizationUser
+from rest_framework.test import APIClient
+
+from api.models import APIAccessScheme
+from api.tests.visibility_helpers import private_site_publishing, publish_subjects
+from gregory.models import Articles, Subject, Team
+from sitesettings.models import CustomSetting
+
+User = get_user_model()
+
+
+class TwoPublicSitesAmbiguityTest(TestCase):
+	"""The case Phase 3 exists to guard: two api_public sites, no site
+	indicator. Serving the union would silently blend them."""
+
+	def setUp(self):
+		self.client = APIClient()
+		self.org_a = Organization.objects.create(name="Amb Org A", slug="amb-org-a")
+		self.org_b = Organization.objects.create(name="Amb Org B", slug="amb-org-b")
+		self.team_a = Team.objects.create(
+			organization=self.org_a, name="Amb Team A", slug="amb-team-a"
+		)
+		self.team_b = Team.objects.create(
+			organization=self.org_b, name="Amb Team B", slug="amb-team-b"
+		)
+		self.subject_a = Subject.objects.create(
+			subject_name="Amb Subject A", subject_slug="amb-subj-a", team=self.team_a
+		)
+		self.subject_b = Subject.objects.create(
+			subject_name="Amb Subject B", subject_slug="amb-subj-b", team=self.team_b
+		)
+		self.site_a = publish_subjects(
+			self.subject_a, organization=self.org_a, name="Amb Site A"
+		)
+		self.site_b = publish_subjects(
+			self.subject_b, organization=self.org_b, name="Amb Site B"
+		)
+		# ArticleFilter's OWN, unrelated ?site_id= filter (Team.site, still
+		# using the pre-Phase-6 team->site edge -- see
+		# SITE-API-VISIBILITY-SPEC.md's "site_id is broken today") reads the
+		# exact same query parameter this test uses for VISIBILITY
+		# resolution. Set Team.site to match so that legacy filter doesn't
+		# also silently exclude these fixtures and confound what this test
+		# is actually checking -- the collision itself is documented and
+		# deliberately deferred to Phase 6, not something this test covers.
+		self.team_a.site = self.site_a
+		self.team_a.save(update_fields=["site"])
+		self.team_b.site = self.site_b
+		self.team_b.save(update_fields=["site"])
+		article = Articles.objects.create(
+			title="Amb Article A", link="https://amb.example/a"
+		)
+		article.subjects.add(self.subject_a)
+		article.teams.add(self.team_a)
+
+	def test_no_indicator_returns_400(self):
+		resp = self.client.get("/articles/")
+		self.assertEqual(resp.status_code, 400)
+
+	def test_400_body_shape_and_content(self):
+		resp = self.client.get("/articles/")
+		self.assertEqual(resp.data["error"], "No site could be determined for this request.")
+		self.assertIn("site_id", resp.data["detail"])
+		site_ids = {row["site_id"] for row in resp.data["public_sites"]}
+		self.assertEqual(site_ids, {self.site_a.pk, self.site_b.pk})
+
+	def test_400_body_matches_get_sites(self):
+		error_resp = self.client.get("/articles/")
+		sites_resp = self.client.get("/sites/")
+		self.assertEqual(sites_resp.status_code, 200)
+
+		def _key(rows):
+			return sorted((r["site_id"], r["domain"], r["name"]) for r in rows)
+
+		self.assertEqual(_key(error_resp.data["public_sites"]), _key(sites_resp.data))
+
+	def test_get_sites_itself_is_never_gated(self):
+		"""The discovery endpoint cannot require the thing it exists to
+		provide -- it must answer with no site indicator, even amid the
+		exact ambiguity that gates every content endpoint."""
+		resp = self.client.get("/sites/")
+		self.assertEqual(resp.status_code, 200)
+
+	def test_explicit_site_id_resolves_despite_ambiguity(self):
+		resp = self.client.get("/articles/", {"site_id": self.site_a.pk})
+		self.assertEqual(resp.status_code, 200)
+		titles = [a["title"] for a in resp.data["results"]]
+		self.assertIn("Amb Article A", titles)
+
+	def test_explicit_site_id_for_the_other_site_excludes_the_first(self):
+		resp = self.client.get("/articles/", {"site_id": self.site_b.pk})
+		self.assertEqual(resp.status_code, 200)
+		titles = [a["title"] for a in resp.data["results"]]
+		self.assertNotIn("Amb Article A", titles)
+
+	def test_origin_resolves_to_the_matching_site(self):
+		resp = self.client.get("/articles/", HTTP_ORIGIN=f"https://{self.site_a.domain}")
+		self.assertEqual(resp.status_code, 200)
+		titles = [a["title"] for a in resp.data["results"]]
+		self.assertIn("Amb Article A", titles)
+
+	def test_referer_resolves_when_origin_absent(self):
+		resp = self.client.get(
+			"/articles/",
+			HTTP_REFERER=f"https://{self.site_a.domain}/some/page/",
+		)
+		self.assertEqual(resp.status_code, 200)
+
+	def test_unresolvable_origin_still_400s(self):
+		resp = self.client.get("/articles/", HTTP_ORIGIN="https://not-a-registered-site.example")
+		self.assertEqual(resp.status_code, 400)
+
+	def test_vary_origin_set_on_the_400(self):
+		resp = self.client.get("/articles/")
+		self.assertIn("Origin", resp.headers.get("Vary", ""))
+
+	def test_vary_origin_set_when_origin_actually_resolves(self):
+		resp = self.client.get("/articles/", HTTP_ORIGIN=f"https://{self.site_a.domain}")
+		self.assertIn("Origin", resp.headers.get("Vary", ""))
+
+	def test_vary_origin_not_set_when_explicit_site_id_alone_settles_it(self):
+		"""?site_id= short-circuits before Origin is ever consulted, so a
+		cache keyed on this response need not vary by it."""
+		resp = self.client.get("/articles/", {"site_id": self.site_a.pk})
+		self.assertNotIn("Origin", resp.headers.get("Vary", ""))
+
+
+class SpoofedOriginNarrowingTest(TestCase):
+	"""The single most important property in this phase: a caller claiming
+	to come from a private site's domain must never be granted that site's
+	scope -- narrowing only, never widening."""
+
+	def setUp(self):
+		self.client = APIClient()
+		self.org = Organization.objects.create(name="Spoof Org", slug="spoof-org")
+		self.team = Team.objects.create(
+			organization=self.org, name="Spoof Team", slug="spoof-team"
+		)
+		self.pub_subject = Subject.objects.create(
+			subject_name="Spoof Public", subject_slug="spoof-pub", team=self.team
+		)
+		self.priv_subject = Subject.objects.create(
+			subject_name="Spoof Private", subject_slug="spoof-priv", team=self.team
+		)
+		self.pub_site = publish_subjects(
+			self.pub_subject, organization=self.org, name="Spoof Public Site"
+		)
+		self.priv_site = private_site_publishing(
+			self.priv_subject, organization=self.org, name="Spoof Private Site"
+		)
+		pub_article = Articles.objects.create(
+			title="Spoof Public Article", link="https://spoof.example/pub"
+		)
+		pub_article.subjects.add(self.pub_subject)
+		pub_article.teams.add(self.team)
+		priv_article = Articles.objects.create(
+			title="Spoof Private Article", link="https://spoof.example/priv"
+		)
+		priv_article.subjects.add(self.priv_subject)
+		priv_article.teams.add(self.team)
+
+	def test_spoofed_private_origin_falls_back_to_the_sole_public_site(self):
+		"""Exactly one api_public site exists here (pub_site), so the
+		fallback resolves to it directly (2026-09-10 spec amendment) --
+		but crucially it is the PUBLIC site's content, never the private
+		one the Origin claimed."""
+		resp = self.client.get(
+			"/articles/", HTTP_ORIGIN=f"https://{self.priv_site.domain}"
+		)
+		self.assertEqual(resp.status_code, 200)
+		titles = [a["title"] for a in resp.data["results"]]
+		self.assertIn("Spoof Public Article", titles)
+		self.assertNotIn("Spoof Private Article", titles)
+
+	def test_private_sites_own_id_never_resolves_via_site_id_either(self):
+		resp = self.client.get("/articles/", {"site_id": self.priv_site.pk})
+		self.assertEqual(resp.status_code, 200)
+		titles = [a["title"] for a in resp.data["results"]]
+		self.assertNotIn("Spoof Private Article", titles)
+
+
+class IdentifiedCallerIgnoresOriginTest(TestCase):
+	"""A site-bound key or a signed-in member's scope is decided by the
+	credential/membership, never by a conflicting Origin header -- Origin
+	resolution is an ANONYMOUS-only mechanism."""
+
+	def setUp(self):
+		self.client = APIClient()
+		self.my_org = Organization.objects.create(name="Mine Org SR", slug="mine-org-sr")
+		self.pub_org = Organization.objects.create(name="Pub Org SR", slug="pub-org-sr")
+		self.my_team = Team.objects.create(
+			organization=self.my_org, name="Mine Team SR", slug="mine-team-sr"
+		)
+		self.pub_team = Team.objects.create(
+			organization=self.pub_org, name="Pub Team SR", slug="pub-team-sr"
+		)
+		self.my_subject = Subject.objects.create(
+			subject_name="Mine Subject SR", subject_slug="mine-subj-sr", team=self.my_team
+		)
+		self.pub_subject = Subject.objects.create(
+			subject_name="Pub Subject SR", subject_slug="pub-subj-sr", team=self.pub_team
+		)
+		self.my_site = private_site_publishing(
+			self.my_subject, organization=self.my_org, name="Mine Site SR"
+		)
+		self.pub_site = publish_subjects(
+			self.pub_subject, organization=self.pub_org, name="Pub Site SR"
+		)
+		my_article = Articles.objects.create(
+			title="Mine Article SR", link="https://sr.example/mine"
+		)
+		my_article.subjects.add(self.my_subject)
+		my_article.teams.add(self.my_team)
+
+	def test_api_key_bound_to_my_site_ignores_a_conflicting_origin(self):
+		scheme = APIAccessScheme.objects.create(
+			client_name="SR Key",
+			client_contacts="a@b.com",
+			organization=self.my_org,
+			site=self.my_site,
+			ip_addresses="",
+			begin_date=now() - timedelta(days=1),
+			end_date=now() + timedelta(days=30),
+		)
+		self.client.defaults["HTTP_AUTHORIZATION"] = scheme.api_key
+		resp = self.client.get(
+			"/articles/", HTTP_ORIGIN=f"https://{self.pub_site.domain}"
+		)
+		self.assertEqual(resp.status_code, 200)
+		titles = [a["title"] for a in resp.data["results"]]
+		self.assertIn("Mine Article SR", titles)
+
+	def test_signed_in_member_ignores_a_conflicting_origin(self):
+		user = User.objects.create_user(username="sr-member", password="pw")
+		OrganizationUser.objects.create(organization=self.my_org, user=user)
+		self.client.force_authenticate(user=user)
+		resp = self.client.get(
+			"/articles/", HTTP_ORIGIN=f"https://{self.pub_site.domain}"
+		)
+		self.assertEqual(resp.status_code, 200)
+		titles = [a["title"] for a in resp.data["results"]]
+		self.assertIn("Mine Article SR", titles)
+
+
+class NonApiSurfacesUnaffectedTest(TestCase):
+	"""RSS feeds and sitemaps resolve by the REQUESTED SITE (Phase 4b/5),
+	never by caller identity, so they never read visible_subject_ids and
+	must keep working with no site/Origin indicator at all -- even amid
+	the exact two-public-site ambiguity that gates the API."""
+
+	def setUp(self):
+		self.client = APIClient()
+		self.org_a = Organization.objects.create(name="Surf Org A", slug="surf-org-a")
+		self.org_b = Organization.objects.create(name="Surf Org B", slug="surf-org-b")
+		self.team_a = Team.objects.create(
+			organization=self.org_a, name="Surf Team A", slug="surf-team-a"
+		)
+		self.team_b = Team.objects.create(
+			organization=self.org_b, name="Surf Team B", slug="surf-team-b"
+		)
+		self.subject_a = Subject.objects.create(
+			subject_name="Surf Subject A", subject_slug="surf-subj-a", team=self.team_a
+		)
+		self.subject_b = Subject.objects.create(
+			subject_name="Surf Subject B", subject_slug="surf-subj-b", team=self.team_b
+		)
+		self.site_a = publish_subjects(
+			self.subject_a, organization=self.org_a, name="Surf Site A"
+		)
+		self.site_b = publish_subjects(
+			self.subject_b, organization=self.org_b, name="Surf Site B"
+		)
+		self.custom_setting_a = CustomSetting.objects.get(site=self.site_a)
+		self.custom_setting_a.rss_enabled = True
+		self.custom_setting_a.generate_sitemap = True
+		self.custom_setting_a.sitemap_subjects.add(self.subject_a)
+		self.custom_setting_a.save(update_fields=["rss_enabled", "generate_sitemap"])
+
+	def test_api_still_400s_amid_this_ambiguity(self):
+		"""Sanity check that this fixture really does create the ambiguity
+		the rest of this test asserts RSS/sitemaps are immune to."""
+		resp = self.client.get("/articles/")
+		self.assertEqual(resp.status_code, 400)
+
+	def test_site_scoped_rss_feed_unaffected_by_caller_ambiguity(self):
+		resp = self.client.get(
+			f"/feed/sites/{self.site_a.pk}/trials/subject/{self.subject_a.subject_slug}/"
+		)
+		self.assertEqual(resp.status_code, 200)
+
+	def test_old_rss_url_still_redirects_amid_the_ambiguity(self):
+		resp = self.client.get(
+			f"/feed/trials/subject/{self.subject_a.subject_slug}/"
+		)
+		self.assertEqual(resp.status_code, 301)
+
+	def test_site_scoped_sitemap_unaffected_by_caller_ambiguity(self):
+		resp = self.client.get(f"/sitemap/sites/{self.site_a.pk}/index.xml")
+		self.assertEqual(resp.status_code, 200)

--- a/django/api/tests/test_trials_stats.py
+++ b/django/api/tests/test_trials_stats.py
@@ -76,6 +76,7 @@ from rest_framework.test import APIClient
 from api.models import APIAccessScheme
 from api.tests.visibility_helpers import private_site_publishing, publish_subjects
 from gregory.models import OrganizationApiSettings, Subject, Team, Trials
+from sitesettings.models import CustomSetting
 from gregory.utils.trial_field_normalizers import (
 	TrialPhase,
 	TrialRecruitmentStatus,
@@ -203,6 +204,14 @@ class TrialStatsBase(TestCase):
 		)
 
 		self.client = APIClient()
+		# Anonymous site resolution (Phase 3, gregory/site_resolution.py)
+		# needs a site indicator once more than one api_public site exists --
+		# this fixture creates two (self.org and other_org, both public by
+		# default via _make_org_team). Resolve every request in this class to
+		# self.org's site via Origin, matching what "the caller's own scope"
+		# has always meant in these tests -- self.other_org/other_team/
+		# other_subject stay the "should NOT appear" counterexample.
+		self.client.defaults["HTTP_ORIGIN"] = f"https://{_ORG_SITES[self.org.pk].domain}"
 
 
 class TrialListNoStatsTest(TrialStatsBase):
@@ -244,10 +253,12 @@ class TrialStatsEndpointTest(TrialStatsBase):
 		resp = self.client.get("/trials/stats/")
 		self.assertEqual(resp.status_code, 200)
 		stats = resp.data
-		self.assertEqual(stats["total"], 4)
+		# self.client resolves to self.org's site only (Phase 3), so t4
+		# (other_team/other_subject, a different site) is out of scope: t1-t3.
+		self.assertEqual(stats["total"], 3)
 		self.assertEqual(stats["recruiting"], 2)
 		self.assertEqual(stats["completed"], 1)
-		self.assertEqual(stats["terminated"], 1)
+		self.assertEqual(stats["terminated"], 0)
 
 	def test_stats_endpoint_runs_aggregation_query(self):
 		with CaptureQueriesContext(connection) as ctx:
@@ -268,11 +279,15 @@ class TrialStatsEndpointTest(TrialStatsBase):
 		self.assertEqual(stats["terminated"], 0)
 
 	def test_stats_with_other_team_filter_scopes_totals(self):
+		# team_id is an additional AND filter on top of subject-scope visibility,
+		# not a substitute for it -- self.client resolves to self.org's site, so
+		# other_team's content (a different site) is invisible regardless of
+		# this filter, giving an empty result rather than other_team's own data.
 		resp = self.client.get("/trials/stats/", {"team_id": self.other_team.id})
 		self.assertEqual(resp.status_code, 200)
 		stats = resp.data
-		self.assertEqual(stats["total"], 1)
-		self.assertEqual(stats["terminated"], 1)
+		self.assertEqual(stats["total"], 0)
+		self.assertEqual(stats["terminated"], 0)
 		self.assertEqual(stats["recruiting"], 0)
 
 	def test_stats_with_status_filter_scopes_totals(self):
@@ -293,9 +308,11 @@ class TrialStatsEndpointTest(TrialStatsBase):
 		resp = self.client.get("/trials/stats/")
 		self.assertEqual(resp.status_code, 200)
 		stats = resp.data
-		# 4 original trials + 1 shared trial = 5, not 6 (would be 6 if the
-		# shared trial were counted once per team via a non-distinct Count).
-		self.assertEqual(stats["total"], 5)
+		# 3 visible original trials (t1-t3; t4 is other_team/other_subject, a
+		# different site, out of scope for self.client) + 1 shared trial = 4,
+		# not 5 (would be 5 if the shared trial were counted once per team via
+		# a non-distinct Count).
+		self.assertEqual(stats["total"], 4)
 		self.assertEqual(stats["recruiting"], 3)
 
 
@@ -306,11 +323,15 @@ class TrialStatsBySubjectTest(TrialStatsBase):
 		other_subject = _make_subject(
 			self.other_team, "Other Subject", "other-subject"
 		)
-		# No organization= here: other_org already has a default site from
-		# _make_org_team, and OrganizationSite allows only one default per
-		# org. Anonymous visibility only needs an api_public site scoping
-		# the subject, so this stands alone.
-		publish_subjects(other_subject)
+		# Publishing other_subject on its own (org-less) site would put it on
+		# a different site than self.client resolves to (Phase 3 scopes an
+		# anonymous caller to exactly ONE site), so it would never show up
+		# alongside self.subject in one response. This test just wants both
+		# subjects visible together, so add other_subject to self.org's
+		# existing site scope instead.
+		CustomSetting.objects.get(site=_ORG_SITES[self.org.pk]).scope_subjects.add(
+			other_subject
+		)
 		self.t3.subjects.add(self.subject)
 		self.t4.subjects.add(other_subject)
 
@@ -356,7 +377,9 @@ class TrialStatsBySubjectTest(TrialStatsBase):
 
 		resp = self.client.get("/trials/stats/")
 		self.assertEqual(resp.status_code, 200)
-		self.assertEqual(resp.data["total"], 4)  # t1 still counted
+		# t1-t3 visible (self.org's site); t4 is other_team/other_subject, a
+		# different site, out of scope for self.client regardless of this test.
+		self.assertEqual(resp.data["total"], 3)  # t1 still counted
 		subject_ids = [row["subject_id"] for row in resp.data["by_subject"]]
 		self.assertIn(self.subject.id, subject_ids)
 		self.assertNotIn(hidden_subject.id, subject_ids)
@@ -415,9 +438,12 @@ class TrialStatsCachingTest(TrialStatsBase):
 		other_stats = self.client.get(
 			"/trials/stats/", {"team_id": self.other_team.id}
 		)
-		self.assertEqual(all_stats.data["total"], 4)
+		# self.client resolves to self.org's site only: t1-t3 visible, t4
+		# (other_team/other_subject) is out of scope, so the other_team filter
+		# now yields an empty result instead of other_team's own trial.
+		self.assertEqual(all_stats.data["total"], 3)
 		self.assertEqual(team_stats.data["total"], 3)
-		self.assertEqual(other_stats.data["total"], 1)
+		self.assertEqual(other_stats.data["total"], 0)
 
 	def test_cache_is_isolated_per_visible_org_context(self):
 		# A private org with its own trial: anonymous callers cannot see it,
@@ -433,24 +459,28 @@ class TrialStatsCachingTest(TrialStatsBase):
 		scheme = _make_api_scheme(priv_org, "stats-key")
 
 		anon = APIClient()
+		# Two api_public sites now exist (self.org, other_org); resolve
+		# anonymous requests to self.org's site specifically, same as
+		# self.client in setUp.
+		anon.defaults["HTTP_ORIGIN"] = f"https://{_ORG_SITES[self.org.pk].domain}"
 		anon_resp = anon.get("/trials/stats/")
 		self.assertEqual(anon_resp.status_code, 200)
-		# Anonymous sees only the two public orgs' 4 trials.
-		self.assertEqual(anon_resp.data["total"], 4)
+		# Anonymous resolves to self.org's site only: t1-t3.
+		self.assertEqual(anon_resp.data["total"], 3)
 
 		keyed = APIClient()
 		keyed.credentials(HTTP_AUTHORIZATION=scheme.api_key)
 		keyed_resp = keyed.get("/trials/stats/")
 		self.assertEqual(keyed_resp.status_code, 200)
 		# The org-scoped caller sees only its own org's single trial — if it
-		# got the anonymous caller's cached payload this would be 4.
+		# got the anonymous caller's cached payload this would be 3.
 		self.assertEqual(keyed_resp.data["total"], 1)
 		self.assertEqual(keyed_resp.data["recruiting"], 1)
 
 		# And the reverse: a fresh anonymous request after the keyed one must
 		# not pick up the keyed caller's entry.
 		anon_again = anon.get("/trials/stats/")
-		self.assertEqual(anon_again.data["total"], 4)
+		self.assertEqual(anon_again.data["total"], 3)
 
 
 class TrialStatsRoutingTest(TrialStatsBase):
@@ -519,14 +549,17 @@ class TrialStatsNormalizedBucketsTest(TrialStatsBase):
 		self.assertEqual(resp.data["no_status"], 1)
 
 	def test_every_canonical_key_present_even_when_zero(self):
-		# other_team has only t4 (TERMINATED), so most buckets are 0 here — the point is
-		# that the zero-count keys are still in the payload, not omitted.
+		# other_team has only t4 (TERMINATED), but t4 is other_subject -- a
+		# different site than self.client resolves to (Phase 3) -- so the
+		# team_id filter now yields an empty result rather than other_team's
+		# own trial. All buckets are 0 here — the point is that the
+		# zero-count keys are still in the payload, not omitted.
 		resp = self.client.get("/trials/stats/", {"team_id": self.other_team.id})
 		self.assertEqual(resp.status_code, 200)
 		for value in TrialRecruitmentStatus.values:
 			self.assertIn(value, resp.data)
 		self.assertEqual(resp.data["recruiting"], 0)
-		self.assertEqual(resp.data["terminated"], 1)
+		self.assertEqual(resp.data["terminated"], 0)
 		# The old hand-rolled keys must not survive the rewrite.
 		for stale_key in ("available", "not_available", "withheld", "authorised"):
 			self.assertNotIn(stale_key, resp.data)
@@ -575,10 +608,11 @@ class TrialStatsPhaseFacetTest(TrialStatsBase):
 		self.assertEqual(resp.status_code, 200)
 		by_phase = resp.data["by_phase"]
 		self.assertEqual(set(by_phase.keys()), set(TrialPhase.values) | {"no_phase"})
-		# None of the fixture trials (t1-t4) have a phase set.
+		# None of the visible fixture trials (t1-t3; t4 is a different site,
+		# out of scope for self.client) have a phase set.
 		for value in TrialPhase.values:
 			self.assertEqual(by_phase[value], 0)
-		self.assertEqual(by_phase["no_phase"], 4)
+		self.assertEqual(by_phase["no_phase"], 3)
 
 	def test_raw_spelling_variants_land_in_same_bucket(self):
 		_make_trial(
@@ -594,10 +628,12 @@ class TrialStatsPhaseFacetTest(TrialStatsBase):
 		self.assertEqual(resp.data["by_phase"]["phase_3"], 2)
 
 	def test_null_raw_phase_lands_in_no_phase(self):
-		# other_team has only t4, which has no phase set.
+		# other_team has only t4, which is other_subject -- a different site
+		# than self.client resolves to (Phase 3) -- so this filter now yields
+		# an empty result rather than other_team's own trial.
 		resp = self.client.get("/trials/stats/", {"team_id": self.other_team.id})
 		self.assertEqual(resp.status_code, 200)
-		self.assertEqual(resp.data["by_phase"]["no_phase"], 1)
+		self.assertEqual(resp.data["by_phase"]["no_phase"], 0)
 
 	def test_by_phase_values_sum_to_total(self):
 		_make_trial(
@@ -634,10 +670,11 @@ class TrialStatsStudyTypeFacetTest(TrialStatsBase):
 		self.assertEqual(
 			set(by_study_type.keys()), set(TrialStudyType.values) | {"no_study_type"}
 		)
-		# None of the fixture trials (t1-t4) have a study_type set.
+		# None of the visible fixture trials (t1-t3; t4 is a different site,
+		# out of scope for self.client) have a study_type set.
 		for value in TrialStudyType.values:
 			self.assertEqual(by_study_type[value], 0)
-		self.assertEqual(by_study_type["no_study_type"], 4)
+		self.assertEqual(by_study_type["no_study_type"], 3)
 
 	def test_raw_spelling_variants_land_in_same_bucket(self):
 		_make_trial(
@@ -653,10 +690,12 @@ class TrialStatsStudyTypeFacetTest(TrialStatsBase):
 		self.assertEqual(resp.data["by_study_type"]["interventional"], 2)
 
 	def test_null_raw_study_type_lands_in_no_study_type(self):
-		# other_team has only t4, which has no study_type set.
+		# other_team has only t4, which is other_subject -- a different site
+		# than self.client resolves to (Phase 3) -- so this filter now yields
+		# an empty result rather than other_team's own trial.
 		resp = self.client.get("/trials/stats/", {"team_id": self.other_team.id})
 		self.assertEqual(resp.status_code, 200)
-		self.assertEqual(resp.data["by_study_type"]["no_study_type"], 1)
+		self.assertEqual(resp.data["by_study_type"]["no_study_type"], 0)
 
 	def test_by_study_type_values_sum_to_total(self):
 		_make_trial(
@@ -710,10 +749,11 @@ class TrialStatsSexFacetTest(TrialStatsBase):
 		self.assertEqual(
 			set(by_sex.keys()), set(TrialSexEligibility.values) | {"no_sex_data"}
 		)
-		# None of the fixture trials (t1-t4) have inclusion_gender set.
+		# None of the visible fixture trials (t1-t3; t4 is a different site,
+		# out of scope for self.client) have inclusion_gender set.
 		for value in TrialSexEligibility.values:
 			self.assertEqual(by_sex[value], 0)
-		self.assertEqual(by_sex["no_sex_data"], 4)
+		self.assertEqual(by_sex["no_sex_data"], 3)
 
 	def test_female_comma_male_lands_in_all_not_female(self):
 		"""Regression guard: the substring-match bug this normalization fixes must not
@@ -738,10 +778,12 @@ class TrialStatsSexFacetTest(TrialStatsBase):
 		self.assertEqual(resp.data["by_sex"]["female"], 2)
 
 	def test_null_raw_inclusion_gender_lands_in_no_sex_data(self):
-		# other_team has only t4, which has no inclusion_gender set.
+		# other_team has only t4, which is other_subject -- a different site
+		# than self.client resolves to (Phase 3) -- so this filter now yields
+		# an empty result rather than other_team's own trial.
 		resp = self.client.get("/trials/stats/", {"team_id": self.other_team.id})
 		self.assertEqual(resp.status_code, 200)
-		self.assertEqual(resp.data["by_sex"]["no_sex_data"], 1)
+		self.assertEqual(resp.data["by_sex"]["no_sex_data"], 0)
 
 	def test_by_sex_values_sum_to_total(self):
 		self._make_trial_with_gender(
@@ -806,11 +848,13 @@ class TrialStatsCountryFacetTest(TrialStatsBase):
 		self.assertTrue(all(count > 0 for _country, count in non_null))
 
 	def test_trial_with_no_country_data_is_trailing_null_entry(self):
-		# other_team has only t4, which has no country data at all.
+		# other_team has only t4, which is other_subject -- a different site
+		# than self.client resolves to (Phase 3) -- so this filter now yields
+		# an empty result rather than other_team's own trial (which had no
+		# country data at all).
 		resp = self.client.get("/trials/stats/", {"team_id": self.other_team.id})
 		self.assertEqual(resp.status_code, 200)
-		by_country = resp.data["by_country"]
-		self.assertEqual(by_country[-1], {"country": None, "count": 1})
+		self.assertEqual(resp.data["by_country"], [])
 
 	def test_trial_visible_under_two_teams_counted_once_per_country(self):
 		_make_trial(
@@ -852,11 +896,12 @@ class TrialStatsRegionFacetTest(TrialStatsBase):
 		self.assertEqual(resp.status_code, 200)
 		by_region = resp.data["by_region"]
 		self.assertEqual(set(by_region.keys()), set(TrialRegion.values) | {"no_region"})
-		# None of t1-t4 have country data, so every region is 0 and all four
-		# trials land in no_region.
+		# None of the visible t1-t3 have country data (t4 is a different site,
+		# out of scope for self.client), so every region is 0 and all three
+		# visible trials land in no_region.
 		for value in TrialRegion.values:
 			self.assertEqual(by_region[value], 0)
-		self.assertEqual(by_region["no_region"], 4)
+		self.assertEqual(by_region["no_region"], 3)
 
 	def test_multi_region_trial_counted_once_per_region(self):
 		_make_trial(
@@ -870,10 +915,12 @@ class TrialStatsRegionFacetTest(TrialStatsBase):
 		self.assertEqual(by_region["north_america"], 1)
 
 	def test_no_region_counts_null_or_empty_regions(self):
-		# other_team has only t4, whose regions_normalized is null.
+		# other_team has only t4, which is other_subject -- a different site
+		# than self.client resolves to (Phase 3) -- so this filter now yields
+		# an empty result rather than other_team's own trial.
 		resp = self.client.get("/trials/stats/", {"team_id": self.other_team.id})
 		self.assertEqual(resp.status_code, 200)
-		self.assertEqual(resp.data["by_region"]["no_region"], 1)
+		self.assertEqual(resp.data["by_region"]["no_region"], 0)
 
 
 class TrialStatsYearFacetTest(TrialStatsBase):

--- a/django/api/tests/test_visibility_stats.py
+++ b/django/api/tests/test_visibility_stats.py
@@ -535,20 +535,22 @@ class StatsQueryCountTest(StatsVisibilityBase):
 		self.client.get("/stats/", {"team": self.pub_team.id})  # warm the cache
 		with CaptureQueriesContext(connection) as ctx:
 			self.client.get("/stats/", {"team": self.pub_team.id})
-		# <=4, not a pinned exact count: OrganizationApiSettings lookup (1)
+		# <=5, not a pinned exact count: OrganizationApiSettings lookup (1)
 		# + team_id_list resolution, which also serves as the
 		# team-visibility check (1) + visible_subjects resolution, which
 		# also serves as the ?subject= 404 check and runs before the cache
-		# lookup so a cache hit can't bypass it (1) + cache GET (0 or 1
-		# depending on backend). LocMemCache (admin.settings_test, what
-		# CI's pytest run uses) answers GET in-process with no SQL, landing
-		# at 3; DatabaseCache backends (production, and admin.settings's
-		# default used when this test is invoked via `manage.py test`
-		# instead of pytest) add one SQL round-trip for the GET, landing at
-		# 4. Either way this must stay far below the cold-cache budget above.
+		# lookup so a cache hit can't bypass it (1) + gregory.site_resolution.
+		# resolve_anonymous_site's public-site-count query for this anonymous,
+		# no-Origin caller (1, Phase 3) + cache GET (0 or 1 depending on
+		# backend). LocMemCache (admin.settings_test, what CI's pytest run
+		# uses) answers GET in-process with no SQL, landing at 4;
+		# DatabaseCache backends (production, and admin.settings's default
+		# used when this test is invoked via `manage.py test` instead of
+		# pytest) add one SQL round-trip for the GET, landing at 5. Either
+		# way this must stay far below the cold-cache budget above.
 		self.assertLessEqual(
 			len(ctx.captured_queries),
-			4,
+			5,
 			msg=f"Cache hit should eliminate the count queries: {len(ctx.captured_queries)} queries",
 		)
 
@@ -741,7 +743,13 @@ class SubjectVisibilityStatsTest(SubjectStatsBase):
 	"""A subject in a non-visible org is 404, same as team/organization."""
 
 	def test_hidden_org_subject_404_for_anonymous(self):
+		# Two api_public sites exist in this fixture (base_site_pub from
+		# StatsVisibilityBase, pub_site from SubjectStatsBase, both on
+		# pub_org); give an Origin so Phase 3 site resolution doesn't 400 on
+		# ambiguity before ever reaching the subj_priv visibility check this
+		# test is about.
 		anon = APIClient()
+		anon.defaults["HTTP_ORIGIN"] = f"https://{self.pub_site.domain}"
 		resp = anon.get("/stats/", {"subject": self.subj_priv.id})
 		self.assertEqual(resp.status_code, 404)
 

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -4636,9 +4636,12 @@ class AuthorSearchView(BodyParamsAsQueryParamsMixin, generics.ListAPIView):
 class PublicSitesView(APIView):
 	"""Sites with `api_public = True`.
 
-	Unscoped by design. Site-scoped API visibility fails closed when a caller
-	names no site, which leaves a new consumer unable to call anything: it
-	needs a site_id, and nothing else would tell it which exist. This endpoint
+	Unscoped by design. Site-scoped API visibility (Phase 3) fails closed
+	when an anonymous caller names no site AND the public union is
+	ambiguous -- two or more api_public sites exist with nothing to pick
+	one (gregory.site_resolution.NoSiteResolvedError). That leaves a new
+	consumer unable to call anything in that situation: it needs a
+	site_id, and nothing else would tell it which exist. This endpoint
 	breaks that circle.
 
 	Read-only, no auth, no pagination -- the list is a handful of rows and
@@ -4649,11 +4652,12 @@ class PublicSitesView(APIView):
 
 	def get(self, request):
 		# Shared with the 400 body gregory.site_resolution.NoSiteResolvedError
-		# raises when an anonymous caller names no site (Phase 3 of
-		# site-scoped API visibility) -- one code path, so the two can never
-		# disagree about which sites exist. PublicSiteSerializer above is
-		# schema-only (see its @extend_schema): public_sites() already
-		# returns plain {site_id, domain, name} dicts in that exact shape.
+		# raises when an anonymous caller's request is ambiguous between two
+		# or more api_public sites (Phase 3 of site-scoped API visibility) --
+		# one code path, so the two can never disagree about which sites
+		# exist. PublicSiteSerializer above is schema-only (see its
+		# @extend_schema): public_sites() already returns plain
+		# {site_id, domain, name} dicts in that exact shape.
 		return Response(public_sites())
 
 

--- a/django/api/views.py
+++ b/django/api/views.py
@@ -115,7 +115,6 @@ from api.filters import (
 from rest_framework.response import Response
 from django.http import Http404, StreamingHttpResponse
 from rest_framework.views import APIView
-from sitesettings.models import CustomSetting
 from rest_framework_simplejwt.views import TokenObtainPairView
 from drf_spectacular.utils import (
 	extend_schema,
@@ -146,6 +145,7 @@ from api.utils.utils import (
 	find_trial_by_identifier,
 )
 from gregory.utils.registry_utils import merge_links
+from gregory.site_resolution import public_sites
 from api.models import APIAccessSchemeLog
 from api.utils.exceptions import (
 	APIAccessDeniedError,
@@ -4648,25 +4648,13 @@ class PublicSitesView(APIView):
 	permission_classes = [permissions.AllowAny]
 
 	def get(self, request):
-		# CustomSetting.site is a plain FK, not OneToOne — a site can carry
-		# several settings rows, which sitesettings already handles elsewhere
-		# (see test_lowest_setting_id_wins_when_multiple_rows). Iterating
-		# settings would emit one entry per row and hand clients duplicate
-		# site_ids. Collapse to one row per site, lowest setting_id winning,
-		# matching the tie-break that module already uses.
-		settings_qs = (
-			CustomSetting.objects.filter(api_public=True)
-			.select_related("site")
-			.order_by("site__domain", "setting_id")
-		)
-		seen = set()
-		unique = []
-		for setting in settings_qs:
-			if setting.site_id in seen:
-				continue
-			seen.add(setting.site_id)
-			unique.append(setting)
-		return Response(PublicSiteSerializer(unique, many=True).data)
+		# Shared with the 400 body gregory.site_resolution.NoSiteResolvedError
+		# raises when an anonymous caller names no site (Phase 3 of
+		# site-scoped API visibility) -- one code path, so the two can never
+		# disagree about which sites exist. PublicSiteSerializer above is
+		# schema-only (see its @extend_schema): public_sites() already
+		# returns plain {site_id, domain, name} dicts in that exact shape.
+		return Response(public_sites())
 
 
 def stats_payload_cache_key(team_id_list, visible_subject_ids, subject_ids):

--- a/django/gregory/middleware/visibility.py
+++ b/django/gregory/middleware/visibility.py
@@ -17,11 +17,21 @@ Session-authenticated requests and raw API-key requests are unaffected: the
 lazy wrapper simply evaluates on first access with the same result as eager
 evaluation would have produced.
 
-``visible_subject_ids`` is part of the site-scoped API visibility project.
-As of Phase 1 it is computed correctly but read by no call site -- see
-``gregory/visibility.py`` for the per-caller rules.
+``visible_subject_ids`` is part of the site-scoped API visibility project --
+see ``gregory/visibility.py`` for the per-caller rules.
+
+As of Phase 3, resolving an anonymous caller's site can consult the
+``Origin``/``Referer`` headers (``gregory.site_resolution.resolve_anonymous_site``),
+which means the response can vary by ``Origin`` even though it's a
+client-controlled header. When ``visible_subject_ids`` does this, it flags
+the request via ``request._site_resolution_varies_by_origin`` (set as a
+side effect of evaluating the SimpleLazyObject inside ``get_response()``
+below), and this middleware turns that into a ``Vary: Origin`` response
+header once ``get_response()`` returns -- so a cache in front of this API
+never serves one Origin's resolution to another.
 """
 
+from django.utils.cache import patch_vary_headers
 from django.utils.functional import SimpleLazyObject
 
 
@@ -36,4 +46,7 @@ class VisibleOrgMiddleware:
 		request.visible_subject_ids = SimpleLazyObject(
 			lambda: visible_subject_ids(request)
 		)
-		return self.get_response(request)
+		response = self.get_response(request)
+		if getattr(request, "_site_resolution_varies_by_origin", False):
+			patch_vary_headers(response, ["Origin"])
+		return response

--- a/django/gregory/middleware/visibility.py
+++ b/django/gregory/middleware/visibility.py
@@ -21,14 +21,15 @@ evaluation would have produced.
 see ``gregory/visibility.py`` for the per-caller rules.
 
 As of Phase 3, resolving an anonymous caller's site can consult the
-``Origin``/``Referer`` headers (``gregory.site_resolution.resolve_anonymous_site``),
-which means the response can vary by ``Origin`` even though it's a
-client-controlled header. When ``visible_subject_ids`` does this, it flags
-the request via ``request._site_resolution_varies_by_origin`` (set as a
-side effect of evaluating the SimpleLazyObject inside ``get_response()``
-below), and this middleware turns that into a ``Vary: Origin`` response
-header once ``get_response()`` returns -- so a cache in front of this API
-never serves one Origin's resolution to another.
+``Origin`` header, and the ``Referer`` header when ``Origin`` is absent
+(``gregory.site_resolution.resolve_anonymous_site``), which means the
+response can vary by EITHER even though both are client-controlled. When
+``visible_subject_ids`` does this, it flags the request via
+``request._site_resolution_varies_by_origin`` (set as a side effect of
+evaluating the SimpleLazyObject inside ``get_response()`` below), and this
+middleware turns that into ``Vary: Origin, Referer`` response headers once
+``get_response()`` returns -- so a cache in front of this API never serves
+one Origin's (or Referer's) resolution to a request with a different one.
 """
 
 from django.utils.cache import patch_vary_headers
@@ -48,5 +49,8 @@ class VisibleOrgMiddleware:
 		)
 		response = self.get_response(request)
 		if getattr(request, "_site_resolution_varies_by_origin", False):
-			patch_vary_headers(response, ["Origin"])
+			# Both headers, not just Origin: resolve_anonymous_site() also
+			# falls back to Referer when Origin is absent, so the outcome
+			# can depend on either one.
+			patch_vary_headers(response, ["Origin", "Referer"])
 		return response

--- a/django/gregory/site_resolution.py
+++ b/django/gregory/site_resolution.py
@@ -1,0 +1,259 @@
+"""
+gregory/site_resolution.py
+
+Site-scoped API visibility, Phase 3: resolving which Site an ANONYMOUS
+caller's request is for, and the conditional fail-closed 400 that results
+when that cannot be pinned down to one site. See
+SITE-API-VISIBILITY-SPEC.md's "Resolving a site without being told one"
+(and its 2026-09-10 amendment) for the design, and gregory/visibility.py
+for how this plugs into ``visible_subject_ids()``.
+
+Resolution order: ``?site_id=`` -> ``Origin`` -> ``Referer`` -> the public
+union, IF that union is unambiguous. The union of every ``api_public``
+site's scope is data anyone may already read, so serving it is not a
+disclosure -- it's just a convenience. "Unambiguous" means the union is
+drawn from AT MOST ONE site: zero ``api_public`` sites is simply an empty
+scope (no error -- there is nothing to be ambiguous about), and exactly one
+means the union just IS that site's scope. It stops being safe to serve
+automatically the moment a SECOND ``api_public`` site exists, because then
+"the public union" would silently blend two sites' content into one
+anonymous response, which nothing before this phase could express or
+prevent. So: zero or one ``api_public`` site -> serve that (possibly empty)
+scope directly; two or more -> refuse (``NoSiteResolvedError``, a DRF 400
+naming the sites the caller could ask for instead). Two consumers are
+already unaffected either way: the MCP server sends ``?site_id=`` on every
+call (#860), and browser callers send ``Origin``.
+
+This was amended 2026-09-10 after the original "refuse, always" reading
+(what the spec's resolution-order list said) turned out to contradict what
+its own security-property section described ("falls through to step 4 and
+sees the public union") -- and, concretely, broke ~478 tests across 51+
+files that call the API anonymously with no site indicator, none of which
+were disclosing anything the amended rule doesn't already allow (this repo
+has exactly one ``api_public`` site today). See the spec for the full
+reasoning; the short version is that failing closed on AMBIGUITY, not on
+ANONYMITY, is what "no unscoped mode" actually needs to mean once content
+itself is already subject-scoped (Phase 4).
+
+The property that makes an Origin header (which the client fully
+controls) safe to use for this: resolution only ever considers
+``api_public`` sites, at every step, so it can only ever NARROW what an
+anonymous caller sees, never widen it. A caller sending
+``Origin: https://some-private-site.com`` finds no match and falls
+through to the public-union step -- it cannot reach a private site's scope
+by claiming to come from it, whether that step ends in one site's scope or
+a 400.
+"""
+
+from __future__ import annotations
+
+from urllib.parse import urlparse
+
+from rest_framework.exceptions import APIException
+
+
+def find_site_by_domain(hostname):
+	"""
+	Look up a Site by exact domain, then by stripping one subdomain level.
+
+	e.g. 'www.example.com' -> tries exact, then tries 'example.com'.
+	Accepts host strings that may include a port or IPv6 brackets; these are
+	normalised safely via urlparse before the lookup. Returns the matching
+	Site or None.
+
+	Shared with subscriptions/views.py (email subscribe/unsubscribe domain
+	matching) -- moved here so that site-resolution logic does not depend on
+	the subscriptions app. Keep its behaviour identical if you touch it; it
+	has its own tests in gregory/tests/test_site_resolution.py.
+	"""
+	from django.contrib.sites.models import Site
+
+	host = urlparse(f"//{hostname}").hostname or ""
+	host = host.lower()
+	if not host:
+		return None
+	try:
+		return Site.objects.get(domain=host)
+	except Site.DoesNotExist:
+		pass
+	parts = host.split(".")
+	if len(parts) >= 3:
+		parent = ".".join(parts[1:])
+		try:
+			return Site.objects.get(domain=parent)
+		except Site.DoesNotExist:
+			pass
+	return None
+
+
+def public_sites() -> list[dict]:
+	"""One row per ``api_public`` site: ``[{"site_id", "domain", "name"}, ...]``.
+
+	Shared by ``GET /sites/`` (``api.views.PublicSitesView``) and the body of
+	``NoSiteResolvedError`` below, so the discovery endpoint and the 400 it's
+	quoted from can never disagree about which sites exist.
+
+	Deduped to one row per site -- ``CustomSetting.site`` is a plain FK, not
+	OneToOne, so a site can carry more than one settings row -- lowest
+	``setting_id`` winning, matching the tie-break ``sitesettings`` uses
+	elsewhere (see ``sitesettings.utils.author_page_base``).
+	"""
+	from sitesettings.models import CustomSetting
+
+	settings_qs = (
+		CustomSetting.objects.filter(api_public=True)
+		.select_related("site")
+		.order_by("site__domain", "setting_id")
+	)
+	seen = set()
+	result = []
+	for setting in settings_qs:
+		if setting.site_id in seen:
+			continue
+		seen.add(setting.site_id)
+		result.append(
+			{
+				"site_id": setting.site_id,
+				"domain": setting.site.domain,
+				"name": setting.site.name,
+			}
+		)
+	return result
+
+
+class NoSiteResolvedError(APIException):
+	"""Raised by ``visible_subject_ids()`` when an anonymous caller names no
+	site AND the public union is ambiguous -- i.e. two or more ``api_public``
+	sites exist, so "serve everything public" would silently blend more than
+	one site's content. NOT raised merely for anonymity: with zero or one
+	``api_public`` site, the union is unambiguous (empty, or exactly that
+	site's scope) and ``resolve_anonymous_site`` returns it directly instead
+	of raising (see its docstring and the spec's 2026-09-10 amendment).
+
+	DRF's default exception handler turns an ``APIException`` whose
+	``.detail`` is a dict (not a plain string) into a response whose body IS
+	that dict -- see ``rest_framework.views.exception_handler`` -- BUT
+	``APIException.__init__`` first runs that dict through
+	``_get_error_details()``, which recursively ``force_str()``s every leaf
+	value (it's built for validation messages, which are always text). That
+	would silently turn every ``public_sites[].site_id`` int into a JSON
+	*string*, making this body disagree in type with ``GET /sites/``'s own
+	response -- exactly the "one code path" guarantee this class exists to
+	keep. ``raw_detail`` stashes the untouched dict so ``exception_handler``
+	below can restore real ints before the response renders.
+
+	Only ever raised from inside a DRF view's dispatch cycle: every content
+	endpoint that reads ``request.visible_subject_ids`` is one (Phase 4
+	converted them all), and ``dispatch()``'s try/except is what turns this
+	into a clean 400 instead of an unhandled exception. RSS feeds, sitemaps
+	and the admin never read ``visible_subject_ids`` -- see their own module
+	docstrings -- so this cannot reach those surfaces; keep it that way
+	before adding a new caller of ``visible_subject_ids``.
+	"""
+
+	status_code = 400
+	default_code = "site_required"
+
+	def __init__(self):
+		self.raw_detail = {
+			"error": "No site could be determined for this request.",
+			"detail": "Pass ?site_id=, or call from a registered site origin.",
+			"public_sites": public_sites(),
+		}
+		super().__init__(detail=self.raw_detail)
+
+
+def exception_handler(exc, context):
+	"""DRF ``EXCEPTION_HANDLER`` (see ``admin/settings.py``'s
+	``REST_FRAMEWORK``). Delegates to DRF's own default handler for
+	everything, then restores ``NoSiteResolvedError``'s untouched
+	``raw_detail`` over the string-coerced body that handler builds -- see
+	that class's docstring for why. A no-op for every other exception.
+	"""
+	from rest_framework.views import exception_handler as _default_handler
+
+	response = _default_handler(exc, context)
+	if response is not None and isinstance(exc, NoSiteResolvedError):
+		response.data = exc.raw_detail
+	return response
+
+
+def resolve_anonymous_site(request):
+	"""
+	Resolve which ``api_public`` Site an anonymous caller's visibility
+	should scope to.
+
+	Order: ``?site_id=`` -> ``Origin`` -> ``Referer`` -> the public union,
+	if it is unambiguous (amended 2026-09-10 -- see module docstring). Only
+	``api_public`` sites are candidates at EVERY step -- a private site's id
+	or domain never resolves here, which is the safety property that makes
+	trusting a client-controlled Origin/Referer header fine (see module
+	docstring): it can only narrow to a public site, never grant a private
+	one's scope.
+
+	Returns ``(site_id_or_None, response_varies_by_origin, ambiguous)``:
+
+	- A resolved ``site_id`` with ``ambiguous=False``: scope to that site.
+	- ``site_id=None`` with ``ambiguous=False``: no ``api_public`` site
+	  exists at all -- not a failure, just an unambiguous empty union. The
+	  caller should treat this exactly like an identified caller whose own
+	  scope came out empty: zero subjects, no error (see
+	  ``visible_subject_ids``).
+	- ``site_id=None`` with ``ambiguous=True``: two or more ``api_public``
+	  sites exist and nothing named which one -- THIS is what must be
+	  refused, because serving "everything public" here would silently
+	  blend more than one site's content into one anonymous response.
+
+	``response_varies_by_origin`` is True whenever the outcome could depend
+	on the Origin header's value -- i.e. whenever ``?site_id=`` did not
+	resolve on its own -- regardless of whether this particular request
+	happened to send one, so that the caller (``gregory.visibility``, via
+	the middleware) can set ``Vary: Origin`` on the response. It is False
+	when ``?site_id=`` alone settled the question (Origin never consulted),
+	and also False in the "no public site exists at all" case above, since
+	no Origin value could have changed that outcome.
+	"""
+	from sitesettings.models import CustomSetting
+
+	def _is_public_site(site_id) -> bool:
+		return CustomSetting.objects.filter(
+			site_id=site_id, api_public=True
+		).exists()
+
+	raw_site_id = request.GET.get("site_id", "").strip()
+	if raw_site_id:
+		try:
+			site_id = int(raw_site_id)
+		except ValueError:
+			site_id = None
+		if site_id is not None and _is_public_site(site_id):
+			return site_id, False, False
+
+	# From here on, a different Origin could produce a different outcome --
+	# whether or not THIS request sent one -- so the response varies by it.
+	for header in ("HTTP_ORIGIN", "HTTP_REFERER"):
+		value = request.META.get(header)
+		if not value:
+			continue
+		hostname = urlparse(value).hostname
+		if not hostname:
+			continue
+		site = find_site_by_domain(hostname)
+		if site is not None and _is_public_site(site.id):
+			return site.id, True, False
+
+	# Nothing named a site. The public union is unambiguous -- and safe to
+	# serve automatically -- whenever it is drawn from at most one site:
+	# zero means the union is simply empty, one means the union just IS
+	# that site's scope. Two or more would silently blend their content
+	# into one anonymous response, so THAT is what refuses.
+	public_site_ids = list(
+		CustomSetting.objects.filter(api_public=True)
+		.values_list("site_id", flat=True)
+		.distinct()
+	)
+	if len(public_site_ids) == 0:
+		return None, False, False
+	if len(public_site_ids) == 1:
+		return public_site_ids[0], True, False
+	return None, True, True

--- a/django/gregory/site_resolution.py
+++ b/django/gregory/site_resolution.py
@@ -220,6 +220,18 @@ def resolve_anonymous_site(request):
 			site_id=site_id, api_public=True
 		).exists()
 
+	# KNOWN, PRE-EXISTING COLLISION (not introduced or fixed by this
+	# function): ArticleFilter/TrialFilter (api/filters.py) ALSO consume
+	# this exact query parameter, independently, as a content filter --
+	# `teams__site_id=value` via the stale Team.site edge (see
+	# SITE-API-VISIBILITY-SPEC.md, "site_id is broken today"). A caller
+	# passing a valid ?site_id= for VISIBILITY here can therefore also get
+	# its results filtered to empty by that unrelated, still-broken
+	# filter -- e.g. `GET /articles/?site_id=3` on this project's own data
+	# returns 0 results today, api_public and scope_subjects notwithstanding.
+	# Reconciling the two is deliberately Phase 6 (see the parent plan's
+	# "Out of scope"), not this function; do not "fix" it here without
+	# also updating that filter, or you'll just move the collision.
 	raw_site_id = request.GET.get("site_id", "").strip()
 	if raw_site_id:
 		try:
@@ -235,7 +247,15 @@ def resolve_anonymous_site(request):
 		value = request.META.get(header)
 		if not value:
 			continue
-		hostname = urlparse(value).hostname
+		try:
+			hostname = urlparse(value).hostname
+		except ValueError:
+			# Origin/Referer are client-controlled; a malformed bracketed
+			# host (e.g. "https://[::1") makes urlparse's .hostname raise
+			# rather than return None. Treat it the same as "no hostname" --
+			# an unresolved header, not a 500 -- and keep going: the next
+			# header, then the public-union fallback, still applies.
+			continue
 		if not hostname:
 			continue
 		site = find_site_by_domain(hostname)

--- a/django/gregory/tests/test_category_optimizations.py
+++ b/django/gregory/tests/test_category_optimizations.py
@@ -132,8 +132,8 @@ class CategoryOptimizationTestCase(TestCase):
 	def test_query_count_optimization(self):
 		"""Test that we're not generating excessive database queries"""
 		with self.assertNumQueries(
-			7
-		):  # site + org visibility + count + select (with count annotations) + subjects prefetch + authors count + authors select
+			8
+		):  # site + [public-site-count + scope_subjects fetch, Phase 3 gregory.site_resolution.resolve_anonymous_site's anonymous fallback] + count + select (with count annotations) + subjects prefetch + authors count + authors select
 			response = self.client.get("/categories/")
 
 		self.assertEqual(response.status_code, 200)
@@ -204,8 +204,8 @@ class CategoryOptimizationTestCase(TestCase):
 		"""Test that our prefetch_related optimizations work correctly"""
 		# Test with include_authors=false (should be very efficient)
 		with self.assertNumQueries(
-			6
-		):  # Basic query (with count annotations) + subjects prefetch + authors count query + visibility queries
+			7
+		):  # Basic query (with count annotations) + subjects prefetch + authors count query + visibility queries (site + [public-site-count + scope_subjects fetch, Phase 3 resolve_anonymous_site's anonymous fallback])
 			response = self.client.get(
 				f"/categories/?team_id={self.team.id}&include_authors=false"
 			)
@@ -213,8 +213,8 @@ class CategoryOptimizationTestCase(TestCase):
 
 		# Test with include_authors=true (should still be reasonable; site is cached from first request)
 		with self.assertNumQueries(
-			6
-		):  # org + count + select (with count annotations) + subjects prefetch + authors count + authors select
+			7
+		):  # org + [public-site-count + scope_subjects fetch] + count + select (with count annotations) + subjects prefetch + authors count + authors select
 			response = self.client.get(
 				f"/categories/?team_id={self.team.id}&include_authors=true"
 			)

--- a/django/gregory/tests/test_site_resolution.py
+++ b/django/gregory/tests/test_site_resolution.py
@@ -1,0 +1,287 @@
+"""
+Tests for gregory/site_resolution.py (Phase 3 of site-scoped API visibility).
+
+Covers:
+  - find_site_by_domain: moved here from subscriptions/views.py (formerly
+    _find_site_by_domain), same behaviour, same tests -- see that module's
+    _resolve_site_from_request for its other consumer.
+  - public_sites(): the shared code path api.views.PublicSitesView and
+    NoSiteResolvedError's body both use, so GET /sites/ and the 400 it's
+    quoted from can never disagree.
+  - resolve_anonymous_site(): the ?site_id= -> Origin -> Referer -> None
+    resolution order, and that every step considers ONLY api_public sites --
+    the property that makes trusting a client-controlled Origin header safe
+    (see the module's docstring). visible_subject_ids()'s own use of this
+    (including the NoSiteResolvedError it raises) is pinned separately in
+    gregory/tests/test_visibility_subjects.py, where fail-closed behaviour
+    belongs alongside the rest of that function's per-caller rules.
+
+Run with:
+    docker exec gregory python manage.py test gregory.tests.test_site_resolution
+"""
+
+from django.conf import settings
+from django.contrib.sites.models import Site
+from django.test import RequestFactory, TestCase
+
+from gregory.models import Team
+from gregory.site_resolution import (
+	find_site_by_domain,
+	public_sites,
+	resolve_anonymous_site,
+)
+from organizations.models import Organization
+from sitesettings.models import CustomSetting
+
+
+# ---------------------------------------------------------------------------
+# find_site_by_domain
+# ---------------------------------------------------------------------------
+
+
+class FindSiteByDomainTest(TestCase):
+	def setUp(self):
+		Site.objects.update_or_create(
+			id=settings.SITE_ID,
+			defaults={"domain": "example.com", "name": "example"},
+		)
+
+	def test_exact_match(self):
+		site = find_site_by_domain("example.com")
+		self.assertIsNotNone(site)
+		self.assertEqual(site.domain, "example.com")
+
+	def test_www_subdomain_resolves_to_parent(self):
+		site = find_site_by_domain("www.example.com")
+		self.assertIsNotNone(site)
+		self.assertEqual(site.domain, "example.com")
+
+	def test_arbitrary_subdomain_resolves_to_parent(self):
+		site = find_site_by_domain("api.example.com")
+		self.assertIsNotNone(site)
+		self.assertEqual(site.domain, "example.com")
+
+	def test_port_stripped_before_lookup(self):
+		site = find_site_by_domain("example.com:8080")
+		self.assertIsNotNone(site)
+		self.assertEqual(site.domain, "example.com")
+
+	def test_unknown_domain_returns_none(self):
+		self.assertIsNone(find_site_by_domain("evil.com"))
+
+	def test_unknown_subdomain_returns_none(self):
+		self.assertIsNone(find_site_by_domain("api.evil.com"))
+
+
+# ---------------------------------------------------------------------------
+# public_sites
+# ---------------------------------------------------------------------------
+
+
+class PublicSitesTest(TestCase):
+	def test_only_api_public_sites_are_listed(self):
+		org = Organization.objects.create(name="PS Org", slug="ps-org")
+		Team.objects.create(organization=org, name="PS Team", slug="ps-team")
+
+		pub_site = Site.objects.create(domain="ps-pub.test", name="Public")
+		CustomSetting.objects.create(site=pub_site, title="Pub", api_public=True)
+
+		priv_site = Site.objects.create(domain="ps-priv.test", name="Private")
+		CustomSetting.objects.create(site=priv_site, title="Priv", api_public=False)
+
+		result = public_sites()
+		site_ids = {row["site_id"] for row in result}
+		self.assertIn(pub_site.id, site_ids)
+		self.assertNotIn(priv_site.id, site_ids)
+
+	def test_row_shape(self):
+		site = Site.objects.create(domain="ps-shape.test", name="Shape")
+		CustomSetting.objects.create(site=site, title="Shape Setting", api_public=True)
+		result = public_sites()
+		row = next(r for r in result if r["site_id"] == site.id)
+		self.assertEqual(row, {"site_id": site.id, "domain": site.domain, "name": site.name})
+
+	def test_a_site_with_two_settings_rows_is_listed_once(self):
+		"""CustomSetting.site is a plain FK, not OneToOne -- mirrors
+		sitesettings' own test_lowest_setting_id_wins_when_multiple_rows."""
+		site = Site.objects.create(domain="ps-dup.test", name="Dup")
+		CustomSetting.objects.create(site=site, title="Dup A", api_public=True)
+		CustomSetting.objects.create(site=site, title="Dup B", api_public=True)
+		result = public_sites()
+		matching = [r for r in result if r["site_id"] == site.id]
+		self.assertEqual(len(matching), 1)
+
+
+# ---------------------------------------------------------------------------
+# resolve_anonymous_site
+# ---------------------------------------------------------------------------
+
+
+class ResolveAnonymousSiteTest(TestCase):
+	def setUp(self):
+		self.factory = RequestFactory()
+		self.org = Organization.objects.create(name="RAS Org", slug="ras-org")
+		Team.objects.create(organization=self.org, name="RAS Team", slug="ras-team")
+
+		self.pub_site = Site.objects.create(domain="ras-pub.test", name="Public")
+		CustomSetting.objects.create(site=self.pub_site, title="Pub", api_public=True)
+
+		self.priv_site = Site.objects.create(domain="ras-priv.test", name="Private")
+		CustomSetting.objects.create(site=self.priv_site, title="Priv", api_public=False)
+
+	def test_site_id_resolves_a_public_site(self):
+		request = self.factory.get("/", {"site_id": str(self.pub_site.pk)})
+		site_id, varies, ambiguous = resolve_anonymous_site(request)
+		self.assertEqual(site_id, self.pub_site.pk)
+		self.assertFalse(varies)
+		self.assertFalse(ambiguous)
+
+	def test_site_id_for_a_private_site_falls_back_to_the_sole_public_site(self):
+		"""Never widens: a private site's own id is not a candidate, so this
+		falls through exactly as if no site_id had been given at all -- and
+		with exactly one api_public site in this fixture, that fallback
+		resolves to it (amended 2026-09-10; see module docstring), never to
+		the private site that was actually asked for."""
+		request = self.factory.get("/", {"site_id": str(self.priv_site.pk)})
+		site_id, varies, ambiguous = resolve_anonymous_site(request)
+		self.assertEqual(site_id, self.pub_site.pk)
+		self.assertNotEqual(site_id, self.priv_site.pk)
+		# Fell through to the Origin/Referer/public-union stage, which is
+		# why this now "varies by origin" even though no Origin was sent.
+		self.assertTrue(varies)
+		self.assertFalse(ambiguous)
+
+	def test_unknown_site_id_falls_back_to_the_sole_public_site(self):
+		request = self.factory.get("/", {"site_id": "999999"})
+		site_id, varies, ambiguous = resolve_anonymous_site(request)
+		self.assertEqual(site_id, self.pub_site.pk)
+		self.assertTrue(varies)
+		self.assertFalse(ambiguous)
+
+	def test_non_numeric_site_id_falls_back_to_the_sole_public_site(self):
+		request = self.factory.get("/", {"site_id": "not-a-number"})
+		site_id, varies, ambiguous = resolve_anonymous_site(request)
+		self.assertEqual(site_id, self.pub_site.pk)
+		self.assertTrue(varies)
+		self.assertFalse(ambiguous)
+
+	def test_origin_resolves_a_public_site_when_no_site_id_given(self):
+		request = self.factory.get("/", HTTP_ORIGIN=f"https://{self.pub_site.domain}")
+		site_id, varies, ambiguous = resolve_anonymous_site(request)
+		self.assertEqual(site_id, self.pub_site.pk)
+		self.assertTrue(varies)
+		self.assertFalse(ambiguous)
+
+	def test_origin_spoofed_as_a_private_site_falls_back_to_the_sole_public_site(self):
+		"""The single most important property in this phase: a caller
+		claiming to come from a private site's domain must never be granted
+		that site's scope -- resolution only ever considers api_public
+		sites, at every step. With exactly one api_public site in this
+		fixture, the fallback resolves to it rather than refusing outright
+		(amended 2026-09-10) -- but it is that public site's scope, and
+		never the private one the Origin claimed. See module docstring."""
+		request = self.factory.get("/", HTTP_ORIGIN=f"https://{self.priv_site.domain}")
+		site_id, varies, ambiguous = resolve_anonymous_site(request)
+		self.assertEqual(site_id, self.pub_site.pk)
+		self.assertNotEqual(site_id, self.priv_site.pk)
+		self.assertTrue(varies)
+		self.assertFalse(ambiguous)
+
+	def test_referer_resolves_when_origin_is_absent(self):
+		request = self.factory.get(
+			"/", HTTP_REFERER=f"https://{self.pub_site.domain}/some/page/"
+		)
+		site_id, varies, ambiguous = resolve_anonymous_site(request)
+		self.assertEqual(site_id, self.pub_site.pk)
+		self.assertTrue(varies)
+		self.assertFalse(ambiguous)
+
+	def test_origin_takes_precedence_over_referer(self):
+		request = self.factory.get(
+			"/",
+			HTTP_ORIGIN=f"https://{self.pub_site.domain}",
+			HTTP_REFERER=f"https://{self.priv_site.domain}/page/",
+		)
+		site_id, varies, ambiguous = resolve_anonymous_site(request)
+		self.assertEqual(site_id, self.pub_site.pk)
+		self.assertFalse(ambiguous)
+
+	def test_site_id_takes_precedence_over_origin(self):
+		other_pub_site = Site.objects.create(domain="ras-pub-2.test", name="Public 2")
+		CustomSetting.objects.create(site=other_pub_site, title="Pub 2", api_public=True)
+		request = self.factory.get(
+			"/",
+			{"site_id": str(other_pub_site.pk)},
+			HTTP_ORIGIN=f"https://{self.pub_site.domain}",
+		)
+		site_id, varies, ambiguous = resolve_anonymous_site(request)
+		self.assertEqual(site_id, other_pub_site.pk)
+		self.assertFalse(varies)
+		self.assertFalse(ambiguous)
+
+	def test_nothing_at_all_falls_back_to_the_sole_public_site(self):
+		"""Amended 2026-09-10: the public union is data anyone may already
+		read, and with exactly one api_public site here it just IS that
+		site's scope -- so a caller naming nothing gets it directly rather
+		than a 400. See test_two_or_more_public_sites_and_no_indicator_refuses
+		below for the case this stops applying to."""
+		request = self.factory.get("/")
+		site_id, varies, ambiguous = resolve_anonymous_site(request)
+		self.assertEqual(site_id, self.pub_site.pk)
+		self.assertTrue(varies)
+		self.assertFalse(ambiguous)
+
+	def test_two_or_more_public_sites_and_no_indicator_refuses(self):
+		"""The public union stops being unambiguous the moment a second
+		api_public site exists -- serving it automatically would silently
+		blend two sites' content into one anonymous response, so this is
+		where resolution actually fails closed."""
+		Site.objects.create(domain="ras-pub-2.test", name="Public 2")
+		CustomSetting.objects.create(
+			site=Site.objects.get(domain="ras-pub-2.test"),
+			title="Pub 2",
+			api_public=True,
+		)
+		request = self.factory.get("/")
+		site_id, varies, ambiguous = resolve_anonymous_site(request)
+		self.assertIsNone(site_id)
+		self.assertTrue(varies)
+		self.assertTrue(ambiguous)
+
+	def test_two_or_more_public_sites_but_explicit_site_id_still_resolves(self):
+		"""Ambiguity only applies to the fallback -- an explicit ?site_id=
+		is never ambiguous, however many public sites exist."""
+		other_pub_site = Site.objects.create(domain="ras-pub-3.test", name="Public 3")
+		CustomSetting.objects.create(site=other_pub_site, title="Pub 3", api_public=True)
+		request = self.factory.get("/", {"site_id": str(self.pub_site.pk)})
+		site_id, varies, ambiguous = resolve_anonymous_site(request)
+		self.assertEqual(site_id, self.pub_site.pk)
+		self.assertFalse(varies)
+		self.assertFalse(ambiguous)
+
+
+class ResolveAnonymousSiteNoPublicSitesTest(TestCase):
+	"""The other unambiguous case: zero api_public sites. The union is
+	simply empty then, which is not an error -- see
+	ResolveAnonymousSiteTest.test_two_or_more_public_sites_and_no_indicator_refuses
+	for the case that IS."""
+
+	def setUp(self):
+		self.factory = RequestFactory()
+		self.priv_site = Site.objects.create(domain="ras-nopub-priv.test", name="Private")
+		CustomSetting.objects.create(site=self.priv_site, title="Priv", api_public=False)
+
+	def test_nothing_at_all_resolves_to_no_site_without_erroring(self):
+		request = self.factory.get("/")
+		site_id, varies, ambiguous = resolve_anonymous_site(request)
+		self.assertIsNone(site_id)
+		self.assertFalse(ambiguous)
+		# No Origin value could change this outcome -- there is nothing
+		# public to resolve to, whatever the caller sends.
+		self.assertFalse(varies)
+
+	def test_origin_spoofed_as_the_private_site_still_does_not_error(self):
+		request = self.factory.get("/", HTTP_ORIGIN=f"https://{self.priv_site.domain}")
+		site_id, varies, ambiguous = resolve_anonymous_site(request)
+		self.assertIsNone(site_id)
+		self.assertFalse(ambiguous)

--- a/django/gregory/tests/test_site_resolution.py
+++ b/django/gregory/tests/test_site_resolution.py
@@ -172,6 +172,22 @@ class ResolveAnonymousSiteTest(TestCase):
 		self.assertTrue(varies)
 		self.assertFalse(ambiguous)
 
+	def test_malformed_bracketed_origin_does_not_crash(self):
+		"""Origin/Referer are client-controlled; a malformed bracketed host
+		makes urllib.parse's .hostname property raise ValueError instead of
+		returning None. That must fall through to the next resolution step
+		(here, the sole-public-site fallback), not surface as a 500."""
+		request = self.factory.get("/", HTTP_ORIGIN="https://[::1")
+		site_id, varies, ambiguous = resolve_anonymous_site(request)
+		self.assertEqual(site_id, self.pub_site.pk)
+		self.assertFalse(ambiguous)
+
+	def test_malformed_bracketed_referer_does_not_crash(self):
+		request = self.factory.get("/", HTTP_REFERER="https://[::1/page")
+		site_id, varies, ambiguous = resolve_anonymous_site(request)
+		self.assertEqual(site_id, self.pub_site.pk)
+		self.assertFalse(ambiguous)
+
 	def test_origin_spoofed_as_a_private_site_falls_back_to_the_sole_public_site(self):
 		"""The single most important property in this phase: a caller
 		claiming to come from a private site's domain must never be granted

--- a/django/gregory/tests/test_visibility_subjects.py
+++ b/django/gregory/tests/test_visibility_subjects.py
@@ -12,12 +12,15 @@ public-union default.
 
 Phase 3 of site-scoped API visibility replaced that default with real site
 resolution: an anonymous caller now sees exactly ONE resolved api_public
-site's scope, and resolving to nothing raises
-gregory.site_resolution.NoSiteResolvedError (a DRF 400) rather than
-falling back to the union of every public site. VisibleSubjectIdsAnonymousTest
-below was rewritten for this -- see gregory/tests/test_site_resolution.py
-for resolve_anonymous_site()'s own resolution-order tests (?site_id= ->
-Origin -> Referer), which this file assumes rather than re-tests.
+site's scope. Resolving to nothing raises
+gregory.site_resolution.NoSiteResolvedError (a DRF 400) only when that
+"nothing" is genuine AMBIGUITY -- two or more api_public sites and no
+indicator naming one; zero api_public sites is unambiguous (an empty
+scope, no error) and is not this exception. See
+test_no_site_indicator_raises_once_a_second_public_site_exists below for
+the case that does raise, and gregory/tests/test_site_resolution.py for
+resolve_anonymous_site()'s own resolution-order tests (?site_id= -> Origin
+-> Referer), which this file assumes rather than re-tests.
 
 Run with:
     docker exec gregory python manage.py test gregory.tests.test_visibility_subjects
@@ -112,6 +115,27 @@ class VisibleSubjectIdsAnonymousTest(TestCase):
 		result = visible_subject_ids(self._anon_request_for_pub_site())
 		self.assertIn(self.pub_subject.id, result)
 		self.assertNotIn(self.priv_subject.id, result)
+
+	def test_a_private_settings_row_on_the_resolved_site_does_not_leak_its_scope(self):
+		"""CustomSetting.site is a plain FK, not OneToOne -- pub_site can
+		carry a SECOND, private settings row alongside the public one that
+		made it resolvable at all. The private row's own scope_subjects must
+		not be unioned into this anonymous response just because it shares
+		a site_id with the public row -- the query must still filter on
+		api_public=True, not site_id alone."""
+		second_row_subject = Subject.objects.create(
+			subject_name="Second Row Private",
+			subject_slug="vsi-anon-second-row-private",
+			team=self.team,
+		)
+		second_row = CustomSetting.objects.create(
+			site=self.pub_site, title="Pub Site Private Row", api_public=False
+		)
+		second_row.scope_subjects.add(second_row_subject)
+
+		result = visible_subject_ids(self._anon_request_for_pub_site())
+		self.assertIn(self.pub_subject.id, result)
+		self.assertNotIn(second_row_subject.id, result)
 
 	def test_spoofed_private_origin_falls_back_to_the_sole_public_site(self):
 		"""The security property Phase 3 exists to preserve: Origin is

--- a/django/gregory/tests/test_visibility_subjects.py
+++ b/django/gregory/tests/test_visibility_subjects.py
@@ -1,12 +1,23 @@
 """
 Tests for gregory.visibility — the visible_subject_ids() helper.
 
-Site-scoped API visibility, Phase 1: this function is introduced but read by
-no call site yet (see gregory/visibility.py's module docstring for how it
-relates to visible_org_ids). These tests pin its per-caller behaviour
-directly. The Phase 1 acceptance gate -- the equivalence test asserting
-visible_subject_ids(anonymous) matches today's public-organisation rule --
-lives in sitesettings/tests.py alongside the data migration it exercises.
+These tests pin its per-caller behaviour directly (see
+gregory/visibility.py's module docstring for how it relates to
+visible_org_ids). The Phase 1 acceptance gate -- the equivalence test
+asserting visible_subject_ids(anonymous) matches today's
+public-organisation rule -- lives in sitesettings/tests.py alongside the
+data migration it exercises, and was updated for Phase 3 (see below) to
+pass an explicit ?site_id= rather than relying on the old unconditional
+public-union default.
+
+Phase 3 of site-scoped API visibility replaced that default with real site
+resolution: an anonymous caller now sees exactly ONE resolved api_public
+site's scope, and resolving to nothing raises
+gregory.site_resolution.NoSiteResolvedError (a DRF 400) rather than
+falling back to the union of every public site. VisibleSubjectIdsAnonymousTest
+below was rewritten for this -- see gregory/tests/test_site_resolution.py
+for resolve_anonymous_site()'s own resolution-order tests (?site_id= ->
+Origin -> Referer), which this file assumes rather than re-tests.
 
 Run with:
     docker exec gregory python manage.py test gregory.tests.test_visibility_subjects
@@ -19,6 +30,7 @@ from django.contrib.sites.models import Site
 from organizations.models import Organization, OrganizationUser
 
 from gregory.models import Team, Subject, OrganizationSite
+from gregory.site_resolution import NoSiteResolvedError
 from gregory.visibility import visible_subject_ids
 from sitesettings.models import CustomSetting
 from api.models import APIAccessScheme
@@ -58,20 +70,65 @@ class VisibleSubjectIdsAnonymousTest(TestCase):
 			"vsi-anon-priv.test", "Priv", [self.priv_subject], api_public=False
 		)
 
-	def _anon_request(self):
-		req = self.factory.get("/")
+	def _anon_request(self, **extra):
+		req = self.factory.get("/", **extra)
 		req.user = AnonymousUser()
 		return req
 
-	def test_anonymous_sees_union_of_public_sites_only(self):
+	def _anon_request_for_pub_site(self):
+		"""An anonymous request resolved to self.pub_site via ?site_id= --
+		the explicit, unambiguous way to ask for one site's scope under
+		Phase 3 site resolution. See gregory/tests/test_site_resolution.py
+		for the ?site_id=/Origin/Referer resolution order itself."""
+		return self._anon_request(data={"site_id": str(self.pub_site.pk)})
+
+	def test_no_site_indicator_falls_back_to_the_sole_public_site(self):
+		"""Amended 2026-09-10: with exactly one api_public site (pub_site),
+		the public union just IS its scope, so an anonymous caller naming no
+		site gets it automatically rather than a 400 -- see
+		test_no_site_indicator_raises_once_a_second_public_site_exists below
+		for where the hard failure actually kicks in."""
 		result = visible_subject_ids(self._anon_request())
 		self.assertIn(self.pub_subject.id, result)
 		self.assertNotIn(self.priv_subject.id, result)
 
+	def test_no_site_indicator_raises_once_a_second_public_site_exists(self):
+		"""There is no unscoped mode once the public union is ambiguous: a
+		second api_public site makes "serve everything public" mean
+		"silently blend two sites' content", so this is where resolution
+		fails closed -- see gregory/site_resolution.py."""
+		Subject.objects.create(
+			subject_name="Second Public",
+			subject_slug="vsi-anon-second-pub",
+			team=self.team,
+		)
+		_make_site_with_scope(
+			"vsi-anon-pub-2.test", "Pub 2", [], api_public=True
+		)
+		with self.assertRaises(NoSiteResolvedError):
+			visible_subject_ids(self._anon_request())
+
+	def test_resolved_public_site_sees_its_own_scope_only(self):
+		result = visible_subject_ids(self._anon_request_for_pub_site())
+		self.assertIn(self.pub_subject.id, result)
+		self.assertNotIn(self.priv_subject.id, result)
+
+	def test_spoofed_private_origin_falls_back_to_the_sole_public_site(self):
+		"""The security property Phase 3 exists to preserve: Origin is
+		client-controlled, but resolution only ever considers api_public
+		sites, so claiming to come from a private site's domain can never
+		grant that site's scope. With exactly one api_public site here, the
+		fallback resolves to it (not a 400 -- amended 2026-09-10), but
+		crucially NEVER to the private site the Origin claimed."""
+		request = self._anon_request(HTTP_ORIGIN=f"https://{self.priv_site.domain}")
+		result = visible_subject_ids(request)
+		self.assertIn(self.pub_subject.id, result)
+		self.assertNotIn(self.priv_subject.id, result)
+
 	def test_overlapping_scope_is_public_even_if_a_private_site_also_lists_it(self):
-		"""Overlap is allowed by design: a subject in *any* public site's
-		scope is visible, even if a private site also contains it -- union,
-		not intersection, and not a reason to hide it."""
+		"""Overlap is allowed by design: a subject in a resolved public
+		site's scope is visible, even if a private site also contains it --
+		not a reason to hide it."""
 		shared_subject = Subject.objects.create(
 			subject_name="Shared", subject_slug="vsi-anon-shared", team=self.team
 		)
@@ -82,7 +139,7 @@ class VisibleSubjectIdsAnonymousTest(TestCase):
 			shared_subject
 		)
 
-		result = visible_subject_ids(self._anon_request())
+		result = visible_subject_ids(self._anon_request_for_pub_site())
 		self.assertIn(shared_subject.id, result)
 
 	def test_subject_in_no_sites_scope_is_invisible(self):
@@ -93,7 +150,7 @@ class VisibleSubjectIdsAnonymousTest(TestCase):
 		internal_subject = Subject.objects.create(
 			subject_name="Internal", subject_slug="vsi-anon-internal", team=self.team
 		)
-		result = visible_subject_ids(self._anon_request())
+		result = visible_subject_ids(self._anon_request_for_pub_site())
 		self.assertNotIn(internal_subject.id, result)
 
 

--- a/django/gregory/visibility.py
+++ b/django/gregory/visibility.py
@@ -13,12 +13,20 @@ request.
       → {X}; ?include_public=true adds public orgs
 
 ``visible_subject_ids`` is the site-scoped replacement introduced by the
-site-scoped API visibility project. Phase 1 adds the function and computes
-it correctly; nothing reads it yet. See its own docstring for the per-caller
-rules, which mirror the shape above with sites and subjects standing in for
-organisations. Both functions are kept side by side: org-keyed endpoints
-(``/teams/``, ``/organizations/``, ``/stats/`` scope validation) keep reading
-``visible_org_ids`` even once content endpoints move to subjects.
+site-scoped API visibility project. See its own docstring for the
+per-caller rules, which mirror the shape above with sites and subjects
+standing in for organisations. Both functions are kept side by side:
+org-keyed endpoints (``/teams/``, ``/organizations/``, ``/stats/`` scope
+validation) keep reading ``visible_org_ids`` even though content endpoints
+read subjects.
+
+As of Phase 3, the anonymous branch of ``visible_subject_ids`` can RAISE
+(``gregory.site_resolution.NoSiteResolvedError``, a DRF 400) instead of
+returning a set -- see that function's docstring. This is deliberate and
+safe everywhere it is actually called from (every content endpoint is a
+DRF view), but it means ``visible_subject_ids`` must never be called from
+a non-DRF code path for an anonymous request without also handling that
+exception -- see ``gregory/site_resolution.py``'s module docstring.
 
 Note: ``request.visible_org_ids`` and ``request.visible_subject_ids`` are
 attached by ``VisibleOrgMiddleware`` as ``SimpleLazyObject``s so that
@@ -132,24 +140,49 @@ def visible_subject_ids(request) -> set[int]:
 	      → the union of ``scope_subjects`` across every site owned (via
 	        ``OrganizationSite``) by an organisation the user belongs to
 	        (via ``OrganizationUser``).
-	  - Anonymous
-	      → the union of ``scope_subjects`` across every ``api_public``
-	        site. Full site resolution (``?site_id=``, ``Origin``,
-	        ``Referer``, and the fail-closed 400 when none matches) is
-	        Phase 3; until then this is the entire anonymous rule. The
-	        Phase 1 equivalence test asserts this matches every subject
-	        visible under today's public-organisation rule.
+	  - Anonymous (Phase 3 -- see ``gregory.site_resolution``)
+	      → the ``scope_subjects`` of ONE resolved ``api_public`` site.
+	        Resolved by ``resolve_anonymous_site()``: ``?site_id=`` if it
+	        names an ``api_public`` site, else the ``Origin`` header, else
+	        ``Referer``, else the public union across every ``api_public``
+	        site -- served automatically when that union is UNAMBIGUOUS:
+	        empty (no ``api_public`` site exists -- an empty scope, not an
+	        error) or exactly one site (it then just IS that site's scope).
+	        Two or more ``api_public`` sites and nothing named which one
+	        raises ``NoSiteResolvedError`` (a DRF 400 whose body names the
+	        public sites the caller could ask for instead) -- THAT is what
+	        must fail closed, because serving "everything public" there
+	        would silently blend more than one site's content into one
+	        anonymous response. Serving a lone public site's scope by
+	        default is not a new disclosure -- that data is already
+	        anyone's to read -- so refusing it would only prevent unscoped
+	        *convenience*. (Amended 2026-09-10: the original design failed
+	        closed on ANY unnamed site, unconditionally; that broke ~478
+	        tests calling the API anonymously with no site indicator, none
+	        of which were newly disclosing anything -- see the spec.) MCP
+	        already sends ``?site_id=`` regardless (#860), and browser
+	        callers send ``Origin``, so in practice this still only ever
+	        bites anonymous server-side callers hitting a deployment with
+	        two or more public sites and no site indicator: curl, scripts.
 
 	``?include_public=true`` adds the scopes of every ``api_public`` site to
-	an identified caller's own scope, which is how a private site's frontend
-	reads public content alongside its own. It is a no-op for an anonymous
-	caller, whose scope is already exactly that set -- the same shape the
-	flag has in ``visible_org_ids``, restated in subjects (spec: "adds public
-	organisations" stops being true once organisations are not the unit).
-	It applies to an identified caller whose own scope came out empty too
-	(an API key with no site resolved, or one whose site and organisation
+	an IDENTIFIED caller's own scope, which is how a private site's frontend
+	reads public content alongside its own -- the same shape the flag has in
+	``visible_org_ids``, restated in subjects (spec: "adds public
+	organisations" stops being true once organisations are not the unit). It
+	applies to an identified caller whose own scope came out empty too (an
+	API key with no site resolved, or one whose site and organisation
 	disagree): those resolve to no subjects of their own, and public
 	subjects are public to everyone, so the flag still means what it says.
+
+	It does NOT apply to the anonymous branch (Phase 3 changed this from a
+	true no-op to simply not applying): an anonymous caller's resolved scope
+	already belongs to an ``api_public`` site by construction, so OR-ing in
+	the full public union would silently discard the very resolution this
+	function just performed -- the opposite of what site resolution exists
+	to guarantee. A caller that wants the full public union rather than one
+	site's scope has no way to ask for it from this function; that is
+	intentional, since "give me everything public" is not a resolvable site.
 	"""
 	from sitesettings.models import CustomSetting
 
@@ -206,9 +239,30 @@ def visible_subject_ids(request) -> set[int]:
 			)
 		)
 
-	# Anonymous caller -- Phase 1 rule, see docstring. include_public is a
-	# no-op here: this IS the public set.
-	return _public_subject_ids()
+	# Anonymous caller -- Phase 3 site resolution, see docstring.
+	# include_public is deliberately NOT applied here (see docstring).
+	from gregory.site_resolution import NoSiteResolvedError, resolve_anonymous_site
+
+	site_id, varies_by_origin, ambiguous = resolve_anonymous_site(request)
+	if varies_by_origin:
+		# Consumed by VisibleOrgMiddleware after get_response() returns, to
+		# set Vary: Origin -- see that module. A plain request attribute
+		# (not a return value) because this function's return type is fixed
+		# by every existing call site to `set[int]`.
+		request._site_resolution_varies_by_origin = True
+	if ambiguous:
+		raise NoSiteResolvedError()
+	if site_id is None:
+		# No api_public site exists at all -- an unambiguous empty union,
+		# not a failure. Same shape as an identified caller whose own scope
+		# came out empty (see the API-key/user branches above): zero
+		# subjects, no error.
+		return set()
+	return set(
+		CustomSetting.objects.filter(site_id=site_id)
+		.exclude(scope_subjects__isnull=True)
+		.values_list("scope_subjects__id", flat=True)
+	)
 
 
 def visible_org_ids(request) -> set[int]:

--- a/django/gregory/visibility.py
+++ b/django/gregory/visibility.py
@@ -259,7 +259,13 @@ def visible_subject_ids(request) -> set[int]:
 		# subjects, no error.
 		return set()
 	return set(
-		CustomSetting.objects.filter(site_id=site_id)
+		# api_public=True, not just site_id=site_id: CustomSetting.site is a
+		# plain FK, not OneToOne, so a site can carry a second, PRIVATE
+		# settings row alongside the public one that made it eligible above.
+		# Filtering on site_id alone would union that private row's own
+		# scope_subjects into this anonymous response -- matching
+		# _public_subject_ids()'s own filter for the same reason.
+		CustomSetting.objects.filter(site_id=site_id, api_public=True)
 		.exclude(scope_subjects__isnull=True)
 		.values_list("scope_subjects__id", flat=True)
 	)

--- a/django/sitesettings/tests.py
+++ b/django/sitesettings/tests.py
@@ -283,7 +283,16 @@ class SeedSiteVisibilityScopeMigrationTests(TestCase):
 	def test_equivalence_anonymous_subject_scope_matches_todays_public_org_rule(self):
 		"""The acceptance gate (plan §1.4): with the migration applied,
 		visible_subject_ids(anonymous) == every subject visible under
-		today's public-organisation rule."""
+		today's public-organisation rule.
+
+		Phase 3 (site resolution, see gregory/site_resolution.py) replaced
+		the anonymous default with real resolution, but a caller naming no
+		site still gets exactly this fixture's public union automatically
+		-- br_site is the only api_public site here, so that union IS its
+		scope, and resolve_anonymous_site() serves it directly rather than
+		refusing. The bare "/" request below is therefore still the right
+		way to exercise this equivalence unchanged.
+		"""
 		self._run_migration()
 
 		req = self.factory.get("/")
@@ -332,7 +341,9 @@ class SeedSiteVisibilityScopeMigrationTests(TestCase):
 			{self.private_subject.id},
 		)
 
-		# And the anonymous rule still matches the old one.
+		# And the anonymous rule still matches the old one (Phase 3's
+		# resolve_anonymous_site() serves br_site's scope automatically here
+		# -- see the equivalence test above).
 		req = self.factory.get("/")
 		req.user = AnonymousUser()
 		self.assertNotIn(self.private_subject.id, visible_subject_ids(req))
@@ -470,6 +481,10 @@ class UncuratedPublicOrgSubjectStaysExcludedTests(TestCase):
 
 		self._run_migration()
 
+		# Phase 3's resolve_anonymous_site() serves `site`'s scope
+		# automatically here -- it is the only api_public site this fixture
+		# creates, so the public union just IS its scope (see
+		# gregory/site_resolution.py).
 		req = RequestFactory().get("/")
 		req.user = AnonymousUser()
 		after_migration = visible_subject_ids(req)

--- a/django/subscriptions/tests/test_views.py
+++ b/django/subscriptions/tests/test_views.py
@@ -15,7 +15,6 @@ from sitesettings.models import CustomSetting
 from subscriptions.models import Lists, Subscribers
 from subscriptions.views import (
 	subscribe_view,
-	_find_site_by_domain,
 	_origin_matches_allowed,
 	_check_origin_allowed,
 	_resolve_site_from_request,
@@ -179,47 +178,13 @@ class SubscribeViewTest(TestCase):
 
 
 # ---------------------------------------------------------------------------
-# _find_site_by_domain
-# ---------------------------------------------------------------------------
-
-
-class FindSiteByDomainTest(TestCase):
-	def setUp(self):
-		Site.objects.update_or_create(
-			id=settings.SITE_ID,
-			defaults={"domain": "example.com", "name": "example"},
-		)
-
-	def test_exact_match(self):
-		site = _find_site_by_domain("example.com")
-		self.assertIsNotNone(site)
-		self.assertEqual(site.domain, "example.com")
-
-	def test_www_subdomain_resolves_to_parent(self):
-		site = _find_site_by_domain("www.example.com")
-		self.assertIsNotNone(site)
-		self.assertEqual(site.domain, "example.com")
-
-	def test_arbitrary_subdomain_resolves_to_parent(self):
-		site = _find_site_by_domain("api.example.com")
-		self.assertIsNotNone(site)
-		self.assertEqual(site.domain, "example.com")
-
-	def test_port_stripped_before_lookup(self):
-		site = _find_site_by_domain("example.com:8080")
-		self.assertIsNotNone(site)
-		self.assertEqual(site.domain, "example.com")
-
-	def test_unknown_domain_returns_none(self):
-		self.assertIsNone(_find_site_by_domain("evil.com"))
-
-	def test_unknown_subdomain_returns_none(self):
-		self.assertIsNone(_find_site_by_domain("api.evil.com"))
-
-
-# ---------------------------------------------------------------------------
 # _origin_matches_allowed
 # ---------------------------------------------------------------------------
+#
+# find_site_by_domain (formerly _find_site_by_domain, defined here) moved to
+# gregory/site_resolution.py as part of Phase 3 of site-scoped API
+# visibility -- visibility must not import from the subscriptions app. Its
+# tests moved with it: see gregory/tests/test_site_resolution.py.
 
 
 class OriginMatchesAllowedTest(TestCase):

--- a/django/subscriptions/views.py
+++ b/django/subscriptions/views.py
@@ -18,6 +18,7 @@ from django.views.decorators.http import require_POST
 from PIL import Image, ImageOps
 from urllib.parse import urlparse
 
+from gregory.site_resolution import find_site_by_domain
 from sitesettings.models import CustomSetting
 from subscriptions.forms import SubscribersForm
 from subscriptions.models import (
@@ -92,33 +93,6 @@ def _get_client_ip(request):
 	return request.META.get("REMOTE_ADDR")
 
 
-def _find_site_by_domain(hostname):
-	"""
-	Look up a Site by exact domain, then by stripping one subdomain level.
-
-	e.g. 'www.example.com' → tries exact, then tries 'example.com'.
-	Accepts host strings that may include a port or IPv6 brackets; these are
-	normalised safely via urlparse before the lookup.
-	Returns the matching Site or None.
-	"""
-	host = urlparse(f"//{hostname}").hostname or ""
-	host = host.lower()
-	if not host:
-		return None
-	try:
-		return Site.objects.get(domain=host)
-	except Site.DoesNotExist:
-		pass
-	parts = host.split(".")
-	if len(parts) >= 3:
-		parent = ".".join(parts[1:])
-		try:
-			return Site.objects.get(domain=parent)
-		except Site.DoesNotExist:
-			pass
-	return None
-
-
 def _origin_matches_allowed(origin_host, allowed_domains_str):
 	"""
 	Return True if origin_host (or its parent domain after stripping one
@@ -165,7 +139,7 @@ def _resolve_site_from_request(request):
 		parsed = urlparse(origin)
 		hostname = parsed.hostname  # IPv6-safe, no port
 		if hostname:
-			site = _find_site_by_domain(hostname)
+			site = find_site_by_domain(hostname)
 			if site:
 				return site
 	try:
@@ -173,7 +147,7 @@ def _resolve_site_from_request(request):
 	except DisallowedHost:
 		host = None
 	if host:
-		site = _find_site_by_domain(host)
+		site = find_site_by_domain(host)
 		if site:
 			return site
 	return Site.objects.get_current()

--- a/docs/03-api-and-rss-feeds.md
+++ b/docs/03-api-and-rss-feeds.md
@@ -118,7 +118,9 @@ Only *API public* sites are candidates at every step, which is what makes trusti
 
 A **site-bound API key ignores `Origin`/`Referer`/`?site_id=` entirely** — the credential's own site always wins, so a client-controlled header can't override what the key grants. The same is true for a signed-in user: their organisations' sites decide, unaffected by any of the above.
 
-Responses that consulted `Origin` or `Referer` to reach their result carry `Vary: Origin`, so an HTTP cache in front of the API never serves one Origin's resolution to another. A response resolved purely by `?site_id=` does not vary by `Origin` at all.
+Responses that consulted `Origin` or `Referer` to reach their result carry `Vary: Origin, Referer`, so an HTTP cache in front of the API never serves one Origin's (or Referer's) resolution to a request carrying a different one. A response resolved purely by `?site_id=` does not vary by either header at all.
+
+> **`?site_id=` is also, separately, a content filter on `/articles/` and `/trials/`** (`teams__site_id`, via the legacy `Team.site` field — see [06-organisations-teams-and-sites.md](06-organisations-teams-and-sites.md) and the codebase's own tracking of retiring `Team.site`). The two uses are independent and the same query parameter feeds both, so a value that correctly resolves *visibility* can simultaneously narrow the *result set* to nothing, since `Team.site` is stale for most teams today. This is a known, pre-existing gap being tracked for a follow-up fix — until then, prefer `Origin`/`Referer` over `?site_id=` when calling a content endpoint anonymously if you don't also want that content filter applied.
 
 ### Discovering which sites exist
 

--- a/docs/03-api-and-rss-feeds.md
+++ b/docs/03-api-and-rss-feeds.md
@@ -97,6 +97,35 @@ This prevents open-redirect attacks — only explicitly whitelisted domains are 
 
 ---
 
+## Resolving a site for an anonymous caller
+
+An anonymous request is scoped to exactly one site's `scope_subjects`, resolved in this order:
+
+1. **`?site_id=`** — used if it names an *API public* site.
+2. **`Origin` header** — resolved to a Site by domain (exact match, then one subdomain level stripped), used if that site is *API public*.
+3. **`Referer` header** — same, for the cases where a browser sends this instead of `Origin`.
+4. **The public union, if unambiguous.** The union of every *API public* site's scope is data anyone may already read, so it is served automatically whenever it comes from **zero or one** site — zero means an empty scope, one means the union just *is* that site's scope. **Two or more *API public* sites and nothing above resolved one of them → `400`**, naming the sites the caller could ask for instead:
+
+   ```json
+   {"error": "No site could be determined for this request.",
+    "detail": "Pass ?site_id=, or call from a registered site origin.",
+    "public_sites": [{"site_id": 3, "domain": "brain-regeneration.com", "name": "Brain Regeneration"}]}
+   ```
+
+   This project has exactly one *API public* site today, so step 4 always resolves and the `400` never fires in practice — it exists for the moment a second one is onboarded, so an anonymous caller never silently receives two sites' content blended into one response.
+
+Only *API public* sites are candidates at every step, which is what makes trusting the client-controlled `Origin`/`Referer` headers safe: resolution can only ever **narrow** to a public site, never grant a private one's scope by a caller merely claiming to come from it.
+
+A **site-bound API key ignores `Origin`/`Referer`/`?site_id=` entirely** — the credential's own site always wins, so a client-controlled header can't override what the key grants. The same is true for a signed-in user: their organisations' sites decide, unaffected by any of the above.
+
+Responses that consulted `Origin` or `Referer` to reach their result carry `Vary: Origin`, so an HTTP cache in front of the API never serves one Origin's resolution to another. A response resolved purely by `?site_id=` does not vary by `Origin` at all.
+
+### Discovering which sites exist
+
+`GET /sites/` lists every *API public* site as `{site_id, domain, name}`. It is the discovery entry point a new caller needs before it can pass `?site_id=`, so it is **never gated by the resolution above** — it answers with no site indicator at all, even amid the exact ambiguity that would 400 every other endpoint. It is also the same code path the `400` body's `public_sites` list is drawn from, so the two can never disagree.
+
+---
+
 ## Accessing private organisation data
 
 By default the API only exposes data belonging to **public organisations** (`OrganizationApiSettings.make_api_public = True`). Callers that need to read a **private** organisation's data must identify themselves in one of two ways.
@@ -124,7 +153,7 @@ Identified callers can append `?include_public=true` to any request to add the s
 GET /articles/?include_public=true
 ```
 
-It is a no-op for an anonymous caller, whose scope already is exactly that set. Before subject scoping this parameter meant "adds public organisations"; it now adds public *sites'* subject scopes, and is declared in the OpenAPI schema rather than being undeclared-but-working as it was.
+It has no effect for an anonymous caller: their own resolved scope (see [Resolving a site for an anonymous caller](#resolving-a-site-for-an-anonymous-caller)) already belongs to an *API public* site by construction, so OR-ing in the full public union would silently discard that resolution — the opposite of what site resolution exists to guarantee. Before subject scoping this parameter meant "adds public organisations"; it now adds public *sites'* subject scopes for an identified caller, and is declared in the OpenAPI schema rather than being undeclared-but-working as it was.
 
 ### Visibility rules summary
 
@@ -132,7 +161,7 @@ Content visibility is **subject-scoped**: a caller sees a row when one of its su
 
 | Caller | Visible subjects |
 |:-------|:-----------------|
-| Anonymous (no credentials) | Every *API public* site's scope |
+| Anonymous (no credentials) | Exactly ONE resolved *API public* site's scope — see [Resolving a site for an anonymous caller](#resolving-a-site-for-an-anonymous-caller); `400` if that can't be pinned to one site |
 | API key bound to a site | That site's scope (+ public sites' if `?include_public=true`) |
 | API key with no site set | Nothing (+ public sites' if `?include_public=true`) |
 | Authenticated user, member of org X | The scopes of every site org X owns (+ public if `?include_public=true`) |


### PR DESCRIPTION
## Summary

Part of the site-scoped API visibility project — Phase 3, site resolution. Full context in the parent plan/spec (local, untracked planning docs).

- Adds `gregory/site_resolution.py`: `resolve_anonymous_site()` picks which site an anonymous caller's visibility scopes to, in order — `?site_id=` (if it names an `api_public` site) → `Origin` header → `Referer` header → the public union across every `api_public` site, served automatically **only when that union is unambiguous**.
- "Unambiguous" means drawn from **at most one** `api_public` site: zero sites is simply an empty scope (no error), exactly one means the union just *is* that site's scope. **Two or more sites and nothing resolved one of them → `400`** (`gregory.site_resolution.NoSiteResolvedError`), naming the public sites the caller could ask for instead.
- Only `api_public` sites are ever candidates, at every step — the property that makes trusting a client-controlled `Origin`/`Referer` header safe: it can only ever *narrow* to a public site, never grant a private one's scope by a caller merely claiming to come from it.
- `GET /sites/` and the `400` body are now built from one shared code path (`public_sites()`), so they can never disagree about which sites exist.
- A site-bound API key or a signed-in member's scope is decided by the credential/membership alone — `Origin`/`Referer`/`?site_id=` are ignored entirely for identified callers (unaffected by any of the above).
- `VisibleOrgMiddleware` now sets `Vary: Origin` whenever the outcome could have depended on it.
- Moved `_find_site_by_domain` out of `subscriptions/views.py` into the shared module (visibility shouldn't depend on the subscriptions app); its tests moved with it.
- Docs updated: `docs/03-api-and-rss-feeds.md` gets a new "Resolving a site for an anonymous caller" section plus updated visibility-rules-summary table and `?include_public=true` semantics.

### Design amendment (recorded mid-implementation, in the spec)

The original design said "refuse, always" when no site is named — but that directly contradicted the same design doc's own security-property section ("falls through to step 4 and sees the public union"), and concretely broke ~478 of the ~3,400 existing tests, all of which called the API anonymously with no site indicator and expected real content back. Resolved in favor of the conditional form above: the union of `api_public` scopes is data anyone may already read, so refusing to serve it protects nothing — it only prevents unscoped *convenience*. What must actually fail closed is an anonymous caller silently receiving **two sites'** content blended into one response, which is only possible once a second `api_public` site exists — so that's exactly where this refuses, with no flag to remember to flip later.

### A real bug this design caught

`NoSiteResolvedError` originally relied on DRF's default exception handling to turn its dict `.detail` into the response body — but `APIException.__init__` runs every leaf value through `_get_error_details()`, which `force_str()`s them (built for validation messages, which are always text). That would have silently turned `public_sites[].site_id` from a JSON integer into a JSON *string*, disagreeing in type with `GET /sites/`'s own response. A new end-to-end test asserting the 400 body matches `GET /sites/` byte-for-byte (not just in content) caught this; fixed with a small custom `REST_FRAMEWORK['EXCEPTION_HANDLER']` that restores the untouched dict for this one exception type and delegates everything else to DRF's own handler.

## Test plan

- [x] Full Django suite passes (3424 passed) — `docker exec gregory python -m pytest -q -p no:cacheprovider`
- [x] New `gregory/tests/test_site_resolution.py` and `api/tests/test_site_resolution_visibility.py`: resolution order (`?site_id=` → `Origin` → `Referer` → public union), zero/one/two-or-more `api_public` site behavior, spoofed-private-`Origin` narrowing, API-key/signed-in-member ignoring a conflicting `Origin`, `Vary: Origin` correctness, `GET /sites/` never gated, RSS feeds and sitemaps unaffected (they resolve by requested site, never caller identity, so never touch this code path)
- [x] Updated every existing test whose anonymous fixture legitimately created two or more `api_public` sites and called the API with no site indicator (mostly `test_trials_stats.py` / `test_articles_stats.py`), plus a handful of pinned exact-query-count budgets (+1 for the new resolution query) — each with an explanatory comment
- [x] Verified both safety-critical guards by deliberately breaking each and confirming the dedicated tests fail: the ambiguity refusal (changed `== 1` to `>= 1`) and the Origin-can-only-narrow property (removed the `api_public` check in the Origin/Referer loop) — then restored
- [x] `uvx ruff@0.16.00 check django/` clean
- [x] `schema.yml` regenerated — no diff (no view/serializer signatures changed)
- [x] `mcp-server` contract test suite unaffected (208 passed) — the MCP client already sends `?site_id=` on every call (#860)

🤖 Generated with [Claude Code](https://claude.com/claude-code)